### PR TITLE
Simplify calculations for pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@thorchain/asgardex-binance": "https://gitlab.com/thorchain/asgardex-common/asgardex-binance.git#1612a8ec92ec66603b5dce819b01e6cd635e1035",
     "@thorchain/asgardex-theme": "^0.1.0",
     "@thorchain/asgardex-token": "^0.1.0",
-    "@thorchain/asgardex-util": "^0.1.3",
+    "@thorchain/asgardex-util": "^0.2.0",
     "@thorchain/byzantine-module": "^0.1.1",
     "@types/qrcode": "^1.3.4",
     "antd": "^4.2.2",

--- a/src/components/uielements/button/button.style.ts
+++ b/src/components/uielements/button/button.style.ts
@@ -196,7 +196,7 @@ export const ButtonWrapper = styled(Button)<Props>`
     justify-content: space-around;
     align-items: center;
 
-    border-radius: ${(props) => (props.round ? sizes[props.sizevalue].height : '3px')};
+    border-radius: ${(props) => (props.round === 'true' ? sizes[props.sizevalue].height : '3px')};
     min-width: ${(props) => sizes[props.sizevalue].width};
     height: ${(props) => sizes[props.sizevalue].height};
     font-size: ${(props) => fontSettings[props.sizevalue].size};

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const BASE_TOKEN_TICKER = 'RUNE'
+export const RUNE_TICKER = 'RUNE'

--- a/src/helpers/poolHelper.test.ts
+++ b/src/helpers/poolHelper.test.ts
@@ -1,4 +1,4 @@
-import { PoolData, assetAmount } from '@thorchain/asgardex-util'
+import { PoolData, assetAmount, assetToBase } from '@thorchain/asgardex-util'
 
 import { PoolDetails } from '../services/midgard/types'
 import { PoolDetailStatusEnum, PoolDetail } from '../types/generated/midgard'
@@ -70,7 +70,10 @@ describe('helpers/poolHelper/', () => {
       }
     ]
 
-    const pricePoolData: PoolData = { runeBalance: assetAmount(110), assetBalance: assetAmount(100) }
+    const pricePoolData: PoolData = {
+      runeBalance: assetToBase(assetAmount(110)),
+      assetBalance: assetToBase(assetAmount(100))
+    }
 
     it('returns data for pending pools', () => {
       const result = getPoolTableRowsData(poolDetails, pricePoolData, PoolDetailStatusEnum.Bootstrapped)
@@ -88,14 +91,14 @@ describe('helpers/poolHelper/', () => {
 
   describe('getPoolViewData', () => {
     const poolDetail: PoolDetail = {
-      assetDepth: '1000000000',
-      runeDepth: '100000000'
+      assetDepth: '11000000000',
+      runeDepth: '10000000000'
     }
 
     it('transforms `PoolData', () => {
       const result = toPoolData(poolDetail)
-      expect(result.assetBalance.amount().toNumber()).toEqual(10)
-      expect(result.runeBalance.amount().toNumber()).toEqual(1)
+      expect(result.assetBalance.amount().toNumber()).toEqual(11000000000)
+      expect(result.runeBalance.amount().toNumber()).toEqual(10000000000)
     })
   })
 })

--- a/src/helpers/poolHelper.test.ts
+++ b/src/helpers/poolHelper.test.ts
@@ -1,8 +1,8 @@
-import { bn } from '@thorchain/asgardex-util'
+import { PoolData, assetAmount } from '@thorchain/asgardex-util'
 
-import { PriceDataIndex, PoolDetails, PoolsState } from '../services/midgard/types'
+import { PoolDetails } from '../services/midgard/types'
 import { PoolDetailStatusEnum, PoolDetail } from '../types/generated/midgard'
