### PR TITLE
Issue 185/improve price handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "bignumber.js": "^9.0.0",
     "electron-debug": "^3.0.1",
     "electron-log": "^4.1.2",
+    "fp-ts": "^2.6.6",
     "observable-hooks": "^2.3.5",
     "qrcode": "^1.4.4",
     "react": "^16.13.1",

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,7 +17,7 @@ import { useThemeContext } from '../../contexts/ThemeContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
-import { PricePools, PricePoolAsset, PricePool } from '../../views/pools/types'
+import { PricePoolAsset, PricePoolAssets } from '../../views/pools/types'
 import { HeaderContainer, TabLink, HeaderDrawer, HeaderDrawerItem } from './Header.style'
 import HeaderCurrency from './HeaderCurrency'
 import HeaderLang from './HeaderLang'
@@ -54,29 +54,29 @@ const Header: React.FC<Props> = (_): JSX.Element => {
   const poolsRD = useObservableState(midgardService.poolState$, RD.pending)
 
   // store previous data to render it while reloading new data
-  const prevPricePools = useRef<PricePools>()
-  const prevSelectedPricePool = useRef<PricePool>()
+  const prevPricePoolAssets = useRef<PricePoolAssets>()
+  const prevSelectedPricePool = useRef<PricePoolAsset>()
 
-  const pricePools = useMemo(() => {
+  const pricePoolAssets = useMemo(() => {
     const pools = RD.toNullable(poolsRD)
     if (!pools) {
-      return prevPricePools?.current ?? []
+      return prevPricePoolAssets?.current ?? []
     }
-    const pricePools = pools.pricePools
-    prevPricePools.current = pricePools
-    return pricePools
+    const assets = pools.pricePools.map((pool) => pool.asset)
+    prevPricePoolAssets.current = assets
+    return assets
   }, [poolsRD])
 
-  const hasPricePools = useMemo(() => pricePools.length > 0, [pricePools])
+  const hasPricePools = useMemo(() => pricePoolAssets.length > 0, [pricePoolAssets])
 
-  const selectedPricePool = useMemo(() => {
+  const selectedPricePoolAsset = useMemo(() => {
     const pools = RD.toNullable(poolsRD)
     if (!pools) {
       return prevSelectedPricePool.current
     }
-    const selectedPricePool = pools.selectedPricePool
-    prevSelectedPricePool.current = selectedPricePool
-    return selectedPricePool
+    const selected = pools.selectedPricePool.asset
+    prevSelectedPricePool.current = selected
+    return selected
   }, [poolsRD])
 
   const [menuVisible, setMenuVisible] = useState(false)
@@ -173,12 +173,12 @@ const Header: React.FC<Props> = (_): JSX.Element => {
       <HeaderCurrency
         disabled={!hasPricePools}
         isDesktopView={isDesktopView}
-        selectedPool={selectedPricePool}
-        pools={pricePools}
+        selectedAsset={selectedPricePoolAsset}
+        assets={pricePoolAssets}
         changeHandler={currencyChangeHandler}
       />
     ),
-    [hasPricePools, isDesktopView, selectedPricePool, pricePools, currencyChangeHandler]
+    [hasPricePools, isDesktopView, selectedPricePoolAsset, pricePoolAssets, currencyChangeHandler]
   )
 
   const iconStyle = { fontSize: '1.5em', marginRight: '20px' }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -19,10 +19,10 @@ import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
 import { PricePoolAsset, PricePoolAssets } from '../../views/pools/types'
 import { HeaderContainer, TabLink, HeaderDrawer, HeaderDrawerItem } from './Header.style'
-import HeaderCurrency from './HeaderCurrency'
 import HeaderLang from './HeaderLang'
 import HeaderLock from './HeaderLock'
 import HeaderNetStatus from './HeaderNetStatus'
+import HeaderPriceSelector from './HeaderPriceSelector'
 import HeaderSettings from './HeaderSettings'
 import HeaderTheme from './HeaderTheme'
 
@@ -170,7 +170,7 @@ const Header: React.FC<Props> = (_): JSX.Element => {
 
   const renderHeaderCurrency = useMemo(
     () => (
-      <HeaderCurrency
+      <HeaderPriceSelector
         disabled={!hasPricePools}
         isDesktopView={isDesktopView}
         selectedAsset={selectedPricePoolAsset}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -53,7 +53,7 @@ const Header: React.FC<Props> = (_): JSX.Element => {
   const isLocked = useObservableState(isLocked$)
 
   const { service: midgardService } = useMidgardContext()
-  const poolsRD = useObservableState(midgardService.poolState$, RD.pending)
+  const poolsRD = useObservableState(midgardService.poolsState$, RD.pending)
   const selectedPricePoolAsset = useObservableState<Option<PricePoolAsset>>(
     midgardService.selectedPricePoolAsset$,
     some(PoolAsset.RUNE)

--- a/src/components/header/HeaderCurrency.stories.tsx
+++ b/src/components/header/HeaderCurrency.stories.tsx
@@ -2,31 +2,21 @@ import React from 'react'
 
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
-import { PoolData } from '@thorchain/asgardex-util'
 
-import { ONE_ASSET_BASE_AMOUNT } from '../../const'
-import { PoolAsset, PricePools, PricePoolAsset, PricePool } from '../../views/pools/types'
+import { PoolAsset, PricePoolAssets, PricePoolAsset } from '../../views/pools/types'
 import HeaderCurrency from './HeaderCurrency'
 
-const poolData: PoolData = { assetBalance: ONE_ASSET_BASE_AMOUNT, runeBalance: ONE_ASSET_BASE_AMOUNT }
-
-const tusdbPool: PricePool = { asset: PoolAsset.TUSDB, poolData }
-const pools: PricePools = [
-  { asset: PoolAsset.RUNE, poolData },
-  { asset: PoolAsset.BTC, poolData },
-  { asset: PoolAsset.ETH, poolData },
-  tusdbPool
-]
+const assets: PricePoolAssets = [PoolAsset.RUNE, PoolAsset.BTC, PoolAsset.ETH, PoolAsset.TUSDB]
 
 storiesOf('Components/HeaderCurrency', module).add('desktop / mobile', () => {
   const changeHandler = (asset: PricePoolAsset) => console.log(`changed: ${asset}`)
   const isDesktopView = boolean('isDesktopView', false)
   return (
     <HeaderCurrency
-      pools={pools}
+      assets={assets}
       isDesktopView={isDesktopView}
       changeHandler={changeHandler}
-      selectedPool={tusdbPool}
+      selectedAsset={PoolAsset.TUSDB}
     />
   )
 })

--- a/src/components/header/HeaderCurrency.tsx
+++ b/src/components/header/HeaderCurrency.tsx
@@ -4,7 +4,7 @@ import { Row, Dropdown } from 'antd'
 import { ClickParam } from 'antd/lib/menu'
 
 import { ReactComponent as DownIcon } from '../../assets/svg/icon-down.svg'
-import { PricePool, PricePools, PricePoolAsset } from '../../views/pools/types'
+import { PricePoolAsset, PricePoolAssets } from '../../views/pools/types'
 import Menu from '../shared/Menu'
 import {
   HeaderDropdownMenuItem,
@@ -17,14 +17,14 @@ import { toHeaderCurrencyLabel } from './util'
 
 type Props = {
   isDesktopView: boolean
-  pools: PricePools
+  assets: PricePoolAssets
   disabled?: boolean
-  selectedPool?: PricePool
+  selectedAsset?: PricePoolAsset
   changeHandler?: (asset: PricePoolAsset) => void
 }
 
 const HeaderCurrency: React.FC<Props> = (props: Props): JSX.Element => {
-  const { pools, selectedPool, isDesktopView, disabled = false, changeHandler = (_) => {} } = props
+  const { assets, selectedAsset, isDesktopView, disabled = false, changeHandler = (_) => {} } = props
 
   const changeItem = useCallback(
     (param: ClickParam) => {
@@ -37,7 +37,7 @@ const HeaderCurrency: React.FC<Props> = (props: Props): JSX.Element => {
   const menu = useMemo(
     () => (
       <Menu onClick={changeItem}>
-        {pools.map(({ asset }) => {
+        {assets.map((asset) => {
           return (
             <HeaderDropdownMenuItem key={asset}>
               <HeaderDropdownMenuItemText strong>{toHeaderCurrencyLabel(asset)}</HeaderDropdownMenuItemText>
@@ -46,10 +46,10 @@ const HeaderCurrency: React.FC<Props> = (props: Props): JSX.Element => {
         })}
       </Menu>
     ),
-    [changeItem, pools]
+    [changeItem, assets]
   )
 
-  const title = useMemo(() => (selectedPool ? toHeaderCurrencyLabel(selectedPool.asset) : '--'), [selectedPool])
+  const title = useMemo(() => (selectedAsset ? toHeaderCurrencyLabel(selectedAsset) : '--'), [selectedAsset])
   return (
     <HeaderDropdownWrapper>
       <Dropdown disabled={disabled} overlay={menu} trigger={['click']} placement="bottomCenter">

--- a/src/components/header/HeaderPriceSelector.stories.tsx
+++ b/src/components/header/HeaderPriceSelector.stories.tsx
@@ -4,15 +4,15 @@ import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import { PoolAsset, PricePoolAssets, PricePoolAsset } from '../../views/pools/types'
-import HeaderCurrency from './HeaderCurrency'
+import HeaderPriceSelector from './HeaderPriceSelector'
 
 const assets: PricePoolAssets = [PoolAsset.RUNE, PoolAsset.BTC, PoolAsset.ETH, PoolAsset.TUSDB]
 
-storiesOf('Components/HeaderCurrency', module).add('desktop / mobile', () => {
+storiesOf('Components/HeaderPriceSelector', module).add('desktop / mobile', () => {
   const changeHandler = (asset: PricePoolAsset) => console.log(`changed: ${asset}`)
   const isDesktopView = boolean('isDesktopView', false)
   return (
-    <HeaderCurrency
+    <HeaderPriceSelector
       assets={assets}
       isDesktopView={isDesktopView}
       changeHandler={changeHandler}

--- a/src/components/header/HeaderPriceSelector.tsx
+++ b/src/components/header/HeaderPriceSelector.tsx
@@ -23,7 +23,7 @@ type Props = {
   changeHandler?: (asset: PricePoolAsset) => void
 }
 
-const HeaderCurrency: React.FC<Props> = (props: Props): JSX.Element => {
+const HeaderPriceSelector: React.FC<Props> = (props: Props): JSX.Element => {
   const { assets, selectedAsset, isDesktopView, disabled = false, changeHandler = (_) => {} } = props
 
   const changeItem = useCallback(
@@ -65,4 +65,4 @@ const HeaderCurrency: React.FC<Props> = (props: Props): JSX.Element => {
   )
 }
 
-export default HeaderCurrency
+export default HeaderPriceSelector

--- a/src/helpers/stateHelper.ts
+++ b/src/helpers/stateHelper.ts
@@ -1,0 +1,38 @@
+import { Observable, BehaviorSubject } from 'rxjs'
+
+type ObservableState<T> = {
+  get$: Observable<T>
+  get: () => T
+  set: (value: T) => void
+}
+
+/**
+ * Factory to create an Observable State
+ *
+ * It returns an object with following properties:
+ *
+ * `get$` - A getter as an Observable - to subscribe to any changes if needed
+ * `get` - A getter of current value
+ * `set` - A setter to update values
+ *
+ * Example:
+ *
+ * const { get$, get, set} = observableState(0)
+ * // subscribe to any updates
+ * get$.subscribe({next: (value) => console.log('next value' , value)})
+ * // get current value
+ * const current = get()
+ * console.log(current) // 0
+ * set(1)
+ * console.log(current) // 1
+ * // Now "next value 1" will be printed by previous subscription, too
+ *
+ */
+export const observableState = <T>(initial: T): ObservableState<T> => {
+  const subject$$ = new BehaviorSubject(initial)
+  return {
+    get$: subject$$.asObservable(),
+    get: () => subject$$.getValue(),
+    set: (newValue: T) => subject$$.next(newValue)
+  }
+}

--- a/src/services/midgard/types.ts
+++ b/src/services/midgard/types.ts
@@ -1,8 +1,9 @@
 import * as RD from '@devexperts/remote-data-ts'
 import BigNumber from 'bignumber.js'
+import { Option } from 'fp-ts/lib/Option'
 
 import { AssetDetail, PoolDetail, NetworkInfo } from '../../types/generated/midgard'
-import { PricePools, PricePool } from '../../views/pools/types'
+import { PricePools } from '../../views/pools/types'
 
 export type PoolAsset = string
 export type PoolAssets = string[]
@@ -23,8 +24,7 @@ export type PoolsState = {
   assetDetails: AssetDetails
   poolAssets: PoolAssets
   poolDetails: PoolDetails
-  pricePools: PricePools
-  selectedPricePool: PricePool
+  pricePools: Option<PricePools>
 }
 
 export type PoolsStateRD = RD.RemoteData<Error, PoolsState>

--- a/src/views/View.style.tsx
+++ b/src/views/View.style.tsx
@@ -4,7 +4,6 @@ import { size } from 'styled-theme'
 
 export const ViewWrapper = styled(Layout.Content)`
   padding: 70px 50px;
-  width: 100vw;
   margin-top: ${size('headerHeight')};
   margin-bottom: ${size('footerHeight')};
   min-height: calc(100vh - ${size('headerHeight')} - ${size('footerHeight')});

--- a/src/views/playground/PlaygroundView.tsx
+++ b/src/views/playground/PlaygroundView.tsx
@@ -39,7 +39,7 @@ const PlaygroundView: React.FC<Props> = (_): JSX.Element => {
   useSubscription(transfers$, transferHandler)
 
   const { service: midgardService } = useMidgardContext()
-  const poolState = useObservableState(midgardService.poolState$, RD.initial)
+  const poolState = useObservableState(midgardService.poolsState$, RD.initial)
 
   const renderPools = useMemo(
     () =>

--- a/src/views/pools/PoolsOverview.tsx
+++ b/src/views/pools/PoolsOverview.tsx
@@ -38,7 +38,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
   const history = useHistory()
 
   const { service: midgardService } = useMidgardContext()
-  const poolsRD = useObservableState(midgardService.poolState$, RD.pending)
+  const poolsRD = useObservableState(midgardService.poolsState$, RD.pending)
   const selectedPricePoolAsset = useObservableState<Option<PricePoolAsset>>(
     midgardService.selectedPricePoolAsset$,
     some(PoolAsset.RUNE)

--- a/src/views/pools/PoolsOverview.tsx
+++ b/src/views/pools/PoolsOverview.tsx
@@ -6,6 +6,8 @@ import { BaseAmount, baseToAsset, formatAssetAmountCurrency } from '@thorchain/a
 import { Grid, Row } from 'antd'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
 import BigNumber from 'bignumber.js'
+import * as O from 'fp-ts/lib/Option'
+import { Option, some } from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useHistory } from 'react-router-dom'
 
@@ -23,11 +25,12 @@ import * as stakeRoutes from '../../routes/stake'
 import * as swapRoutes from '../../routes/swap'
 import { SwapRouteParams } from '../../routes/swap'
 import { PoolsState } from '../../services/midgard/types'
+import { selectedPricePoolSelector } from '../../services/midgard/utils'
 import { Maybe, Nothing } from '../../types/asgardex'
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 import View from '../View'
 import { ActionColumn, TableAction, BlockLeftLabel } from './PoolsOverview.style'
-import { PoolTableRowData, PoolTableRowsData } from './types'
+import { PoolTableRowData, PoolTableRowsData, PricePoolAsset, PoolAsset } from './types'
 
 type Props = {}
 
@@ -36,6 +39,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
 
   const { service: midgardService } = useMidgardContext()
   const poolsRD = useObservableState(midgardService.poolState$, RD.pending)
+  const selectedPricePoolAsset = useObservableState<Option<PricePoolAsset>>(
+    midgardService.selectedPricePoolAsset$,
+    some(PoolAsset.RUNE)
+  )
   const networkInfoRD = useObservableState(midgardService.networkInfo$, RD.pending)
 
   const [blocksLeft, setBlocksLeft] = useState('')
@@ -68,8 +75,9 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
 
   const pricePool = useMemo(() => {
     const pools = RD.toNullable(poolsRD)
-    return pools?.selectedPricePool ?? RUNE_PRICE_POOL
-  }, [poolsRD])
+    const pricePools = pools && O.toNullable(pools.pricePools)
+    return (pricePools && selectedPricePoolSelector(pricePools, selectedPricePoolAsset)) || RUNE_PRICE_POOL
+  }, [poolsRD, selectedPricePoolAsset])
 
   const clickSwapHandler = (p: SwapRouteParams) => {
     history.push(swapRoutes.swap.path(p))

--- a/src/views/pools/types.ts
+++ b/src/views/pools/types.ts
@@ -1,5 +1,6 @@
 import { BaseAmount, PoolData } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 
@@ -34,7 +35,7 @@ export type PricePool = {
   poolData: PoolData
 }
 
-export type PricePools = PricePool[]
+export type PricePools = NonEmptyArray<PricePool>
 
 export type PoolTableRowData = {
   pool: Pool

--- a/yarn.lock
+++ b/yarn.lock
@@ -8659,6 +8659,11 @@ fp-ts@^2.0.0:
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.6.2.tgz#0115221e223e0e4a1d08d93c0ebaee9241688cd1"
   integrity sha512-RUm0iNcD7eMFZo6W1K10kqi0DyYX06lbbjyNgKwEWg1kPZw91ZXlkEx/9cII1x/jY4fHzh14+Hquk5sJnXBzQA==
 
+fp-ts@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.6.6.tgz#cfb57772a845628e56da05d8c5dc03227aedadb4"
+  integrity sha512-zYfhPNb2fwpkrJ5RpgEMsrvMv8r9x+guJptnaEBF295YtoVr3+jbGDXZqSqPcfEWas5Trj3FpbDkzmXbx0YYzQ==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"


### PR DESCRIPTION
- [x]  Change props of `HeaderCurrency` to simplify data handling
- [x] Extract `selectedPricePoolAsset` from `PoolsState`
- [x] Rename `HeaderCurrency` -> `HeaderPriceSelector`
- [x] Add `selectedPricePoolSelector` incl. tests
- [x] Introduce `ObservableState` + `observableState` to simplify creation of observable states
- [x] Add [`fp-ts`](https://github.com/gcanti/fp-ts) library

Closes #185 
