### PR TITLE
Add `styleHelper` from BEPSwap

### DIFF
--- a/src/helpers/styleHelper.test.ts
+++ b/src/helpers/styleHelper.test.ts
@@ -1,0 +1,43 @@
+import { css } from 'styled-components'
+import { media } from './styleHelper'
+
+describe('helpers/styleHelpers', () => {
+  describe('media', () => {
+    it('adds media query for xs', () => {
+      const result = css`
+        ${media.xs`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 0px)', 'display: block']))
+    })
+    it('adds media query for sm', () => {
+      const result = css`
+        ${media.sm`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 576px)', 'display: block']))
+    })
+    it('adds media query for md', () => {
+      const result = css`
+        ${media.md`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 768px)', 'display: block']))
+    })
+    it('adds media query for lg', () => {
+      const result = css`
+        ${media.lg`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 992px)', 'display: block']))
+    })
+    it('adds media query for xl', () => {
+      const result = css`
+        ${media.xl`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 1200px)', 'display: block']))
+    })
+    it('adds media query for xxl', () => {
+      const result = css`
+        ${media.xxl`display: block`}
+      `
+      expect(result).toEqual(expect.arrayContaining(['(min-width: 1600px)', 'display: block']))
+    })
+  })
+})

--- a/src/helpers/styleHelper.ts
+++ b/src/helpers/styleHelper.ts
@@ -1,0 +1,43 @@
+import { css, SimpleInterpolation, FlattenSimpleInterpolation } from 'styled-components'
+
+type MediaKey = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
+
+type MediaQueries = {
+  [key in MediaKey]: string
+}
+
+// Ant design uses breakpoints similar to Bootstrap
+// https://ant.design/components/grid/#Col
+// https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints
+// and we do the same here
+const mediaQueries: MediaQueries = {
+  xs: '(min-width: 0px)',
+  sm: '(min-width: 576px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 992px)',
+  xl: '(min-width: 1200px)',
+  xxl: '(min-width: 1600px)'
+}
+
+type Media = {
+  [key in MediaKey]: (
+    styles: TemplateStringsArray,
+    ...interpolations: SimpleInterpolation[]
+  ) => FlattenSimpleInterpolation
+}
+
+/**
+ * Helper to provide media queries for any breakpoint we have defined in `MediaQueries`
+ */
+export const media: Media = Object.keys(mediaQueries).reduce((acc, segment) => {
+  // Tagged template to create media queries
+  const styledMediaFunction = (styles: TemplateStringsArray, ...interpolations: SimpleInterpolation[]) => css`
+    @media ${mediaQueries[segment as MediaKey]} {
+      ${css(styles, interpolations)}
+    }
+  `
+  return {
+    ...acc,
+    [segment]: styledMediaFunction
+  }
+}, {} as Media)


### PR DESCRIPTION
to define breakpoints and media queries, including few type improvements and tests.

Closes #49 