-import { filterPendingPools, getDeepestPool, getPoolViewData } from './poolHelper'
+import { filterPendingPools, getDeepestPool, getPoolTableRowsData, toPoolData } from './poolHelper'
 
 describe('helpers/poolHelper/', () => {
   const pool1: PoolDetail = { status: PoolDetailStatusEnum.Bootstrapped, runeDepth: '1000' }
@@ -58,144 +58,44 @@ describe('helpers/poolHelper/', () => {
     const poolDetails: PoolDetails = [
       {
         asset: 'BNB.TOMOB-1E1',
-        assetDepth: '18446742858123318865',
-        assetROI: '20667660.85795645',
-        assetStakedTotal: '1044674093274',
-        buyAssetCount: '36',
-        buyFeeAverage: '10291935822.907797',
-        buyFeesTotal: '370509689624',
-        buySlipAverage: '0.13204722398788565',
-        buyTxAverage: '84802745137.44766',
-        buyVolume: '3052898824948',
-        poolDepth: '18446717002400377230',
-        poolFeeAverage: '6555438775.205882',
-        poolFeesTotal: '445769836714',
-        poolROI: '14060601.737624915',
-        poolROI12: '14060601.737624915',
-        poolSlipAverage: '0.3197441186194363',
-        poolStakedTotal: '3682199542975',
-        poolTxAverage: '58669549406.92824',
-        poolUnits: '1689199469669',
-        poolVolume: '21102028120401',
-        poolVolume24hr: '21102028120401',
-        price: '0.9999993321277123',
-        runeDepth: '18446730538054964423',
-        runeROI: '7453542.617293379',
-        runeStakedTotal: '2637526147410',
-        sellAssetCount: '32',
-        sellFeeAverage: '2351879596.5625',
-        sellFeesTotal: '75260147090',
-        sellSlipAverage: '0.5309031250799308',
-        sellTxAverage: '29269704210.093884',
-        sellVolume: '18049129295453',
-        stakeTxCount: '37',
-        stakersCount: '22',
-        stakingTxCount: '48',
-        status: PoolDetailStatusEnum.Enabled,
-        swappersCount: '1',
-        swappingTxCount: '68',
-        withdrawTxCount: '11'
+        status: PoolDetailStatusEnum.Enabled
       },
       {
         asset: 'BNB.LOK-3C0',
-        assetDepth: '37424296744',
-        assetROI: '0.328218990570089',
-        assetStakedTotal: '28176300000',
-        buyAssetCount: '9',
-        buyFeeAverage: '208491058.14241052',
-        buyFeesTotal: '1876419523',
-        buySlipAverage: '0.2013888888888889',
-        buyTxAverage: '1566610377.3971372',
-        buyVolume: '14099493396',
-        poolDepth: '48673495212',
-        poolFeeAverage: '600993113.3846154',
-        poolFeesTotal: '7812910474',
-        poolROI: '0.1384894550884584',
-        poolROI12: '0.1384894550884584',
-        poolSlipAverage: '0.38851538801995605',
-        poolStakedTotal: '43973955359',
-        poolTxAverage: '2529481811.70531',
-        poolUnits: '26913706341',
-        poolVolume: '21541614020',
-        poolVolume24hr: '21541614020',
-        price: '0.6502927168538379',
-        runeDepth: '24336747606',
-        runeROI: '-0.05124008039317224',
-        runeStakedTotal: '25651112682',
-        sellAssetCount: '4',
-        sellFeeAverage: '1484122737.75',
-        sellFeesTotal: '5936490951',
-        sellSlipAverage: '0.8095500110648572',
-        sellTxAverage: '4695942538.898699',
-        sellVolume: '7442120624',
-        stakeTxCount: '6',
-        stakersCount: '5',
-        stakingTxCount: '6',
-        status: PoolDetailStatusEnum.Enabled,
-        swappersCount: '1',
-        swappingTxCount: '13',
-        withdrawTxCount: '0'
+        status: PoolDetailStatusEnum.Enabled
       },
       {
         asset: 'BNB.BOLT-E42',
-        assetDepth: '18446743420523926728',
-        assetROI: '151586055.02546698',
-        assetStakedTotal: '122018650092',
-        buyAssetCount: '9',
-        buyFeeAverage: '0.6805646594055487',
-        buyFeesTotal: '6',
-        buySlipAverage: '0.04975555568105645',
-        buyTxAverage: '700.5684392037332',
-        buyVolume: '6305',
-        poolDepth: '299879750322',
-        poolFeeAverage: '0.6666666666666666',
-        poolFeesTotal: '6',
-        poolROI: '75793027.61991315',
-        poolROI12: '75793027.61991315',
-        poolSlipAverage: '0.04975555568105645',
-        poolStakedTotal: '123915426389',
-        poolTxAverage: '700.5684392037332',
-        poolUnits: '122589177745',
-        poolVolume: '6305',
-        poolVolume24hr: '6305',
-        price: '0.000000008128257207403678',
-        runeDepth: '149939875161',
-        runeROI: '0.21435932665378687',
-        runeStakedTotal: '123915425398',
-        sellAssetCount: '0',
-        sellFeeAverage: '0',
-        sellFeesTotal: '0',
-        sellSlipAverage: '0',
-        sellTxAverage: '0',
-        sellVolume: '0',
-        stakeTxCount: '7',
-        stakersCount: '4',
-        stakingTxCount: '8',
-        status: PoolDetailStatusEnum.Bootstrapped,
-        swappersCount: '1',
-        swappingTxCount: '9',
-        withdrawTxCount: '1'
+        status: PoolDetailStatusEnum.Bootstrapped
       }
     ]
 
-    const priceIndex: PriceDataIndex = {
-      LOK: bn(0.6502927168538379),
-      TOMOB: bn(0.9999993354396914),
-      BOLT: bn(8.128257207403678e-9),
-      RUNE: bn(1)
-    }
+    const pricePoolData: PoolData = { runeBalance: assetAmount(110), assetBalance: assetAmount(100) }
 
     it('returns data for pending pools', () => {
-      const result = getPoolViewData({ poolDetails, priceIndex } as PoolsState, PoolDetailStatusEnum.Bootstrapped)
+      const result = getPoolTableRowsData(poolDetails, pricePoolData, PoolDetailStatusEnum.Bootstrapped)
       expect(result.length).toEqual(1)
       expect(result[0].pool.target).toEqual('BOLT')
     })
 
     it('returns data for available pools', () => {
-      const result = getPoolViewData({ poolDetails, priceIndex } as PoolsState, PoolDetailStatusEnum.Enabled)
+      const result = getPoolTableRowsData(poolDetails, pricePoolData, PoolDetailStatusEnum.Enabled)
       expect(result.length).toEqual(2)
       expect(result[0].pool.target).toEqual('TOMOB')
       expect(result[1].pool.target).toEqual('LOK')
+    })
+  })
+
+  describe('getPoolViewData', () => {
+    const poolDetail: PoolDetail = {
+      assetDepth: '1000000000',
+      runeDepth: '100000000'
+    }
+
+    it('transforms `PoolData', () => {
+      const result = toPoolData(poolDetail)
+      expect(result.assetBalance.amount().toNumber()).toEqual(10)
+      expect(result.runeBalance.amount().toNumber()).toEqual(1)
     })
   })
 })

--- a/src/helpers/poolHelper.ts
+++ b/src/helpers/poolHelper.ts
@@ -1,4 +1,4 @@
-import { bnOrZero, baseToAsset, baseAmount, PoolData } from '@thorchain/asgardex-util'
+import { bnOrZero, baseAmount, PoolData } from '@thorchain/asgardex-util'
 
 import { PoolDetails } from '../services/midgard/types'
 import { getAssetFromString } from '../services/midgard/utils'
