### PR TITLE
Fix storybook to avoid using contexts of i18n and wallet

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,19 +7,24 @@ import { BrowserRouter as Router, Route } from 'react-router-dom'
 
 import { AppProvider } from '../src/contexts/AppContext'
 import { ThemeProvider } from '../src/contexts/ThemeContext'
-import { I18nProvider } from '../src/contexts/I18nContext'
 import { AppWrapper } from '../src/App.style'
+import { Locale } from '../src/shared/i18n/types'
+import { getMessagesByLocale } from '../src/i18n'
+import { IntlProvider } from 'react-intl'
 
 const lightTheme = { name: 'Light', ...themes.light }
 const darkTheme = { name: 'Dark', ...themes.dark }
+const locale = Locale.EN
+const messages = getMessagesByLocale(locale)
 
 const providerFn = ({ theme, children }) => (
   <AppProvider>
-    <I18nProvider>
+    {/* We use IntlProvider instead of our our custom I18nProvider to provide messages, but w/o dependencies to Electron/Node source, which can't run in storybook */}
+    <IntlProvider locale={locale} messages={messages} defaultLocale={locale}>
       <ThemeProvider theme={theme}>
         <AppWrapper>{children}</AppWrapper>
       </ThemeProvider>
-    </I18nProvider>
+    </IntlProvider>
   </AppProvider>
 )
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,8 +3,10 @@ import React from 'react'
 import { none } from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 
+import { useI18nContext } from '../../contexts/I18nContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useWalletContext } from '../../contexts/WalletContext'
+import { initialLocale } from '../../services/i18n/service'
 import HeaderComponent from './HeaderComponent'
 
 const Header: React.FC = (): JSX.Element => {
@@ -14,6 +16,9 @@ const Header: React.FC = (): JSX.Element => {
   const { service: midgardService } = useMidgardContext()
   const { poolsState$, setSelectedPricePool, selectedPricePoolAsset$ } = midgardService
 
+  const { changeLocale, locale$ } = useI18nContext()
+  const currentLocale = useObservableState(locale$, initialLocale)
+
   return (
     <HeaderComponent
       keystore={keystore}
@@ -21,6 +26,8 @@ const Header: React.FC = (): JSX.Element => {
       poolsState$={poolsState$}
       setSelectedPricePool={setSelectedPricePool}
       selectedPricePoolAsset$={selectedPricePoolAsset$}
+      locale={currentLocale}
+      changeLocale={changeLocale}
     />
   )
 }

--- a/src/components/header/HeaderComponent.stories.tsx
+++ b/src/components/header/HeaderComponent.stories.tsx
@@ -5,6 +5,7 @@ import { storiesOf } from '@storybook/react'
 import { none } from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
+import { Locale } from '../../shared/i18n/types'
 import HeaderComponent from './HeaderComponent'
 
 storiesOf('Components/Header', module).add('default', () => {
@@ -15,6 +16,7 @@ storiesOf('Components/Header', module).add('default', () => {
       poolsState$={Rx.of(RD.pending)}
       setSelectedPricePool={() => console.log('setSelectedPricePool')}
       selectedPricePoolAsset$={Rx.of(none)}
+      locale={Locale.EN}
     />
   )
 })

--- a/src/components/header/HeaderComponent.tsx
+++ b/src/components/header/HeaderComponent.tsx
@@ -22,6 +22,7 @@ import * as walletRoutes from '../../routes/wallet'
 import { PoolsStateRD, SelectedPricePoolAsset } from '../../services/midgard/types'
 import { KeystoreState } from '../../services/wallet/types'
 import { isLocked, hasImportedKeystore } from '../../services/wallet/util'
+import { Locale } from '../../shared/i18n/types'
 import { PricePoolAsset, PricePoolAssets, PoolAsset } from '../../views/pools/types'
 import { HeaderContainer, TabLink, HeaderDrawer, HeaderDrawerItem } from './HeaderComponent.style'
 import HeaderLang from './HeaderLang'
@@ -50,10 +51,20 @@ type Props = {
   setSelectedPricePool: (asset: PricePoolAsset) => void
   poolsState$: Observable<PoolsStateRD>
   selectedPricePoolAsset$: Observable<SelectedPricePoolAsset>
+  locale: Locale
+  changeLocale?: (locale: Locale) => void
 }
 
 const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
-  const { keystore, poolsState$, selectedPricePoolAsset$, lockHandler, setSelectedPricePool } = props
+  const {
+    keystore,
+    poolsState$,
+    selectedPricePoolAsset$,
+    lockHandler,
+    setSelectedPricePool,
+    locale,
+    changeLocale
+  } = props
 
   const intl = useIntl()
 
@@ -213,6 +224,11 @@ const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
     [isDesktopView, clickSettingsHandler]
   )
 
+  const renderHeaderLang = useMemo(
+    () => <HeaderLang isDesktopView={isDesktopView} locale={locale} changeLocale={changeLocale} />,
+    [changeLocale, isDesktopView, locale]
+  )
+
   const iconStyle = { fontSize: '1.5em', marginRight: '20px' }
   const color = useMemo(() => palette('text', 0)({ theme }), [theme])
 
@@ -239,7 +255,7 @@ const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   <HeaderTheme isDesktopView={isDesktopView} />
                   {renderHeaderLock}
                   {renderHeaderSettings}
-                  <HeaderLang isDesktopView={isDesktopView} />
+                  {renderHeaderLang}
                 </Row>
               </Col>
             </>
@@ -286,9 +302,7 @@ const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
             </HeaderDrawerItem>
             <HeaderDrawerItem>{renderHeaderLock}</HeaderDrawerItem>
             <HeaderDrawerItem>{renderHeaderSettings}</HeaderDrawerItem>
-            <HeaderDrawerItem>
-              <HeaderLang isDesktopView={isDesktopView} />
-            </HeaderDrawerItem>
+            <HeaderDrawerItem>{renderHeaderLang}</HeaderDrawerItem>
             <HeaderNetStatus />
           </HeaderDrawer>
         )}

