### PR TITLE
Quick fix: Revert removing `PriceDataIndex` + remove `getAssetFromString`

### DIFF
--- a/src/helpers/poolHelper.ts
+++ b/src/helpers/poolHelper.ts
@@ -1,7 +1,6 @@
-import { bnOrZero, baseAmount, PoolData } from '@thorchain/asgardex-util'
+import { bnOrZero, baseAmount, PoolData, getAssetFromString } from '@thorchain/asgardex-util'
 
 import { PoolDetails } from '../services/midgard/types'
-import { getAssetFromString } from '../services/midgard/utils'
 import { Nothing, Maybe } from '../types/asgardex.d'
 import { PoolDetailStatusEnum, PoolDetail } from '../types/generated/midgard'
 import { PoolTableRowData, PoolTableRowsData } from '../views/pools/types'

--- a/src/services/midgard/types.ts
+++ b/src/services/midgard/types.ts
@@ -1,4 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
+import BigNumber from 'bignumber.js'
 
 import { AssetDetail, PoolDetail, NetworkInfo } from '../../types/generated/midgard'
 
@@ -13,10 +14,8 @@ export type AssetDetailMap = {
 
 export type PoolDetails = PoolDetail[]
 
-export type Asset = {
-  chain?: string
-  symbol?: string
-  ticker?: string
+export type PriceDataIndex = {
+  [symbol: string]: BigNumber
 }
 
 export type PoolsState = {

--- a/src/services/midgard/utils.test.ts
+++ b/src/services/midgard/utils.test.ts
@@ -1,6 +1,6 @@
 import { RUNE_TICKER } from '../../const'
 import { ThorchainEndpoint, AssetDetail } from '../../types/generated/midgard'
-import { getAssetFromString, getAssetDetailIndex, getAssetDetail } from './utils'
+import { getAssetDetailIndex, getAssetDetail } from './utils'
 
 type PoolDataMock = { asset?: string }
 
@@ -25,33 +25,6 @@ describe('services/midgard/utils/', () => {
       const data = [emptyAsset, emptyAssetSymbol, emptyAssetSymbol, emptyAssetSymbol, emptyAsset] as Array<PoolDataMock>
       const result = getAssetDetailIndex(data)
       expect(result).toStrictEqual({})
-    })
-  })
-
-  describe('getAssetFromString', () => {
-    it('should return an asset with all values', () => {
-      const result = getAssetFromString('BNB.RUNE-B1A')
-      expect(result).toEqual({
-        chain: 'BNB',
-        symbol: 'RUNE-B1A',
-        ticker: 'RUNE'
-      })
-    })
-    it('should return an asset with all values, even if chain and symbol are provided only', () => {
-      const result = getAssetFromString('BNB.RUNE')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'RUNE', ticker: 'RUNE' })
-    })
-    it('should return an asset with a value for chain only', () => {
-      const result = getAssetFromString('BNB')
-      expect(result).toEqual({ chain: 'BNB' })
-    })
-    it('returns an asset without any values if the passing value is an empty string', () => {
-      const result = getAssetFromString('')
-      expect(result).toEqual({})
-    })
-    it('returns an asset without any values if the passing value is undefined', () => {
-      const result = getAssetFromString(undefined)
-      expect(result).toEqual({})
     })
   })
 

--- a/src/services/midgard/utils.ts
+++ b/src/services/midgard/utils.ts
@@ -1,6 +1,8 @@
+import { getAssetFromString } from '@thorchain/asgardex-util'
+
 import { Maybe, Nothing } from '../../types/asgardex.d'
 import { AssetDetail } from '../../types/generated/midgard'
-import { Asset, AssetDetails, AssetDetailMap } from './types'
+import { AssetDetails, AssetDetailMap } from './types'
 
 export const getAssetDetailIndex = (assets: AssetDetails): AssetDetailMap | {} => {
   let assetDataIndex = {}
@@ -26,35 +28,3 @@ export const getAssetDetail = (assets: AssetDetails, ticker: string) =>
     }
     return acc
   }, Nothing)
-
-/**
- * Creates an `Asset` by a given string
- *
- * The string has following naming convention:
- * `AAA.BBB-CCC`
- * where
- * chain: `AAA`
- * ticker (optional): `BBB`
- * symbol: `BBB-CCC`
- * or
- * symbol: `CCC` (if no ticker available)
- *
- * Image: ^ https://files.slack.com/files-pri/TBFG8JBBQ-F0147D6PBJA/image.png
- *
- */
-export const getAssetFromString = (s?: string): Asset => {
-  let chain
-  let symbol
-  let ticker
-  if (s) {
-    const data = s.split('.')
-    chain = data[0]
-    const ss = data[1]
-    if (ss) {
-      symbol = ss
-      // grab `ticker` from string or reference to `symbol` as `ticker`
-      ticker = ss.split('-')[0]
-    }
-  }
-  return { chain, symbol, ticker }
-}

--- a/src/views/pools/utils.ts
+++ b/src/views/pools/utils.ts
@@ -5,12 +5,12 @@ import {
   getValueOfAsset1InAsset2,
   baseAmount,
   getValueOfRuneInAsset,
-  assetToBase
+  assetToBase,
+  getAssetFromString
 } from '@thorchain/asgardex-util'
 
 import { RUNE_TICKER } from '../../const'
 import { toPoolData } from '../../helpers/poolHelper'
-import { getAssetFromString } from '../../services/midgard/utils'
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard'
 import { PoolTableRowData, Pool } from './types'
 


### PR DESCRIPTION
- `PriceDataIndex` is needed by `AssetCardMenu`
- `asgardex-util` is providing `getAssetFromString` now.