### PR TITLE
Update `AccountSelector`

### DIFF
--- a/src/renderer/components/wallet/AccountSelector.stories.tsx
+++ b/src/renderer/components/wallet/AccountSelector.stories.tsx
@@ -1,16 +1,20 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { bn } from '@thorchain/asgardex-util'
+import { assetAmount } from '@thorchain/asgardex-util'
 
 import { ASSETS_MAINNET } from '../../../shared/mock/assets'
 import AccountSelector from './AccountSelector'
 
-storiesOf('Wallet/AccountSelector', module).add('default', () => {
-  return (
-    <AccountSelector
-      asset={ASSETS_MAINNET.BOLT}
-      assets={[ASSETS_MAINNET.BNB, ASSETS_MAINNET.TOMO].map((asset) => ({ ...asset, balance: bn(1) }))}
-    />
-  )
-})
+storiesOf('Wallet/AccountSelector', module)
+  .add('default', () => {
+    return (
+      <AccountSelector
+        selectedAsset={ASSETS_MAINNET.BOLT}
+        assets={[ASSETS_MAINNET.BNB, ASSETS_MAINNET.TOMO].map((asset) => ({ asset, balance: assetAmount(1) }))}
+      />
+    )
+  })
+  .add('w/o dropdown', () => {
+    return <AccountSelector selectedAsset={ASSETS_MAINNET.BOLT} assets={[]} />
+  })