@@ -12,10 +12,11 @@ export const getPoolTableRowsData = (
   pricePool: PoolData,
   poolStatus: PoolDetailStatusEnum
 ): PoolTableRowsData => {
-  const deepestPool = getDeepestPool(poolDetails)
+  const poolDetailsFiltered = poolDetails.filter((detail) => detail?.status === poolStatus)
+  const deepestPool = getDeepestPool(poolDetailsFiltered)
   const { symbol: deepestPoolSymbol } = getAssetFromString(deepestPool?.asset)
   // Transform `PoolDetails` -> PoolRowType
-  const poolViewData = poolDetails.map((poolDetail, index) => {
+  return poolDetailsFiltered.map((poolDetail, index) => {
     const { symbol = '' } = getAssetFromString(poolDetail.asset)
     const deepest = symbol && deepestPoolSymbol && symbol === deepestPoolSymbol
     return {
@@ -24,7 +25,6 @@ export const getPoolTableRowsData = (
       key: poolDetail?.asset || index
     } as PoolTableRowData
   })
-  return poolViewData.filter((poolData) => poolData.status === poolStatus)
 }
 
 export const filterPendingPools = (pools: PoolDetails) =>
@@ -49,7 +49,7 @@ export const toPoolData = (detail: PoolDetail) => {
   const assetDepth = bnOrZero(detail.assetDepth)
   const runeDepth = bnOrZero(detail.runeDepth)
   return {
-    assetBalance: baseToAsset(baseAmount(assetDepth)),
-    runeBalance: baseToAsset(baseAmount(runeDepth))
+    assetBalance: baseAmount(assetDepth),
+    runeBalance: baseAmount(runeDepth)
   } as PoolData
 }

--- a/src/services/midgard/service.ts
+++ b/src/services/midgard/service.ts
@@ -3,10 +3,8 @@ import byzantine from '@thorchain/byzantine-module'
 import * as Rx from 'rxjs'
 import { retry, catchError, concatMap, tap, exhaustMap, mergeMap } from 'rxjs/operators'
 
-import { BASE_TOKEN_TICKER } from '../../const'
 import { Configuration, DefaultApi } from '../../types/generated/midgard'
 import { PoolsStateRD, PoolsState, PoolDetails, NetworkInfoRD } from './types'
-import { getAssetDetailIndex, getPriceIndex } from './utils'
 
 export const MIDGARD_MAX_RETRY = 3
 export const BYZANTINE_MAX_RETRY = 5
@@ -42,14 +40,7 @@ const getPoolsState$ = () => {
     // store `AssetDetails`
     tap((assetDetails) => (state = { ...state, assetDetails })),
     // Derive + store `assetDetailIndex`
-    tap((assetDetails) => (state = { ...state, assetDetailIndex: getAssetDetailIndex(assetDetails) })),
-    // Derive + store `priceIndex`
-    tap((assetDetails) => {
-      // TODO (@Veado) Get token ticker from persistent storage (issue https://github.com/thorchain/asgardex-electron/issues/127)
-      // const baseTokenTicker = getBasePriceAsset() || BASE_TOKEN_TICKER;
-      const priceIndex = getPriceIndex(assetDetails, BASE_TOKEN_TICKER)
-      state = { ...state, priceIndex }
-    }),
+    tap((assetDetails) => (state = { ...state, assetDetails })),
     //
     concatMap((_) => apiGetPoolsData$(state.poolAssets)),
     // Derive + store `poolDetails`

--- a/src/services/midgard/types.ts
+++ b/src/services/midgard/types.ts
@@ -1,5 +1,4 @@
 import * as RD from '@devexperts/remote-data-ts'
-import BigNumber from 'bignumber.js'
 
 import { AssetDetail, PoolDetail, NetworkInfo } from '../../types/generated/midgard'
 
@@ -14,10 +13,6 @@ export type AssetDetailMap = {
 
 export type PoolDetails = PoolDetail[]
 
-export type PriceDataIndex = {
-  [symbol: string]: BigNumber
-}
-
 export type Asset = {
   chain?: string
   symbol?: string
@@ -27,8 +22,6 @@ export type Asset = {
 export type PoolsState = {
   assetDetails: AssetDetails
   poolAssets: PoolAssets
-  assetDetailIndex: AssetDetailMap
-  priceIndex: PriceDataIndex
   poolDetails: PoolDetails
 }
 

--- a/src/services/midgard/utils.test.ts
+++ b/src/services/midgard/utils.test.ts
@@ -1,8 +1,6 @@
-import { bn } from '@thorchain/asgardex-util'
-
-import { ThorchainEndpoint } from '../../types/generated/midgard'
-import { PriceDataIndex } from './types'
-import { getAssetFromString, getAssetDetailIndex, getPriceIndex } from './utils'
+import { RUNE_TICKER } from '../../const'
+import { ThorchainEndpoint, AssetDetail } from '../../types/generated/midgard'
+import { getAssetFromString, getAssetDetailIndex, getAssetDetail } from './utils'
 
 type PoolDataMock = { asset?: string }
 
@@ -30,41 +28,6 @@ describe('services/midgard/utils/', () => {
     })
   })
 
-  describe('getPriceIndex', () => {
-    it('should return prices indexes based on RUNE price', () => {
-      const result = getPriceIndex(
-        [
-          { asset: 'BNB.TOMOB-1E1', priceRune: '0.3333333333333333' },
-          { asset: 'BNB.BBB', priceRune: '2206.896551724138' }
-        ],
-        'AAA'
-      )
-      const expected: PriceDataIndex = {
-        RUNE: bn(1),
-        TOMOB: bn('0.3333333333333333'),
-        BBB: bn('2206.896551724138')
-      }
-      expect(result).toEqual(expected)
-    })
-    it('should return a prices indexes based on BBB price', () => {
-      const result = getPriceIndex(
-        [
-          { asset: 'AAA.AAA-AAA', priceRune: '4' },
-          { asset: 'BBB.BBB-BBB', priceRune: '2' },
-          { asset: 'CCC.CCC-CCC', priceRune: '10' }
-        ],
-        'BBB'
-      )
-      const expected: PriceDataIndex = {
-        RUNE: bn(0.5),
-        AAA: bn(2),
-        BBB: bn(1),
-        CCC: bn(5)
-      }
-      expect(result).toEqual(expected)
-    })
-  })
-
   describe('getAssetFromString', () => {
     it('should return an asset with all values', () => {
       const result = getAssetFromString('BNB.RUNE-B1A')
@@ -89,6 +52,20 @@ describe('services/midgard/utils/', () => {
     it('returns an asset without any values if the passing value is undefined', () => {
       const result = getAssetFromString(undefined)
       expect(result).toEqual({})
+    })
+  })
+
+  describe('getDetail', () => {
+    const runeDetail: AssetDetail = { asset: 'BNB.RUNE-B1A' }
+    const bnbDetail: AssetDetail = { asset: 'BNB.BNB' }
+
+    it('returns details of RUNE', () => {
+      const result = getAssetDetail([runeDetail, bnbDetail], RUNE_TICKER)
+      expect(result).toEqual(runeDetail)
+    })
+    it('returns Nothing if no RUNE details available', () => {
+      const result = getAssetDetail([bnbDetail], 'TOMOB')
+      expect(result).toBeNothing()
     })
   })
 })

--- a/src/types/generated/midgard/apis/DefaultApi.ts
+++ b/src/types/generated/midgard/apis/DefaultApi.ts
@@ -49,7 +49,7 @@ export interface GetTxDetailsRequest {
     address?: string;
     txid?: string;
     asset?: string;
-    type?: GetTxDetailsTypeEnum;
+    type?: string;
 }
 
 /**
@@ -227,16 +227,4 @@ export class DefaultApi extends BaseAPI {
         });
     };
 
-}
-
-/**
- * @export
- * @enum {string}
- */
-export enum GetTxDetailsTypeEnum {
-    Swap = 'swap',
-    Stake = 'stake',
-    Unstake = 'unstake',
-    Add = 'add',
-    Refund = 'refund'
 }

--- a/src/types/generated/midgard/models/NetworkInfo.ts
+++ b/src/types/generated/midgard/models/NetworkInfo.ts
@@ -54,7 +54,7 @@ export interface NetworkInfo {
      */
     nextChurnHeight?: string;
     /**
-     * The remaining time of pool activation (in seconds)
+     * The remaining time of pool activation (in blocks)
      * @type {number}
      * @memberof NetworkInfo
      */

--- a/src/types/generated/midgard/models/TxDetails.ts
+++ b/src/types/generated/midgard/models/TxDetails.ts
@@ -95,6 +95,7 @@ export enum TxDetailsTypeEnum {
     Add = 'add',
     Pool = 'pool',
     Gas = 'gas',
-    Refund = 'refund'
+    Refund = 'refund',
+    DoubleSwap = 'doubleSwap'
 }
 

--- a/src/views/pools/PoolsOverview.tsx
+++ b/src/views/pools/PoolsOverview.tsx
@@ -2,9 +2,10 @@ import React, { useCallback, useMemo, useRef, useEffect, useState } from 'react'
 
 import { SyncOutlined, SwapOutlined, PlusOutlined } from '@ant-design/icons'
 import * as RD from '@devexperts/remote-data-ts'
-import { bn } from '@thorchain/asgardex-util'
+import { PoolData, assetAmount, AssetAmount, formatAssetAmount } from '@thorchain/asgardex-util'
 import { Grid, Row } from 'antd'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
+import BigNumber from 'bignumber.js'
 import { useObservableState } from 'observable-hooks'
 import { useHistory } from 'react-router-dom'
 
@@ -15,7 +16,7 @@ import Label from '../../components/uielements/label'
 import Table from '../../components/uielements/table'
 import Trend from '../../components/uielements/trend'
 import { useMidgardContext } from '../../contexts/MidgardContext'
-import { getPoolViewData, hasPendingPools } from '../../helpers/poolHelper'
+import { getPoolTableRowsData, hasPendingPools } from '../../helpers/poolHelper'
 import useInterval, { INACTIVE_INTERVAL } from '../../hooks/useInterval'
 import * as stakeRoutes from '../../routes/stake'
 import * as swapRoutes from '../../routes/swap'
@@ -25,7 +26,7 @@ import { Maybe, Nothing } from '../../types/asgardex.d'
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 import View from '../View'
 import { ActionColumn, TableAction, BlockLeftLabel } from './PoolsOverview.style'
-import { PoolRowType, PoolRowTypeList } from './types'
+import { PoolTableRowData, PoolTableRowsData } from './types'
 
 type Props = {}
 
@@ -48,9 +49,9 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
 
   // store previous data of pools to render these while reloading
-  const previousPools = useRef<Maybe<PoolRowTypeList>>(Nothing)
+  const previousPools = useRef<Maybe<PoolTableRowsData>>(Nothing)
   // store previous data of pending pools to render these while reloading
-  const previousPendingPools = useRef<Maybe<PoolRowTypeList>>(Nothing)
+  const previousPendingPools = useRef<Maybe<PoolTableRowsData>>(Nothing)
 
   const pendingCountdownHandler = useCallback(() => {
     midgardService.reloadNetworkInfo()
@@ -63,6 +64,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
   }, [poolsRD])
 
   useInterval(pendingCountdownHandler, pendingCountdownInterval)
+
+  // Hardcoded "price" pool amounts - temporary and for debugging only
+  // Will be removed by https://github.com/thorchain/asgardex-electron/issues/173
+  const pricePool: PoolData = { runeBalance: assetAmount(1), assetBalance: assetAmount(1) }
 
   const clickSwapHandler = (p: SwapRouteParams) => {
     history.push(swapRoutes.swap.path(p))
@@ -90,7 +95,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'btn',
     title: renderBtnColTitle,
     width: 280,
-    render: (_: string, record: PoolRowType) => {
+    render: (_: string, record: PoolTableRowData) => {
       const {
         pool: { asset, target }
       } = record
@@ -110,7 +115,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     }
   }
 
-  const poolColumn: ColumnType<PoolRowType> = {
+  const poolColumn: ColumnType<PoolTableRowData> = {
     key: 'pool',
     title: 'pool',
     dataIndex: 'pool',
@@ -118,7 +123,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     render: ({ target }: { asset: string; target: string }) => <Coin type="rune" over={target} />
   }
 
-  const poolColumnMobile: ColumnType<PoolRowType> = {
+  const poolColumnMobile: ColumnType<PoolTableRowData> = {
     key: 'pool',
     title: 'pool',
     dataIndex: 'pool',
@@ -129,66 +134,91 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     )
   }
 
-  const assetColumn: ColumnType<PoolRowType> = {
+  const assetColumn: ColumnType<PoolTableRowData> = {
     key: 'asset',
     title: 'asset',
     dataIndex: 'pool',
     render: ({ target }: { target: string }) => <Label>{target}</Label>,
-    sorter: (a: PoolRowType, b: PoolRowType) => a.pool.target.localeCompare(b.pool.target),
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => a.pool.target.localeCompare(b.pool.target),
     sortDirections: ['descend', 'ascend']
   }
 
-  const priceColumn: ColumnType<PoolRowType> = {
+  const priceColumn: ColumnType<PoolTableRowData> = {
     key: 'poolprice',
     title: 'price',
     dataIndex: 'poolPrice',
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.poolPrice.minus(b.raw.poolPrice).toNumber(),
+    render: (price: AssetAmount) => <Label>{formatAssetAmount(price, 3)}</Label>,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
+      const aAmount = a.poolPrice.amount()
+      const bAmount = b.poolPrice.amount()
+      return aAmount.minus(bAmount).toNumber()
+    },
     sortDirections: ['descend', 'ascend'],
     defaultSortOrder: 'descend'
   }
 
-  const depthColumn: ColumnType<PoolRowType> = {
+  const depthColumn: ColumnType<PoolTableRowData> = {
     key: 'depth',
     title: 'depth',
-    dataIndex: 'depth',
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.depth.minus(b.raw.depth).toNumber(),
+    dataIndex: 'depthPrice',
+    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
+      const aAmount = a.depthPrice.amount()
+      const bAmount = b.depthPrice.amount()
+      return aAmount.minus(bAmount).toNumber()
+    },
     sortDirections: ['descend', 'ascend']
   }
 
-  const volumeColumn: ColumnType<PoolRowType> = {
+  const volumeColumn: ColumnType<PoolTableRowData> = {
     key: 'vol',
     title: '24h vol',
-    dataIndex: 'volume',
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.volume.minus(b.raw.volume).toNumber(),
+    dataIndex: 'volumePrice',
+    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
+      const aAmount = a.volumePrice.amount()
+      const bAmount = b.volumePrice.amount()
+      return aAmount.minus(bAmount).toNumber()
+    },
     sortDirections: ['descend', 'ascend']
   }
 
-  const transactionColumn: ColumnType<PoolRowType> = {
+  const transactionColumn: ColumnType<PoolTableRowData> = {
     key: 'transaction',
     title: 'avg. size',
-    dataIndex: 'transaction',
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.transaction.minus(b.raw.transaction).toNumber(),
+    dataIndex: 'transactionPrice',
+    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
+      const aAmount = a.transactionPrice.amount()
+      const bAmount = b.transactionPrice.amount()
+      return aAmount.minus(bAmount).toNumber()
+    },
     sortDirections: ['descend', 'ascend']
   }
 
-  const slipColumn: ColumnType<PoolRowType> = {
+  const slipColumn: ColumnType<PoolTableRowData> = {
     key: 'slip',
     title: 'avg. slip',
     dataIndex: 'slip',
-    render: (slip: string) => <Trend amount={bn(slip)} />,
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.slip.minus(b.raw.slip).toNumber(),
+    render: (slip: BigNumber) => <Trend amount={slip} />,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => a.slip.minus(b.slip).toNumber(),
     sortDirections: ['descend', 'ascend']
   }
 
-  const tradeColumn: ColumnType<PoolRowType> = {
+  const tradeColumn: ColumnType<PoolTableRowData> = {
     key: 'trade',
     title: 'trades',
-    dataIndex: 'trade',
-    sorter: (a: PoolRowType, b: PoolRowType) => a.raw.trade.minus(b.raw.trade).toNumber(),
+    dataIndex: 'trades',
+    render: (trades: BigNumber) => <Label>{trades.toString()}</Label>,
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
+      const aAmount = a.trades
+      const bAmount = b.trades
+      return aAmount.minus(bAmount).toNumber()
+    },
     sortDirections: ['descend', 'ascend']
   }
 
-  const desktopPoolsColumns: ColumnsType<PoolRowType> = [
+  const desktopPoolsColumns: ColumnsType<PoolTableRowData> = [
     poolColumn,
     assetColumn,
     priceColumn,
@@ -200,10 +230,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     btnPoolsColumn
   ]
 
-  const mobilePoolsColumns: ColumnsType<PoolRowType> = [poolColumnMobile, btnPoolsColumn]
+  const mobilePoolsColumns: ColumnsType<PoolTableRowData> = [poolColumnMobile, btnPoolsColumn]
 
   const renderPoolsTable = useCallback(
-    (tableData: PoolRowType[], loading = false) => {
+    (tableData: PoolTableRowData[], loading = false) => {
       const columns = isDesktopView ? desktopPoolsColumns : mobilePoolsColumns
       return <Table columns={columns} dataSource={tableData} loading={loading} rowKey="key" />
     },
@@ -228,21 +258,21 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
           },
           // success state
           (pools: PoolsState): JSX.Element => {
-            const poolViewData = getPoolViewData(pools, PoolDetailStatusEnum.Enabled)
+            const poolViewData = getPoolTableRowsData(pools.poolDetails, pricePool, PoolDetailStatusEnum.Enabled)
             previousPools.current = poolViewData
             return renderPoolsTable(poolViewData)
           }
         )(poolsRD)}
       </>
     ),
-    [poolsRD, renderPoolsTable]
+    [poolsRD, pricePool, renderPoolsTable]
   )
 
   const btnPendingPoolsColumn = {
     key: 'btn',
     title: '',
     width: 200,
-    render: (_: string, record: PoolRowType) => {
+    render: (_: string, record: PoolTableRowData) => {
       const {
         pool: { target }
       } = record
@@ -262,18 +292,18 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'blocks',
     title: 'blocks left',
     width: 80,
-    render: (_: string, record: PoolRowType) => {
+    render: (_: string, record: PoolTableRowData) => {
       const { deepest } = record
 
       return (
         <TableAction>
-          <BlockLeftLabel size="normal">{deepest ? blocksLeft.toString() : ''}</BlockLeftLabel>
+          <BlockLeftLabel size="large">{deepest ? blocksLeft.toString() : ''}</BlockLeftLabel>
         </TableAction>
       )
     }
   }
 
-  const desktopPendingPoolsColumns: ColumnsType<PoolRowType> = [
+  const desktopPendingPoolsColumns: ColumnsType<PoolTableRowData> = [
     poolColumn,
     assetColumn,
     priceColumn,
@@ -282,10 +312,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     btnPendingPoolsColumn
   ]
 
-  const mobilePendingPoolsColumns: ColumnsType<PoolRowType> = [poolColumnMobile, btnPendingPoolsColumn]
+  const mobilePendingPoolsColumns: ColumnsType<PoolTableRowData> = [poolColumnMobile, btnPendingPoolsColumn]
 
   const renderPendingPoolsTable = useCallback(
-    (tableData: PoolRowType[], loading = false) => {
+    (tableData: PoolTableRowData[], loading = false) => {
       const columns = isDesktopView ? desktopPendingPoolsColumns : mobilePendingPoolsColumns
       return <Table columns={columns} dataSource={tableData} loading={loading} rowKey="key" />
     },
@@ -306,15 +336,15 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
           // error state - we just show an empty table, an error will be shown on pools table
           (_: Error) => renderPendingPoolsTable([]),
           // success state
-          (pools: PoolsState): JSX.Element => {
-            const poolViewData = getPoolViewData(pools, PoolDetailStatusEnum.Bootstrapped)
+          (state: PoolsState): JSX.Element => {
+            const poolViewData = getPoolTableRowsData(state.poolDetails, pricePool, PoolDetailStatusEnum.Bootstrapped)
             previousPendingPools.current = poolViewData
             return renderPendingPoolsTable(poolViewData)
           }
         )(poolsRD)}
       </>
     ),
-    [poolsRD, renderPendingPoolsTable]
+    [poolsRD, renderPendingPoolsTable, pricePool]
   )
 
   return (

--- a/src/views/pools/PoolsOverview.tsx
+++ b/src/views/pools/PoolsOverview.tsx
@@ -2,7 +2,14 @@ import React, { useCallback, useMemo, useRef, useEffect, useState } from 'react'
 
 import { SyncOutlined, SwapOutlined, PlusOutlined } from '@ant-design/icons'
 import * as RD from '@devexperts/remote-data-ts'
-import { PoolData, assetAmount, AssetAmount, formatAssetAmount } from '@thorchain/asgardex-util'
+import {
+  PoolData,
+  assetAmount,
+  formatAssetAmount,
+  assetToBase,
+  BaseAmount,
+  baseToAsset
+} from '@thorchain/asgardex-util'
 import { Grid, Row } from 'antd'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
 import BigNumber from 'bignumber.js'
@@ -42,6 +49,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
   useEffect(() => {
     const networkInfo = RD.toNullable(networkInfoRD)
     if (networkInfo) {
+      console.log('networkInfo?.poolActivationCountdown?.toString():', networkInfo?.poolActivationCountdown?.toString())
       setBlocksLeft(networkInfo?.poolActivationCountdown?.toString() ?? '')
     }
   }, [networkInfoRD])
@@ -67,7 +75,8 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
 
   // Hardcoded "price" pool amounts - temporary and for debugging only
   // Will be removed by https://github.com/thorchain/asgardex-electron/issues/173
-  const pricePool: PoolData = { runeBalance: assetAmount(1), assetBalance: assetAmount(1) }
+  const oneAsset = assetToBase(assetAmount(1))
+  const pricePool: PoolData = { runeBalance: oneAsset, assetBalance: oneAsset }
 
   const clickSwapHandler = (p: SwapRouteParams) => {
     history.push(swapRoutes.swap.path(p))
@@ -147,7 +156,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'poolprice',
     title: 'price',
     dataIndex: 'poolPrice',
-    render: (price: AssetAmount) => <Label>{formatAssetAmount(price, 3)}</Label>,
+    render: (price: BaseAmount) => <Label>{formatAssetAmount(baseToAsset(price), 3)}</Label>,
     sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
       const aAmount = a.poolPrice.amount()
       const bAmount = b.poolPrice.amount()
@@ -161,7 +170,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'depth',
     title: 'depth',
     dataIndex: 'depthPrice',
-    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    render: (price: BaseAmount) => <Label>{formatAssetAmount(baseToAsset(price))}</Label>,
     sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
       const aAmount = a.depthPrice.amount()
       const bAmount = b.depthPrice.amount()
@@ -174,7 +183,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'vol',
     title: '24h vol',
     dataIndex: 'volumePrice',
-    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    render: (price: BaseAmount) => <Label>{formatAssetAmount(baseToAsset(price))}</Label>,
     sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
       const aAmount = a.volumePrice.amount()
       const bAmount = b.volumePrice.amount()
@@ -187,7 +196,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     key: 'transaction',
     title: 'avg. size',
     dataIndex: 'transactionPrice',
-    render: (price: AssetAmount) => <Label>{formatAssetAmount(price)}</Label>,
+    render: (price: BaseAmount) => <Label>{formatAssetAmount(baseToAsset(price))}</Label>,
     sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
       const aAmount = a.transactionPrice.amount()
       const bAmount = b.transactionPrice.amount()
@@ -297,7 +306,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
 
       return (
         <TableAction>
-          <BlockLeftLabel size="large">{deepest ? blocksLeft.toString() : ''}</BlockLeftLabel>
+          <BlockLeftLabel>{deepest ? blocksLeft.toString() : ''}</BlockLeftLabel>
         </TableAction>
       )
     }

--- a/src/views/pools/types.ts
+++ b/src/views/pools/types.ts
@@ -1,4 +1,4 @@
-import { AssetAmount } from '@thorchain/asgardex-util'
+import { BaseAmount } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
@@ -10,10 +10,10 @@ export type Pool = {
 
 export type PoolTableRowData = {
   pool: Pool
-  depthPrice: AssetAmount
-  volumePrice: AssetAmount
-  transactionPrice: AssetAmount
-  poolPrice: AssetAmount
+  depthPrice: BaseAmount
+  volumePrice: BaseAmount
+  transactionPrice: BaseAmount
+  poolPrice: BaseAmount
   slip: BigNumber
   trades: BigNumber
   status: PoolDetailStatusEnum

--- a/src/views/pools/types.ts
+++ b/src/views/pools/types.ts
@@ -1,32 +1,24 @@
+import { AssetAmount } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 
-type PoolRawValueType = {
-  depth: BigNumber
-  volume: BigNumber
-  transaction: BigNumber
+export type Pool = {
+  asset: string
+  target: string
+}
+
+export type PoolTableRowData = {
+  pool: Pool
+  depthPrice: AssetAmount
+  volumePrice: AssetAmount
+  transactionPrice: AssetAmount
+  poolPrice: AssetAmount
   slip: BigNumber
-  trade: BigNumber
-  poolPrice: BigNumber
-}
-
-export type PoolDataType = {
-  pool: {
-    asset: string
-    target: string
-  }
-  poolPrice: string
-  depth: string
-  volume: string
-  transaction: string
-  slip: string
-  trade: string
+  trades: BigNumber
   status: PoolDetailStatusEnum
-  raw: PoolRawValueType
-  deepest: boolean
+  deepest?: boolean
+  key: string
 }
 
-export type PoolRowType = PoolDataType & { key: number | string }
-
-export type PoolRowTypeList = PoolRowType[]
+export type PoolTableRowsData = PoolTableRowData[]

--- a/src/views/pools/util.test.ts
+++ b/src/views/pools/util.test.ts
@@ -6,7 +6,7 @@ import { PoolTableRowData } from './types'
 import { getPoolTableRowData } from './utils'
 
 describe('poolUtil', () => {
-  describe('getPoolData', () => {
+  describe('getPoolTableRowData', () => {
     const lokPoolDetail: PoolDetail = {
       asset: 'BNB.LOK-3C0',
       assetDepth: '11000000000',
@@ -31,8 +31,8 @@ describe('poolUtil', () => {
         },
         poolPrice: assetToBase(assetAmount(2)),
         depthPrice: assetToBase(assetAmount(1000)),
-        volumePrice: assetToBase(assetAmount('909.0909091')),
-        transactionPrice: assetToBase(assetAmount('909.0909091')),
+        volumePrice: assetToBase(assetAmount(1000)),
+        transactionPrice: assetToBase(assetAmount(1000)),
         slip: bn('0.11'),
         trades: bn(123),
         status: PoolDetailStatusEnum.Enabled,

--- a/src/views/pools/util.test.ts
+++ b/src/views/pools/util.test.ts
@@ -1,5 +1,5 @@
 // import { baseAmount } from '@thorchain/asgardex-token'
-import { bn, assetAmount, PoolData } from '@thorchain/asgardex-util'
+import { bn, assetAmount, PoolData, assetToBase } from '@thorchain/asgardex-util'
 
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard/models/PoolDetail'
 import { PoolTableRowData } from './types'
@@ -18,7 +18,10 @@ describe('poolUtil', () => {
       status: PoolDetailStatusEnum.Bootstrapped
     }
 
-    const pricePoolData: PoolData = { runeBalance: assetAmount(10), assetBalance: assetAmount(100) }
+    const pricePoolData: PoolData = {
+      runeBalance: assetToBase(assetAmount(10)),
+      assetBalance: assetToBase(assetAmount(100))
+    }
 
     it('transforms data for a LOK pool', () => {
       const expected: PoolTableRowData = {
@@ -26,10 +29,10 @@ describe('poolUtil', () => {
           asset: 'RUNE',
           target: 'LOK'
         },
-        poolPrice: assetAmount(2),
-        depthPrice: assetAmount(1000),
-        volumePrice: assetAmount('909.0909091'),
-        transactionPrice: assetAmount('909.0909091'),
+        poolPrice: assetToBase(assetAmount(2)),
+        depthPrice: assetToBase(assetAmount(1000)),
+        volumePrice: assetToBase(assetAmount('909.0909091')),
+        transactionPrice: assetToBase(assetAmount('909.0909091')),
         slip: bn('0.11'),
         trades: bn(123),
         status: PoolDetailStatusEnum.Enabled,

--- a/src/views/pools/util.test.ts
+++ b/src/views/pools/util.test.ts
@@ -1,177 +1,51 @@
 // import { baseAmount } from '@thorchain/asgardex-token'
-import { bn } from '@thorchain/asgardex-util'
+import { bn, assetAmount, PoolData } from '@thorchain/asgardex-util'
 
-import { PriceDataIndex } from '../../services/midgard/types'
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard/models/PoolDetail'
-import { PoolDataType } from './types'
-import { getPoolData } from './utils'
+import { PoolTableRowData } from './types'
+import { getPoolTableRowData } from './utils'
 
 describe('poolUtil', () => {
   describe('getPoolData', () => {
-    const bnbPoolDetail: PoolDetail = {
-      asset: 'BNB.BNB',
-      assetDepth: '611339',
-      assetROI: '-0.4442372727272727',
-      assetStakedTotal: '1100000',
-      buyAssetCount: '1',
-      buyFeeAverage: '199600',
-      buyFeesTotal: '199600',
-      buySlipAverage: '1002000',
-      buyTxAverage: '32387',
-      buyVolume: '32387',
-      poolDepth: '399999598',
-      poolFeeAverage: '99800',
-      poolFeesTotal: '199600',
-      poolROI: '999.2768763636363',
-      poolROI12: '1000.2778813636363',
-      poolSlipAverage: '501000',
-      poolStakedTotal: '359965441',
-      poolTxAverage: '16193',
-      poolUnits: '47400323',
-      poolVolume: '32387',
-      poolVolume24hr: '0',
-      price: '327.15040100500704',
-      runeDepth: '199999799',
-      runeROI: '1998.99799',
-      runeStakedTotal: '100000',
-      sellAssetCount: '0',
-      sellFeeAverage: '0',
-      sellFeesTotal: '0',
-      sellSlipAverage: '0',
-      sellTxAverage: '0',
-      sellVolume: '0',
-      stakeTxCount: '3',
-      stakersCount: '1',
-      stakingTxCount: '4',
-      status: PoolDetailStatusEnum.Enabled,
-      swappersCount: '1',
-      swappingTxCount: '1',
-      withdrawTxCount: '1'
+    const lokPoolDetail: PoolDetail = {
+      asset: 'BNB.LOK-3C0',
+      assetDepth: '11000000000',
+      runeDepth: '10000000000',
+      poolVolume24hr: '10000000000',
+      poolTxAverage: '10000000000',
+      poolSlipAverage: '0.0011',
+      swappingTxCount: '123',
+      status: PoolDetailStatusEnum.Bootstrapped
     }
 
-    const fsnPoolDetail: PoolDetail = {
-      asset: 'BNB.FSN-F1B',
-      assetDepth: '100000',
-      assetROI: '0',
-      assetStakedTotal: '100000',
-      buyAssetCount: '0',
-      buyFeeAverage: '0',
-      buyFeesTotal: '0',
-      buySlipAverage: '0',
-      buyTxAverage: '0',
-      buyVolume: '0',
-      poolDepth: '400000',
-      poolFeeAverage: '0',
-      poolFeesTotal: '0',
-      poolROI: '0.5',
-      poolROI12: '0.5',
-      poolSlipAverage: '0',
-      poolStakedTotal: '300000',
-      poolTxAverage: '0',
-      poolUnits: '87500',
-      poolVolume: '0',
-      poolVolume24hr: '0',
-      price: '2',
-      runeDepth: '200000',
-      runeROI: '1',
-      runeStakedTotal: '100000',
-      sellAssetCount: '0',
-      sellFeeAverage: '0',
-      sellFeesTotal: '0',
-      sellSlipAverage: '0',
-      sellTxAverage: '0',
-      sellVolume: '0',
-      stakeTxCount: '2',
-      stakersCount: '1',
-      stakingTxCount: '2',
-      status: PoolDetailStatusEnum.Enabled,
-      swappersCount: '0',
-      swappingTxCount: '0',
-      withdrawTxCount: '0'
-    }
-    const priceIndex: PriceDataIndex = {
-      RUNE: bn(1),
-      FSN: bn(2)
-    }
-    it('returns PoolData for a FSN based pool', () => {
-      const expected: PoolDataType = {
+    const pricePoolData: PoolData = { runeBalance: assetAmount(10), assetBalance: assetAmount(100) }
+
+    it('transforms data for a LOK pool', () => {
+      const expected: PoolTableRowData = {
         pool: {
           asset: 'RUNE',
-          target: 'FSN'
+          target: 'LOK'
         },
-        poolPrice: '2.000',
-        depth: '0.00',
-        volume: '0.00',
-        transaction: '0.00',
-        slip: '0',
-        trade: '0',
-        raw: {
-          depth: bn(200000),
-          volume: bn(0),
-          transaction: bn(0),
-          slip: bn(0),
-          trade: bn(0),
-          poolPrice: bn(2)
-        }
+        poolPrice: assetAmount(2),
+        depthPrice: assetAmount(1000),
+        volumePrice: assetAmount('909.0909091'),
+        transactionPrice: assetAmount('909.0909091'),
+        slip: bn('0.11'),
+        trades: bn(123),
+        status: PoolDetailStatusEnum.Enabled,
+        deepest: false,
+        key: 'hi'
       }
-      const result = getPoolData('RUNE', fsnPoolDetail, priceIndex, 'RUNE')
-      const rRaw = result.raw
-      const eRaw = expected.raw
+
+      const result = getPoolTableRowData(lokPoolDetail, pricePoolData)
 
       expect(result.pool.asset).toEqual(expected.pool.asset)
       expect(result.pool.target).toEqual(expected.pool.target)
-      expect(result.depth).toEqual(expected.depth)
-      expect(result.volume).toEqual(expected.volume)
-      expect(result.transaction).toEqual(expected.transaction)
-      expect(result.slip).toEqual(expected.slip)
-      expect(result.trade).toEqual(expected.trade)
-
-      expect(rRaw.depth).toEqual(eRaw.depth)
-      expect(rRaw.volume).toEqual(eRaw.volume)
-      expect(rRaw.transaction).toEqual(eRaw.transaction)
-      expect(rRaw.slip).toEqual(eRaw.slip)
-      expect(rRaw.trade).toEqual(eRaw.trade)
-      expect(rRaw.poolPrice).toEqual(eRaw.poolPrice)
-    })
-    it('returns PoolData for a BNB based pool', () => {
-      const expected: PoolDataType = {
-        pool: {
-          asset: 'RUNE',
-          target: 'BNB'
-        },
-        poolPrice: '0.000',
-        depth: '2.00',
-        volume: '0.00',
-        transaction: '0.00',
-        slip: '50100000',
-        trade: '1',
-        raw: {
-          depth: bn(199999799),
-          volume: bn(0),
-          transaction: bn(16193),
-          slip: bn(50100000),
-          trade: bn(1),
-          poolPrice: bn(0)
-        }
-      }
-      const result = getPoolData('RUNE', bnbPoolDetail, priceIndex, 'RUNE')
-      const rRaw = result.raw
-      const eRaw = expected.raw
-
-      expect(result.pool.asset).toEqual(expected.pool.asset)
-      expect(result.pool.target).toEqual(expected.pool.target)
-      expect(result.depth).toEqual(expected.depth)
-      expect(result.volume).toEqual(expected.volume)
-      expect(result.transaction).toEqual(expected.transaction)
-      expect(result.slip).toEqual(expected.slip)
-      expect(result.trade).toEqual(expected.trade)
-
-      expect(rRaw.depth).toEqual(eRaw.depth)
-      expect(rRaw.volume).toEqual(eRaw.volume)
-      expect(rRaw.transaction).toEqual(eRaw.transaction)
-      expect(rRaw.slip).toEqual(eRaw.slip)
-      expect(rRaw.trade).toEqual(eRaw.trade)
-      expect(rRaw.poolPrice).toEqual(eRaw.poolPrice)
+      expect(result.depthPrice.amount().toNumber()).toEqual(expected.depthPrice.amount().toNumber())
+      expect(result.volumePrice.amount().toNumber()).toEqual(expected.volumePrice.amount().toNumber())
+      expect(result.transactionPrice.amount().toNumber()).toEqual(expected.transactionPrice.amount().toNumber())
+      expect(result.slip.toNumber()).toEqual(expected.slip.toNumber())
+      expect(result.trades.toNumber()).toEqual(expected.trades.toNumber())
     })
   })
 })

--- a/src/views/pools/utils.ts
+++ b/src/views/pools/utils.ts
@@ -3,10 +3,9 @@ import {
   PoolData,
   assetAmount,
   getValueOfAsset1InAsset2,
-  // getValueOfRuneInAsset,
   baseAmount,
-  baseToAsset,
-  getValueOfRuneInAsset
+  getValueOfRuneInAsset,
+  assetToBase
 } from '@thorchain/asgardex-util'
 
 import { RUNE_TICKER } from '../../const'
@@ -20,16 +19,17 @@ export const getPoolTableRowData = (poolDetail: PoolDetail, pricePoolData: PoolD
 
   const poolData = toPoolData(poolDetail)
 
-  const poolPrice = getValueOfAsset1InAsset2(assetAmount(1), poolData, pricePoolData)
+  const oneAsset = assetToBase(assetAmount(1))
+  const poolPrice = getValueOfAsset1InAsset2(oneAsset, poolData, pricePoolData)
 
   const depthAmount = baseAmount(bnOrZero(poolDetail?.runeDepth))
-  const depthPrice = getValueOfRuneInAsset(baseToAsset(depthAmount), pricePoolData)
+  const depthPrice = getValueOfRuneInAsset(depthAmount, pricePoolData)
 
   const volumeAmount = baseAmount(bnOrZero(poolDetail?.poolVolume24hr))
-  const volumePrice = getValueOfAsset1InAsset2(baseToAsset(volumeAmount), poolData, pricePoolData)
+  const volumePrice = getValueOfRuneInAsset(volumeAmount, pricePoolData)
 
   const transaction = baseAmount(bnOrZero(poolDetail?.poolTxAverage))
-  const transactionPrice = getValueOfAsset1InAsset2(baseToAsset(transaction), poolData, pricePoolData)
+  const transactionPrice = getValueOfRuneInAsset(transaction, pricePoolData)
 
   const slip = bnOrZero(poolDetail?.poolSlipAverage).multipliedBy(100)
   const trades = bnOrZero(poolDetail?.swappingTxCount)

--- a/src/views/pools/utils.ts
+++ b/src/views/pools/utils.ts
@@ -1,58 +1,54 @@
-import { baseAmount, formatBaseAsTokenAmount } from '@thorchain/asgardex-token'
-import { validBNOrZero, bn } from '@thorchain/asgardex-util'
+import {
+  bnOrZero,
+  PoolData,
+  assetAmount,
+  getValueOfAsset1InAsset2,
+  // getValueOfRuneInAsset,
+  baseAmount,
+  baseToAsset,
+  getValueOfRuneInAsset
+} from '@thorchain/asgardex-util'
 
-import { PriceDataIndex } from '../../services/midgard/types'
+import { RUNE_TICKER } from '../../const'
+import { toPoolData } from '../../helpers/poolHelper'
 import { getAssetFromString } from '../../services/midgard/utils'
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard'
-import { PoolDataType } from './types'
+import { PoolTableRowData, Pool } from './types'
 
-export const getPoolData = (
-  asset: string,
-  poolDetail: PoolDetail,
-  priceIndex: PriceDataIndex,
-  basePriceAsset: string
-): Omit<PoolDataType, 'deepest'> => {
-  const { ticker: target = '' } = getAssetFromString(poolDetail?.asset)
+export const getPoolTableRowData = (poolDetail: PoolDetail, pricePoolData: PoolData): PoolTableRowData => {
+  const { ticker = '' } = getAssetFromString(poolDetail?.asset)
 
-  const runePrice = validBNOrZero(priceIndex?.RUNE)
+  const poolData = toPoolData(poolDetail)
 
-  const poolPrice = validBNOrZero(priceIndex[target.toUpperCase()])
-  const poolPriceString = `${basePriceAsset} ${poolPrice.toFixed(3)}`
+  const poolPrice = getValueOfAsset1InAsset2(assetAmount(1), poolData, pricePoolData)
 
-  // formula: poolDetail.runeDepth * runePrice
-  const depth = bn(poolDetail?.runeDepth ?? 0).multipliedBy(runePrice)
-  const depthAsString = formatBaseAsTokenAmount(baseAmount(depth))
-  // formula: poolDetail.poolVolume24hr * runePrice
-  const volume = bn(poolDetail?.poolVolume24hr ?? 0).multipliedBy(runePrice)
-  const volumeAsString = formatBaseAsTokenAmount(baseAmount(volume))
-  // formula: poolDetail.poolTxAverage * runePrice
-  const transaction = bn(poolDetail?.poolTxAverage ?? 0).multipliedBy(runePrice)
-  const transactionAsString = formatBaseAsTokenAmount(baseAmount(transaction))
-  const slip = bn(poolDetail?.poolSlipAverage ?? 0).multipliedBy(100)
-  const slipAsString = slip.toString()
-  const trade = bn(poolDetail?.swappingTxCount ?? 0)
-  const tradeAsString = trade.toString()
+  const depthAmount = baseAmount(bnOrZero(poolDetail?.runeDepth))
+  const depthPrice = getValueOfRuneInAsset(baseToAsset(depthAmount), pricePoolData)
+
+  const volumeAmount = baseAmount(bnOrZero(poolDetail?.poolVolume24hr))
+  const volumePrice = getValueOfAsset1InAsset2(baseToAsset(volumeAmount), poolData, pricePoolData)
+
+  const transaction = baseAmount(bnOrZero(poolDetail?.poolTxAverage))
+  const transactionPrice = getValueOfAsset1InAsset2(baseToAsset(transaction), poolData, pricePoolData)
+
+  const slip = bnOrZero(poolDetail?.poolSlipAverage).multipliedBy(100)
+  const trades = bnOrZero(poolDetail?.swappingTxCount)
   const status = poolDetail?.status ?? PoolDetailStatusEnum.Disabled
 
+  const pool: Pool = {
+    asset: RUNE_TICKER,
+    target: ticker
+  }
+
   return {
-    pool: {
-      asset,
-      target
-    },
-    poolPrice: poolPriceString,
-    depth: depthAsString,
-    volume: volumeAsString,
-    transaction: transactionAsString,
-    slip: slipAsString,
-    trade: tradeAsString,
+    pool,
+    poolPrice,
+    depthPrice,
+    volumePrice,
+    transactionPrice,
+    slip,
+    trades,
     status,
-    raw: {
-      depth,
-      volume,
-      transaction,
-      slip,
-      trade,
-      poolPrice
-    }
+    key: ticker
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,10 +2451,15 @@
   dependencies:
     "@thorchain/asgardex-util" "^0.1.1"
 
-"@thorchain/asgardex-util@^0.1.1", "@thorchain/asgardex-util@^0.1.3":
+"@thorchain/asgardex-util@^0.1.1":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@thorchain/asgardex-util/-/asgardex-util-0.1.3.tgz#66e0e79dc45b0176ab7aad3b7f27453d1c13c684"
   integrity sha512-wTck5pfRNfPkVQ5CnssINSBG2/Mw4Q5fmGIlHhrRo+ycuSL5XjNDOt7bYJW6RBf/iEegtyi0qKPq1yuvI8ywmg==
+
+"@thorchain/asgardex-util@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@thorchain/asgardex-util/-/asgardex-util-0.2.0.tgz#b45d43ead152a1f7e1c70a7eb81102c9bef96ca2"
+  integrity sha512-JRJnuWs7laXP7V1JzJ4O6TxU0mTcCHg/xu4TAHccFw0aLsTSsavJhGdwbmciMrZRoY+3j6+Hd6PSI3EznsdBaA==
 
 "@thorchain/byzantine-module@^0.1.1":
   version "0.1.1"


### PR DESCRIPTION
- [x] Use `calc` helper functions from `asgardex-util`
- [x] Format values in `PoolsOverview` (but not in `getPoolData` to avoid
duplication of data
- [x] Update + simplify misc. tests
- [x] Simplify `PoolsState` (remove `PriceDataIndex` + `AssetDetailMap`)
- [x] Remove `getPriceIndex` helper
- [x] Add `toPoolData` helper (incl. test)
- [x] Quick fix: `round` property of button did not work
- [x] Use latest `asgardex-util`

Closes #172 