### PR TITLE
Fix language dropdown alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "package:electron": "electron-builder build -c.extraMetadata.main=build/electron.js --config .electronbuildrc",
     "package:ci": "yarn postinstall && yarn build && yarn package:electron --publish always",
     "postinstall": "electron-builder install-app-deps",
-    "lint": "eslint '{src,electron,e2e,}/**/*.{ts,tsx}' --fix",
+    "lint": "eslint \"{src,electron,e2e,}/**/*.{ts,tsx}\" --fix",
     "eject": "craco eject",
     "test:e2e": "yarn build && yarn test:cafe",
     "test:cafe": "cross-env NODE_ENV=production testcafe electron:./ ./e2e/**/*.e2e.ts",

--- a/src/components/header/HeaderLang.tsx
+++ b/src/components/header/HeaderLang.tsx
@@ -61,27 +61,25 @@ const HeaderLang: React.FC<Props> = (_: Props): JSX.Element => {
   return (
     <HeaderLangWrapper>
       <Dropdown overlay={menu} trigger={['click']} placement="bottomCenter">
-        {/* `ant-dropdown-link` does need a height to give dropdown content an offset - dont't remove it! */}
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a className="ant-dropdown-link" style={{ height: '40px' }} onClick={(e) => e.preventDefault()}>
-          <Row
-            style={{
-              justifyContent: 'space-between',
-              paddingLeft: '15px',
-              paddingRight: '15px',
-              height: '60px',
-              alignItems: 'center',
-              width: '100%'
-            }}>
-            {!isDesktopView && <Text style={{ color }}>LANGUAGE</Text>}
-            <Row style={{ alignItems: 'center' }}>
-              <Text strong style={itemStyle}>
-                {currentLocale?.toUpperCase()}
-              </Text>
-              <DownIcon />
-            </Row>
+        {/* No need to have an anchor here */}
+        <Row
+          style={{
+            justifyContent: 'space-between',
+            paddingLeft: '15px',
+            paddingRight: '15px',
+            height: '60px',
+            alignItems: 'center',
+            width: '100%',
+            cursor: 'pointer'
+          }}>
+          {!isDesktopView && <Text style={{ color }}>LANGUAGE</Text>}
+          <Row style={{ alignItems: 'center' }}>
+            <Text strong style={itemStyle}>
+              {currentLocale?.toUpperCase()}
+            </Text>
+            <DownIcon />
           </Row>
-        </a>
+        </Row>
       </Dropdown>
     </HeaderLangWrapper>
   )


### PR DESCRIPTION
Fix strange alignment of dropdown in mobile view #118 

Also, had to change eslint command for it to work on Windows:
`"eslint \"{src,electron,e2e,}/**/*.{ts,tsx}\" --fix"`