--- a/src/renderer/components/wallet/AccountSelector.style.tsx
+++ b/src/renderer/components/wallet/AccountSelector.style.tsx
@@ -1,8 +1,10 @@
-import { Card } from 'antd'
+import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
-export const StyledCard = styled(Card)`
+import UILabel from '../uielements/label'
+
+export const Card = styled(A.Card)`
   background: ${palette('background', 1)};
   .ant-card-body {
     padding: 20px 35px;
@@ -16,6 +18,7 @@ export const AssetWrapper = styled.div`
 export const AssetInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: space-between;
   margin-left: 16px;
 `
@@ -25,6 +28,13 @@ export const AssetTitle = styled.p`
   font-size: 24px;
   font-family: 'MainFontRegular';
   color: ${palette('text', 0)};
-  line-height: 29px;
   text-transform: uppercase;
+`
+
+export const Label = styled(UILabel).attrs({
+  textTransform: 'uppercase',
+  color: 'primary',
+  size: 'big'
+})`
+  padding-top: 0;
 `

--- a/src/renderer/components/wallet/Send.tsx
+++ b/src/renderer/components/wallet/Send.tsx
@@ -7,6 +7,7 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 
 import { BinanceContextValue } from '../../contexts/BinanceContext'
+import { AssetsWithBalanceRD } from '../../services/binance/types'
 import { AssetWithBalance } from '../../types/asgardex'
 import ErrorView from '../shared/error/ErrorView'
 import { LoadingView } from '../shared/loading/LoadingView'
@@ -16,7 +17,7 @@ import { SendForm } from './SendForm'
 
 type SendProps = {
   transactionService: BinanceContextValue['transaction']
-  balances?: RD.RemoteData<Error, AssetWithBalance[]>
+  balances?: AssetsWithBalanceRD
   initialActiveAsset?: RD.RemoteData<Error, O.Option<AssetWithBalance>>
 }
 

--- a/src/renderer/components/wallet/SendForm.tsx
+++ b/src/renderer/components/wallet/SendForm.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { bn } from '@thorchain/asgardex-util'
+import { bn, Asset } from '@thorchain/asgardex-util'
 import { Row, Form } from 'antd'
 import { Store } from 'antd/lib/form/interface'
 import * as O from 'fp-ts/lib/Option'
@@ -8,13 +8,14 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { useIntl } from 'react-intl'
 
 import { ASSETS_MAINNET } from '../../../shared/mock/assets'
+import { AssetsWithBalance } from '../../services/binance/types'
 import { AssetWithBalance } from '../../types/asgardex'
 import { Input, InputNumber } from '../uielements/input'
 import AccountSelector from './AccountSelector'
 import * as Styled from './Send.style'
 
 type SendFormProps = {
-  balances?: AssetWithBalance[]
+  balances?: AssetsWithBalance
   initialActiveAsset?: O.Option<AssetWithBalance>
   onSubmit: (recipient: string, amount: number, symbol: string, password?: string) => void
 }
@@ -25,7 +26,8 @@ export const SendForm: React.FC<SendFormProps> = ({
   initialActiveAsset = O.none
 }): JSX.Element => {
   const intl = useIntl()
-  const [activeAsset, setActiveAsset] = useState<AssetWithBalance>(
+  // `activeAsset` will be removed in https://github.com/thorchain/asgardex-electron/pull/340
+  const [activeAsset] = useState<AssetWithBalance>(
     pipe(
       initialActiveAsset,
       O.getOrElse(() => ({ ...ASSETS_MAINNET.BOLT, balance: bn(0) }))
@@ -68,10 +70,14 @@ export const SendForm: React.FC<SendFormProps> = ({
     [onSubmitProp, activeAsset]
   )
 
+  const changeSelectorHandler = (_asset: Asset) => {
+    // will be implemented by https://github.com/thorchain/asgardex-electron/pull/340
+  }
+
   return (
     <Row>
       <Styled.Col span={24}>
-        <AccountSelector onChange={setActiveAsset} asset={activeAsset} assets={balances} />
+        <AccountSelector onChange={changeSelectorHandler} selectedAsset={activeAsset} assets={balances} />
         <Styled.Form form={form} onFinish={onSubmit} labelCol={{ span: 24 }}>
           <Styled.SubForm>
             <Styled.CustomLabel size="big">{intl.formatMessage({ id: 'common.address' })}</Styled.CustomLabel>

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -28,6 +28,7 @@ const common: CommonMessages = {
   'common.loading': 'Lade...',
   'common.error': 'Fehler',
   'common.success': 'Erfolgreich',
+  'common.change': 'Ändern',
   'common.wallet': 'Wallet',
   'common.assets': 'Assets',
   'common.asset': 'Asset',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -28,6 +28,7 @@ const common: CommonMessages = {
   'common.loading': 'Loading...',
   'common.error': 'Error',
   'common.success': 'Success',
+  'common.change': 'Change',
   'common.wallet': 'Wallet',
   'common.assets': 'Assets',
   'common.asset': 'Asset',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -28,6 +28,7 @@ const common: CommonMessages = {
   'common.loading': 'Загрузка...',
   'common.error': 'Ошибка',
   'common.success': 'Успешно',
+  'common.change': 'Change - RU',
   'common.wallet': 'Кошелек',
   'common.assets': 'Ассеты',
   'common.asset': 'Ассет',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -26,6 +26,7 @@ type CommonMessageKey =
   | 'common.loading'
   | 'common.error'
   | 'common.success'
+  | 'common.change'
   | 'common.wallet'
   | 'common.pool'
   | 'common.pools'

--- a/src/renderer/services/binance/types.ts
+++ b/src/renderer/services/binance/types.ts
@@ -1,10 +1,21 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Balances, BinanceClient, Txs } from '@thorchain/asgardex-binance'
+import { Asset, AssetAmount } from '@thorchain/asgardex-util'
 import { Either } from 'fp-ts/lib/Either'
 import { getEitherM } from 'fp-ts/lib/EitherT'
 import { Option, option } from 'fp-ts/lib/Option'
 
 export type BalancesRD = RD.RemoteData<Error, Balances>
+
+export type AssetWithBalance = {
+  asset: Asset
+  balance: AssetAmount
+  frozenBalance?: AssetAmount
+}
+
+export type AssetsWithBalance = AssetWithBalance[]
+
+export type AssetsWithBalanceRD = RD.RemoteData<Error, AssetsWithBalance>
 
 export type TxsRD = RD.RemoteData<Error, Txs>
 

--- a/src/renderer/views/wallet/SendView.tsx
+++ b/src/renderer/views/wallet/SendView.tsx
@@ -49,7 +49,8 @@ const SendView: React.FC = (): JSX.Element => {
     [balances, asset]
   )
 
-  return <Send transactionService={transaction} balances={balances} initialActiveAsset={initialActiveAsset} />
+  // `balances` will be fixed in https://github.com/thorchain/asgardex-electron/pull/340
+  return <Send transactionService={transaction} balances={RD.initial} initialActiveAsset={initialActiveAsset} />
 }
 
 export default SendView


### PR DESCRIPTION
to handle single list of assets in a better way

- Update `i18n`
- Add `AssetWithBalance`, `AssetsWithBalance`, `AssetsWithBalanceRD` to
service/binance
- Update `Send` components to use updated `AccountSelector`. _**Important note:**_  That's more a temporary approach and sending an transaction won't work - it will be fixed in #340