### PR TITLE
Story of `Send` breaks storybook #323

### DIFF
--- a/src/renderer/components/wallet/Send.stories.tsx
+++ b/src/renderer/components/wallet/Send.stories.tsx
@@ -1,11 +1,43 @@
 import React from 'react'
 
+import { failure, initial, pending, RemoteData, success } from '@devexperts/remote-data-ts'
 import { storiesOf } from '@storybook/react'
+import { EMPTY, Observable, of } from 'rxjs'
 
-// import Send from './Send'
+import Send from './Send'
+
+// eslint-disable-next-line
+const createServiceProp = (value: Observable<RemoteData<Error, any>>) => ({
+  transaction$: value,
+  pushTx: () => of(initial).subscribe(),
+  resetTx: () => null
+})
 
 storiesOf('Wallet/Send', module).add('default', () => {
-  // `Send` breaks storybook https://github.com/thorchain/asgardex-electron/issues/323
-  // return <Send />
-  return <> </>
+  return <Send transactionService={createServiceProp(EMPTY)} />
+})
+
+storiesOf('Wallet/Send', module).add('pending', () => {
+  return <Send transactionService={createServiceProp(of(pending))} />
+})
+
+storiesOf('Wallet/Send', module).add('error', () => {
+  return <Send transactionService={createServiceProp(of(failure(Error('error example'))))} />
+})
+
+storiesOf('Wallet/Send', module).add('success', () => {
+  return (
+    <Send
+      transactionService={createServiceProp(
+        of(
+          success({
+            code: 200,
+            hash: '',
+            log: '',
+            ok: true
+          })
+        )
+      )}
+    />
+  )
 })

--- a/src/renderer/components/wallet/Send.tsx
+++ b/src/renderer/components/wallet/Send.tsx
@@ -8,15 +8,18 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 
 import { ASSETS_MAINNET } from '../../../shared/mock/assets'
-import { useBinanceContext } from '../../contexts/BinanceContext'
+import { BinanceContextValue } from '../../contexts/BinanceContext'
 import BackLink from '../uielements/backLink'
 import { Input, InputNumber } from '../uielements/input'
 import AccountSelector from './AccountSelector'
 import * as Styled from './Send.style'
 
-const Send: React.FC = (): JSX.Element => {
+type SendProps = {
+  transactionService: BinanceContextValue['transaction']
+}
+
+const Send: React.FC<SendProps> = ({ transactionService }): JSX.Element => {
   const intl = useIntl()
-  const { transaction: transactionService } = useBinanceContext()
   const [activeAsset, setActiveAsset] = useState(ASSETS_MAINNET.BOLT)
 
   useEffect(() => {
@@ -72,7 +75,7 @@ const Send: React.FC = (): JSX.Element => {
                     </Styled.FormItem>
                     <Styled.StyledLabel size="big">MAX 35.3 BNB</Styled.StyledLabel>
                     <Styled.CustomLabel size="big">{intl.formatMessage({ id: 'common.memo' })}</Styled.CustomLabel>
-                    <Form.Item name="password ">
+                    <Form.Item name="password">
                       <Input size="large" />
                     </Form.Item>
                   </Styled.SubForm>

--- a/src/renderer/contexts/BinanceContext.tsx
+++ b/src/renderer/contexts/BinanceContext.tsx
@@ -21,7 +21,7 @@ import {
 import { useAppContext } from './AppContext'
 import { useWalletContext } from './WalletContext'
 
-type BinanceContextValue = {
+export type BinanceContextValue = {
   subscribeTransfers: typeof subscribeTransfers
   miniTickers$: typeof miniTickers$
   clientViewState$: typeof clientViewState$

--- a/src/renderer/views/wallet/SendView.tsx
+++ b/src/renderer/views/wallet/SendView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
 import Send from '../../components/wallet/Send'
+import { useBinanceContext } from '../../contexts/BinanceContext'
 
 const SendView: React.FC = (): JSX.Element => {
-  return <Send />
+  const { transaction } = useBinanceContext()
+  return <Send transactionService={transaction} />
 }
 
 export default SendView


### PR DESCRIPTION
* refactored Wallet/Swap component to use transaction service as prop

closes https://github.com/thorchain/asgardex-electron/issues/323