--- a/src/components/header/HeaderLang.stories.tsx
+++ b/src/components/header/HeaderLang.stories.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
+import { Locale } from '../../i18n/types'
 import HeaderLang from './HeaderLang'
 
 storiesOf('Components/HeaderLang', module).add('desktop / mobile', () => {
   const isDesktopView = boolean('isDesktopView', false)
-  return <HeaderLang isDesktopView={isDesktopView} />
+  return <HeaderLang isDesktopView={isDesktopView} locale={Locale.EN} />
 })

--- a/src/components/header/HeaderLang.tsx
+++ b/src/components/header/HeaderLang.tsx
@@ -2,10 +2,8 @@ import React, { useMemo, useCallback } from 'react'
 
 import { Row, Dropdown } from 'antd'
 import { ClickParam } from 'antd/lib/menu'
-import { useObservableState } from 'observable-hooks'
 
 import { ReactComponent as DownIcon } from '../../assets/svg/icon-down.svg'
-import { useI18nContext } from '../../contexts/I18nContext'
 import { LOCALES } from '../../i18n'
 import { Locale } from '../../i18n/types'
 import Menu from '../shared/Menu'
@@ -19,13 +17,12 @@ import {
 
 type Props = {
   isDesktopView: boolean
+  locale: Locale
+  changeLocale?: (locale: Locale) => void
 }
 
 const HeaderLang: React.FC<Props> = (props: Props): JSX.Element => {
-  const { isDesktopView } = props
-
-  const { changeLocale, locale$ } = useI18nContext()
-  const currentLocale = useObservableState(locale$)
+  const { isDesktopView, changeLocale = () => {}, locale } = props
 
   const changeLang = useCallback(
     ({ key }: ClickParam) => {
@@ -55,7 +52,7 @@ const HeaderLang: React.FC<Props> = (props: Props): JSX.Element => {
         <HeaderDropdownContentWrapper>
           {!isDesktopView && <HeaderDropdownTitle>Language</HeaderDropdownTitle>}
           <Row style={{ alignItems: 'center' }}>
-            <HeaderDropdownMenuItemText strong>{currentLocale || ''}</HeaderDropdownMenuItemText>
+            <HeaderDropdownMenuItemText strong>{locale || ''}</HeaderDropdownMenuItemText>
             <DownIcon />
           </Row>
         </HeaderDropdownContentWrapper>

--- a/src/components/wallet/UnlockForm.tsx
+++ b/src/components/wallet/UnlockForm.tsx
@@ -10,7 +10,6 @@ import { useIntl } from 'react-intl'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import { InputPassword } from '../../components/uielements/input'
-import { useWalletContext } from '../../contexts/WalletContext'
 import { envOrDefault } from '../../helpers/envHelper'
 import { RedirectRouteState } from '../../routes/types'
 import * as walletRoutes from '../../routes/wallet'
@@ -22,18 +21,17 @@ import * as Styled from './UnlockForm.style'
 
 type Props = {
   keystore: KeystoreState
-  unlockHandler?: (state: KeystoreState, password: string) => Promise<void>
+  unlock?: (state: KeystoreState, password: string) => Promise<void>
+  removeKeystore?: () => Promise<void>
 }
 
 const UnlockForm: React.FC<Props> = (props: Props): JSX.Element => {
-  const { keystore, unlockHandler = () => Promise.resolve() } = props
+  const { keystore, unlock: unlockHandler = () => Promise.resolve(), removeKeystore = () => Promise.resolve() } = props
 
   const [showRemoveModal, setShowRemoveModal] = useState(false)
   const history = useHistory()
   const location = useLocation<RedirectRouteState>()
   const intl = useIntl()
-  const { keystoreService } = useWalletContext()
-  const { removeKeystore } = keystoreService
   const [form] = Styled.Form.useForm()
 
   const [validPassword, setValidPassword] = useState(false)

--- a/src/views/wallet/UnlockView.tsx
+++ b/src/views/wallet/UnlockView.tsx
@@ -11,7 +11,8 @@ import { hasImportedKeystore } from '../../services/wallet/util'
 
 const UnlockView: React.FC = (): JSX.Element => {
   const { keystoreService } = useWalletContext()
-  const keystore = useObservableState(keystoreService.keystore$, initialKeystoreState())
+  const { keystore$, removeKeystore } = keystoreService
+  const keystore = useObservableState(keystore$, initialKeystoreState())
   const history = useHistory()
 
   useEffect(() => {
@@ -20,7 +21,7 @@ const UnlockView: React.FC = (): JSX.Element => {
     }
   }, [keystore, history])
 
-  return <UnlockForm keystore={keystore} unlockHandler={keystoreService.unlock} />
+  return <UnlockForm keystore={keystore} unlock={keystoreService.unlock} removeKeystore={removeKeystore} />
 }
 
 export default UnlockView


### PR DESCRIPTION
and to avoid Electron / Node dependencies, which breaks storybook

- [x] Use `IntlProvider` instead of our our custom `I18nProvider` in storybook
- [x] Header: Push dependencies of `useI18nContext` down to child components 