### PR TITLE
Fix Dropdown render (warn) messages + others by updating to latest `antd`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@thorchain/asgardex-util": "^0.3.0",
     "@thorchain/byzantine-module": "^0.1.1",
     "@types/electron-devtools-installer": "^2.2.0",
-    "antd": "^4.5.2",
+    "antd": "^4.6.1",
     "bignumber.js": "^9.0.0",
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.2",

--- a/src/renderer/components/wallet/AccountSelector.tsx
+++ b/src/renderer/components/wallet/AccountSelector.tsx
@@ -57,7 +57,13 @@ const AccountSelector: React.FC<Props> = (props: Props): JSX.Element => {
 
           {enableDropdown && (
             <Dropdown overlay={menu} trigger={['click']}>
-              <Styled.Label>{intl.formatMessage({ id: 'common.change' })}</Styled.Label>
+              {/* Important note:
+                  Label has to be wrapped into a `div` to avoid error render messages
+                  such as "Function components cannot be given refs"
+              */}
+              <div>
+                <Styled.Label>{intl.formatMessage({ id: 'common.change' })}</Styled.Label>
+              </div>
             </Dropdown>
           )}
         </Styled.AssetInfoWrapper>

--- a/src/renderer/components/wallet/AssetDetails.style.tsx
+++ b/src/renderer/components/wallet/AssetDetails.style.tsx
@@ -3,79 +3,20 @@ import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import Headline from '../uielements/headline'
-import Label from '../uielements/label'
-
-export const StyledPriceWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: ${palette('background', 1)};
-`
-
-export const StyledAssetName = styled.h1`
-  font-size: 32px;
-  font-family: 'MainFontRegular';
-  color: ${palette('text', 0)};
-  line-height: 1em;
-  text-transform: uppercase;
-`
-
-export const StyledLabel = styled(Label)`
-  margin-bottom: 18px;
-  font-family: 'MainFontRegular';
-`
-
-export const CoinInfoWrapper = styled.div`
-  margin-left: 30px;
-  flex-direction: column;
-`
-
-export const CoinTitle = styled.p`
-  margin-bottom: 10px;
-  font-size: 32px;
-  font-family: 'MainFontRegular';
-  color: ${palette('text', 0)};
-  line-height: 38px;
-  text-transform: uppercase;
-`
-
-export const CoinSubtitle = styled.p`
-  margin-bottom: 0px;
-  font-size: 24px;
-  font-family: 'MainFontRegular';
-  color: ${palette('text', 0)};
-  line-height: 29px;
-  text-transform: uppercase;
-`
-
-export const CoinPrice = styled.p`
-  display: flex;
-  align-items: flex-end;
-  margin-left: 85px;
-  margin-bottom: 0px;
-  font-size: 32px;
-  font-family: 'MainFontRegular';
-  font-weight: 300;
-  color: ${palette('text', 0)};
-  line-height: 38px;
-  text-transform: uppercase;
-`
-
-export const CoinMobilePrice = styled.p`
-  display: flex;
-  align-items: flex-end;
-  margin: 10px 0px 0px;
-  font-size: 32px;
-  font-family: 'MainFontRegular';
-  font-weight: 300;
-  color: ${palette('text', 0)};
-  line-height: 38px;
-  text-transform: uppercase;
-`
+import UILabel from '../uielements/label'
 
 export const Divider = styled(A.Divider)`
   margin: 0px;
   border-top: 1px solid ${palette('gray', 0)};
+`
+
+export const Label = styled(UILabel).attrs({
+  textTransform: 'uppercase',
+  align: 'center',
+  color: 'primary',
+  size: 'big'
+})`
+  cursor: pointer;
 `
 
 export const ActionRow = styled(A.Row)`

--- a/src/renderer/components/wallet/AssetDetails.tsx
+++ b/src/renderer/components/wallet/AssetDetails.tsx
@@ -170,9 +170,13 @@ const AssetDetails: React.FC<Props> = (props: Props): JSX.Element => {
               {isRuneAsset && (
                 <Row justify="center">
                   <Dropdown overlay={changeActionMenu} placement="bottomCenter" trigger={['click']}>
-                    <Label textTransform="uppercase" align="center" color="primary" size="big">
-                      {intl.formatMessage({ id: 'common.change' })}
-                    </Label>
+                    {/* Important note:
+                        Label has to be wrapped into a `div` to avoid error render messages
+                        such as "Function components cannot be given refs"
+                     */}
+                    <div>
+                      <Styled.Label>{intl.formatMessage({ id: 'common.change' })}</Styled.Label>
+                    </div>
                   </Dropdown>
                 </Row>
               )}

--- a/src/renderer/components/wallet/NewMnemonicGenerate.tsx
+++ b/src/renderer/components/wallet/NewMnemonicGenerate.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react'
 
 import { generatePhrase } from '@thorchain/asgardex-crypto'
-import { Rule } from 'antd/lib/form'
-import { Store } from 'antd/lib/form/interface'
+import Form, { Rule } from 'antd/lib/form'
 import { useIntl } from 'react-intl'
 
 import Button, { RefreshButton } from '../uielements/button/'
@@ -15,6 +14,11 @@ export type MnemonicInfo = { phrase: string; password: string }
 type Props = {
   onSubmit: (info: MnemonicInfo) => void
 }
+
+export type FormValues = {
+  password: string
+}
+
 const NewMnemonicGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Element => {
   const [loadingMsg, setLoadingMsg] = useState<string>('')
   const intl = useIntl()
@@ -23,11 +27,13 @@ const NewMnemonicGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Element 
 
   const phraseWords = useMemo(() => phrase.split(' ').map((word) => ({ text: word, _id: word })), [phrase])
 
+  const [form] = Form.useForm<FormValues>()
+
   const handleFormFinish = useCallback(
-    async (formData: Store) => {
+    ({ password }: FormValues) => {
       try {
         setLoadingMsg(intl.formatMessage({ id: 'wallet.create.creating' }) + '...')
-        onSubmit({ phrase, password: formData.password })
+        onSubmit({ phrase, password: password })
       } catch (err) {
         setLoadingMsg('')
       }
@@ -62,7 +68,12 @@ const NewMnemonicGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Element 
         <RefreshButton clickHandler={() => setPhrase(generatePhrase())} />
       </Styled.TitleContainer>
       <MnemonicPhrase words={phraseWords} readOnly={true} />
-      <Styled.Form onFinish={handleFormFinish} labelCol={{ span: 24 }}>
+      {/* `Form<FormValue>` does not work in `styled(Form)`, so we have to add styles here. All is just needed to have correct types in `onFinish` handler)  */}
+      <Form
+        form={form}
+        onFinish={handleFormFinish}
+        labelCol={{ span: 24 }}
+        style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
         <Styled.PasswordContainer>
           <Styled.PasswordItem name="password" validateTrigger={['onSubmit', 'onBlur']} rules={rules}>
             <Input
@@ -88,7 +99,7 @@ const NewMnemonicGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Element 
             {loadingMsg || intl.formatMessage({ id: 'common.next' })}
           </Button>
         </Styled.SubmitItem>
-      </Styled.Form>
+      </Form>
     </>
   )
 }

--- a/src/renderer/components/wallet/UnlockForm.style.tsx
+++ b/src/renderer/components/wallet/UnlockForm.style.tsx
@@ -1,4 +1,4 @@
-import AF from 'antd/lib/form'
+import * as A from 'antd'
 import AT from 'antd/lib/typography/Text'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
@@ -6,13 +6,7 @@ import { palette } from 'styled-theme'
 import { media } from '../../helpers/styleHelper'
 import BaseButton from '../uielements/button'
 
-export const Form = styled(AF)`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-`
-
-export const FormItem = styled(Form.Item)`
+export const FormItem = styled(A.Form.Item)`
   width: 100%;
   margin: 0;
 `
@@ -33,7 +27,7 @@ export const Text = styled(AT)`
   font-weight: 600;
 `
 
-export const PasswordInput = styled(AF.Item)`
+export const PasswordInput = styled(A.Form.Item)`
   width: 100%;
   max-width: 400px;
   margin: 0 auto;

--- a/src/renderer/components/wallet/UnlockForm.tsx
+++ b/src/renderer/components/wallet/UnlockForm.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react'
 
 import { Modal } from 'antd'
-import { Rule } from 'antd/lib/form'
-import { Store } from 'antd/lib/form/interface'
+import Form, { Rule } from 'antd/lib/form'
 import * as O from 'fp-ts/lib/Option'
 import { none, Option, some } from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
@@ -19,6 +18,10 @@ import BackLink from '../uielements/backLink'
 import { InputPassword } from '../uielements/input'
 import * as Styled from './UnlockForm.style'
 
+type FormValues = {
+  password: string
+}
+
 type Props = {
   keystore: KeystoreState
   unlock?: (state: KeystoreState, password: string) => Promise<void>
@@ -32,7 +35,7 @@ const UnlockForm: React.FC<Props> = (props: Props): JSX.Element => {
   const history = useHistory()
   const location = useLocation<RedirectRouteState>()
   const intl = useIntl()
-  const [form] = Styled.Form.useForm()
+  const [form] = Form.useForm<FormValues>()
 
   const [validPassword, setValidPassword] = useState(false)
 
@@ -75,7 +78,7 @@ const UnlockForm: React.FC<Props> = (props: Props): JSX.Element => {
   }
 
   const submitForm = useCallback(
-    async ({ password }: Store) => {
+    async ({ password }: FormValues) => {
       setUnlockError(none)
       await unlockHandler(keystore, password).catch((error) => {
         setUnlockError(some(error))
@@ -116,7 +119,8 @@ const UnlockForm: React.FC<Props> = (props: Props): JSX.Element => {
         <BackLink style={{ position: 'absolute', top: 0, left: 0 }} />
         <Styled.Text>{intl.formatMessage({ id: 'wallet.unlock.title' })}</Styled.Text>
       </Styled.Header>
-      <Styled.Form form={form} onFinish={submitForm}>
+      {/* `Form<FormValue>` does not work in `styled(Form)`, so we have to add styles here. All is just needed to have correct types in `onFinish` handler)  */}
+      <Form form={form} onFinish={submitForm} style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
         <Styled.Content>
           <div style={{ width: '100%' }}>
             <Styled.Text>{intl.formatMessage({ id: 'wallet.unlock.phrase' })}</Styled.Text>
@@ -144,7 +148,7 @@ const UnlockForm: React.FC<Props> = (props: Props): JSX.Element => {
             </Styled.Actions>
           </Styled.FormItem>
         </Styled.Content>
-      </Styled.Form>
+      </Form>
     </>
   )
 }

--- a/src/renderer/components/wallet/txs/FreezeForm.tsx
+++ b/src/renderer/components/wallet/txs/FreezeForm.tsx
@@ -1,14 +1,17 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { bn, assetAmount, assetToString, formatAssetAmountCurrency } from '@thorchain/asgardex-util'
-import { Row } from 'antd'
-import { Store } from 'antd/lib/form/interface'
+import { Row, Form } from 'antd'
 import { useIntl } from 'react-intl'
 
 import { AssetWithBalance, FreezeAction, FreezeTxParams } from '../../../services/binance/types'
 import { InputNumber } from '../../uielements/input'
 import AccountSelector from '../AccountSelector'
 import * as Styled from './Form.style'
+
+export type FormValues = {
+  amount: string
+}
 
 type Props = {
   freezeAction: FreezeAction
@@ -22,7 +25,7 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
 
   const intl = useIntl()
 
-  const [form] = Styled.Form.useForm()
+  const [form] = Form.useForm<FormValues>()
 
   const maxAmount = useMemo(() => {
     if (freezeAction === 'unfreeze') {
@@ -48,8 +51,8 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
   )
 
   const onSubmit = useCallback(
-    (data: Store) => {
-      onSubmitProp({ amount: assetAmount(data.amount), asset: assetWB.asset, action: freezeAction })
+    ({ amount }: FormValues) => {
+      onSubmitProp({ amount: assetAmount(amount), asset: assetWB.asset, action: freezeAction })
     },
     [onSubmitProp, assetWB, freezeAction]
   )
@@ -69,7 +72,8 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
     <Row>
       <Styled.Col span={24}>
         <AccountSelector selectedAsset={assetWB.asset} assets={[assetWB]} />
-        <Styled.Form form={form} onFinish={onSubmit} labelCol={{ span: 24 }}>
+        {/* `Form<FormValue>` does not work in `styled(Form)`, so we have to add styles here. All is just needed to have correct types in `onFinish` handler)  */}
+        <Form form={form} onFinish={onSubmit} labelCol={{ span: 24 }} style={{ padding: '30px' }}>
           <Styled.SubForm>
             <Styled.CustomLabel size="big">{intl.formatMessage({ id: 'common.amount' })}</Styled.CustomLabel>
             <Styled.FormItem
@@ -91,7 +95,7 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
               {submitLabel}
             </Styled.Button>
           </Styled.SubmitItem>
-        </Styled.Form>
+        </Form>
       </Styled.Col>
     </Row>
   )

--- a/src/renderer/components/wallet/txs/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/SendForm.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
+import { Address } from '@thorchain/asgardex-binance'
 import {
   assetToString,
   Asset,
@@ -10,7 +11,6 @@ import {
   formatAssetAmount
 } from '@thorchain/asgardex-util'
 import { Row, Form } from 'antd'
-import { Store } from 'antd/lib/form/interface'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
@@ -31,6 +31,12 @@ import AccountSelector from './../AccountSelector'
 import * as Styled from './Form.style'
 import { sendAmountValidator } from './util'
 
+export type FormValues = {
+  recipient: Address
+  amount: string
+  memo?: string
+}
+
 type Props = {
   assetsWB: AssetsWithBalanceRD
   assetWB: AssetWithBalance
@@ -45,7 +51,7 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const [form] = Styled.Form.useForm()
+  const [form] = Form.useForm<FormValues>()
 
   const assets = useMemo(
     () =>
@@ -101,8 +107,8 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
   )
 
   const onSubmit = useCallback(
-    (data: Store) => {
-      onSubmitProp({ to: data.recipient, amount: assetAmount(data.amount), asset: assetWB.asset, memo: data.memo })
+    ({ amount, recipient, memo }: FormValues) => {
+      onSubmitProp({ to: recipient, amount: assetAmount(amount), asset: assetWB.asset, memo })
     },
     [onSubmitProp, assetWB]
   )
@@ -116,8 +122,8 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
     <Row>
       <Styled.Col span={24}>
         <AccountSelector onChange={changeSelectorHandler} selectedAsset={assetWB.asset} assets={assets} />
-
-        <Styled.Form form={form} onFinish={onSubmit} labelCol={{ span: 24 }}>
+        {/* `Form<FormValue>` does not work in `styled(Form)`, so we have to add styles here. All is just needed to have correct types in `onFinish` handler)  */}
+        <Form form={form} onFinish={onSubmit} labelCol={{ span: 24 }} style={{ padding: '30px' }}>
           <Styled.SubForm>
             <Styled.CustomLabel size="big">{intl.formatMessage({ id: 'common.address' })}</Styled.CustomLabel>
             <Form.Item rules={[{ required: true, validator: addressValidator }]} name="recipient">
@@ -145,7 +151,7 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
               {intl.formatMessage({ id: 'wallet.action.send' })}
             </Styled.Button>
           </Styled.SubmitItem>
-        </Styled.Form>
+        </Form>
       </Styled.Col>
     </Row>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,13 @@
   dependencies:
     tinycolor2 "^1.4.1"
 
+"@ant-design/colors@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-4.0.5.tgz#d7d100d7545cca8f624954604a6892fc48ba5aae"
+  integrity sha512-3mnuX2prnWOWvpFTS2WH2LoouWlOgtnIpc6IarWN6GOzzLF8dW/U8UctuvIPhoboETehZfJ61XP+CGakBEPJ3Q==
+  dependencies:
+    tinycolor2 "^1.4.1"
+
 "@ant-design/css-animation@^1.7.2":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@ant-design/css-animation/-/css-animation-1.7.2.tgz#4ee5d2ec0fb7cc0a78b44e1c82628bd4621ac7e3"
@@ -32,6 +39,18 @@
     "@ant-design/colors" "^3.1.0"
     "@ant-design/icons-svg" "^4.0.0"
     "@babel/runtime" "^7.10.1"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^5.0.1"
+
+"@ant-design/icons@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.2.2.tgz#6533c5a02aec49238ec4748074845ad7d85a4f5e"
+  integrity sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==
+  dependencies:
+    "@ant-design/colors" "^3.1.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    "@babel/runtime" "^7.10.4"
     classnames "^2.2.6"
     insert-css "^2.0.0"
     rc-util "^5.0.1"
@@ -1163,6 +1182,13 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -3717,11 +3743,12 @@ ansi-to-html@^0.6.11:
   dependencies:
     entities "^1.1.2"
 
-antd@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-4.5.2.tgz#0551b2999d5c9827d996b860e827974d50d87ed9"
-  integrity sha512-XDI4ywKpj2LfvvQjHxkdItzLH0zlVvm3wKHyko03BoSzYVinZ9MWap3PXraclb8xBKH8d/14BRJSGmIsvxzkfg==
+antd@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-4.6.1.tgz#d204215d3d00a3ac51a2e93ec2ee1a49adbdb705"
+  integrity sha512-RsqbFvUNSZ5K114492BNo4p+4MpCUpzIsZLu0XFlufYLyIE3pyw184OZjPnJ7b4qlMEvlIoE14N8qCb4BnZF0w==
   dependencies:
+    "@ant-design/colors" "^4.0.5"
     "@ant-design/css-animation" "^1.7.2"
     "@ant-design/icons" "^4.2.1"
     "@ant-design/react-slick" "~0.27.0"
@@ -3729,7 +3756,7 @@ antd@^4.5.2:
     array-tree-filter "^2.1.0"
     classnames "^2.2.6"
     copy-to-clipboard "^3.2.0"
-    lodash "^4.17.13"
+    lodash "^4.17.20"
     moment "^2.25.3"
     omit.js "^2.0.2"
     raf "^3.4.1"
@@ -3740,27 +3767,29 @@ antd@^4.5.2:
     rc-dialog "~8.1.0"
     rc-drawer "~4.1.0"
     rc-dropdown "~3.1.2"
-    rc-field-form "~1.8.0"
+    rc-field-form "~1.10.0"
+    rc-image "~3.0.2"
     rc-input-number "~6.0.0"
     rc-mentions "~1.4.0"
-    rc-menu "~8.5.0"
+    rc-menu "~8.5.2"
+    rc-motion "^1.0.0"
     rc-notification "~4.4.0"
-    rc-pagination "~2.4.1"
-    rc-picker "~1.15.1"
+    rc-pagination "~3.0.3"
+    rc-picker "~2.0.6"
     rc-progress "~3.0.0"
     rc-rate "~2.8.2"
     rc-resize-observer "^0.2.3"
-    rc-select "~11.0.10"
+    rc-select "~11.1.0"
     rc-slider "~9.3.0"
     rc-steps "~4.1.0"
     rc-switch "~3.2.0"
-    rc-table "~7.8.0"
-    rc-tabs "~11.5.0"
+    rc-table "~7.9.2"
+    rc-tabs "~11.6.0"
     rc-textarea "~0.3.0"
     rc-tooltip "~4.2.0"
-    rc-tree "~3.8.0"
-    rc-tree-select "~4.1.0"
-    rc-trigger "~4.3.0"
+    rc-tree "~3.9.0"
+    rc-tree-select "~4.1.1"
+    rc-trigger "~4.4.0"
     rc-upload "~3.2.0"
     rc-util "^5.0.1"
     scroll-into-view-if-needed "^2.2.25"
@@ -11866,6 +11895,11 @@ lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -14708,6 +14742,14 @@ rc-collapse@~2.0.0:
     react-is "^16.7.0"
     shallowequal "^1.1.0"
 
+rc-dialog@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-8.1.1.tgz#ce54bd78e940c030b69d3acfc87874536966a27b"
+  integrity sha512-ToyHiMlV94z8LfnmeKoVvu04Pd9+HdwwSHhY2a8IWeYGA5Cjk1WyIZvS+njCsm8rSMM4NqPqFkMZA0N/Iw0NrQ==
+  dependencies:
+    rc-animate "3.x"
+    rc-util "^5.0.1"
+
 rc-dialog@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-8.1.0.tgz#393910963bb05ac19d6d136620bd09622f1d677a"
@@ -14734,14 +14776,25 @@ rc-dropdown@^3.1.0, rc-dropdown@~3.1.2:
     classnames "^2.2.6"
     rc-trigger "^4.0.0"
 
-rc-field-form@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.8.0.tgz#c51312321409727e5a333873311f9c1f5e13e8c2"
-  integrity sha512-WQyC3yBEKIWehNzkRMTBK/Lzdjronov9GsB9C9bgVcfpDqsIQSSBgGFAJMmWUAGs2IrCbgh9RBY0Ste4foHzvg==
+rc-field-form@~1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.10.1.tgz#f6eb76b5f24b58938ebadfc03cdd814c24de7db3"
+  integrity sha512-aosTtNTqLYX2jsG5GyCv7axe+b57XH73T7TmmrX/cmhemhtFjvNE6RkRkmtP9VOJnZg5YGC5HfK172cnJ1Ij7Q==
   dependencies:
     "@babel/runtime" "^7.8.4"
     async-validator "^3.0.3"
     rc-util "^5.0.0"
+
+rc-image@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rc-image/-/rc-image-3.0.2.tgz#5f57cc08a0cfe41a6a56c6c81a094f1f5c5272dc"
+  integrity sha512-kzUQw0EuxjTatIY6ZJXLtwtm9jDPUK6RnQ8HBxWPCZl1trgEbddU9TwxLfyNs030qztD1j/2juRCYKsEiSgAKQ==
+  dependencies:
+    "@ant-design/icons" "^4.2.2"
+    "@babel/runtime" "^7.11.2"
+    classnames "^2.2.6"
+    rc-dialog "^8.1.0"
+    rc-util "^5.0.6"
 
 rc-input-number@~6.0.0:
   version "6.0.0"
@@ -14764,7 +14817,7 @@ rc-mentions@~1.4.0:
     rc-trigger "^4.3.0"
     rc-util "^5.0.1"
 
-rc-menu@^8.0.1, rc-menu@^8.2.1, rc-menu@~8.5.0:
+rc-menu@^8.0.1, rc-menu@^8.2.1:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-8.5.0.tgz#bf1fff9855d5554bf95b84698ca3ff4724c9b0c6"
   integrity sha512-zEf3gKcdEKrI2/GpotOyIuVqrqEEJLLb+bLBTud+5b6Y70xwUH8IZvK6kXdHdqEnJGEZmq5NIy8Ufcr+HOYGxQ==
@@ -14779,6 +14832,31 @@ rc-menu@^8.0.1, rc-menu@^8.2.1, rc-menu@~8.5.0:
     resize-observer-polyfill "^1.5.0"
     shallowequal "^1.1.0"
 
+rc-menu@~8.5.2:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-8.5.3.tgz#ac427c50929a2bc1a5fb1ce57e187033d3f09361"
+  integrity sha512-OLdN+jwhabgyRZDvWYjYpO7RP7wLybhNuAulgGqx1oUPBJrtgVlG/X4HtPb7nypRx/n+eicj6H8CtbCs0L4m/Q==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "2.x"
+    mini-store "^3.0.1"
+    omit.js "^2.0.0"
+    rc-motion "^1.0.1"
+    rc-trigger "^4.4.0"
+    rc-util "^5.0.1"
+    resize-observer-polyfill "^1.5.0"
+    shallowequal "^1.1.0"
+
+rc-motion@^1.0.0, rc-motion@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-1.0.2.tgz#b8aec288642298d74ddc9ac1773e1b600aaa1c25"
+  integrity sha512-FDmC9ZdzsXerlTZ+YLu+l5erjkMU98s85SFHdQac+pMy6zQ10RuON6Ntv3ZwP0+qY/YlIsK+0uMXIWOJ9LaLIg==
+  dependencies:
+    "@babel/runtime" "^7.11.1"
+    classnames "^2.2.1"
+    raf "^3.4.1"
+    rc-util "^5.0.6"
+
 rc-notification@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-4.4.0.tgz#192d082cd6e2995705f43c6929162631c71e3db1"
@@ -14789,18 +14867,18 @@ rc-notification@~4.4.0:
     rc-animate "3.x"
     rc-util "^5.0.1"
 
-rc-pagination@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-2.4.2.tgz#519aa52f254a1ab90829109f6930bd3b766419f5"
-  integrity sha512-fgLOU4x2LuUuBTLsY27rEgkWOQ5riJ3LCkB0/Jt1lfQvwMyw55bU6OtfjmIkyT/PRKQLcpCmLXSdV+mAsvFdYg==
+rc-pagination@~3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-3.0.3.tgz#48ce55822e153ed9f9b8961fcb3bb8ecab8df37c"
+  integrity sha512-xm6LsiSOAWlxferiL5e0jcun1B9vbvYzcIkqpYZR7YvC5ZrcU9KKihb+DZe3DY+oUc49xhX2qGS4D66ITHqekQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
 
-rc-picker@~1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-1.15.1.tgz#b0d647f3827468f844bc95c9255436ea787d26ce"
-  integrity sha512-YW6I91R1rMDTKpWY2yYjUk3mX4ttk7l8dx5fuojGBj86TGPj0R5vh+wFoRNzOeA4qAHcRzGWGPP60HFnoxL1TA==
+rc-picker@~2.0.6:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-2.0.8.tgz#cfc3486e853272cd2404eebe776b9bee181f23cf"
+  integrity sha512-rdtF04DNzIR0n2+0J0T74oiFxg0Jr7mhOP56NXrLU4EPKD5x53EmCcm+oxm5NhUERJz6pBuIuBHffjneDypoxg==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
@@ -14809,7 +14887,6 @@ rc-picker@~1.15.1:
     moment "^2.24.0"
     rc-trigger "^4.0.0"
     rc-util "^5.0.1"
-    react "^16.0.0"
     shallowequal "^1.1.0"
 
 rc-progress@~3.0.0:
@@ -14838,30 +14915,17 @@ rc-resize-observer@^0.2.0, rc-resize-observer@^0.2.1, rc-resize-observer@^0.2.3:
     rc-util "^5.0.0"
     resize-observer-polyfill "^1.5.1"
 
-rc-select@^11.0.4:
-  version "11.0.10"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-11.0.10.tgz#c3977233e5b83801ba63a4727a946c8808b9eeaa"
-  integrity sha512-6id8KhwapDrYcum1CS/ENwgS2nwoiikNr182Rux4F99SuQAKOVhHyAIuV1GoLlftLemV35Pl+WOS2LUDHLi8hA==
+rc-select@^11.1.1, rc-select@~11.1.0:
+  version "11.1.6"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-11.1.6.tgz#39bb7c685dc61f65d5d73554df58979587c45b16"
+  integrity sha512-X5kCwUGIe3uF5las4bFiXzD3F/hxs5Nz+wpf3xG6esg352ThP5kBROmMOeb91Yo2nOPZyiH6jnLsZLecnyWbZQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
-    rc-animate "^3.0.0"
+    rc-motion "^1.0.1"
     rc-trigger "^4.3.0"
     rc-util "^5.0.1"
-    rc-virtual-list "^1.1.2"
-    warning "^4.0.3"
-
-rc-select@~11.0.10:
-  version "11.0.11"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-11.0.11.tgz#97d0d88aed3f40563b0f0eee6c7cc88dfff0a98d"
-  integrity sha512-7xW5U6fyjr5j6CG3/Bl0ceUKzpNDOctJiIcK1eyLYq7Va+KFB0kNFMYULHPI41m/TJJIKDCW3N08K3rd2Z2SIA==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-animate "^3.0.0"
-    rc-trigger "^4.3.0"
-    rc-util "^5.0.1"
-    rc-virtual-list "^1.1.2"
+    rc-virtual-list "^3.0.3"
     warning "^4.0.3"
 
 rc-slider@~9.3.0:
@@ -14893,22 +14957,22 @@ rc-switch@~3.2.0:
     classnames "^2.2.1"
     rc-util "^5.0.1"
 
-rc-table@~7.8.0:
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-7.8.4.tgz#493e6e8ccd9f078a073f0f7cf46bbb02c55f74d7"
-  integrity sha512-+8JPFD4oGy/4/VdXsPE/12oEkopiZoIi4cS6DJGzjf2CjhrM7KevUOjrs0MhFlXZp/Pnb8qSKoVdVHN1JYtL7Q==
+rc-table@~7.9.2:
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-7.9.5.tgz#246b29fac7149b6c1f09ea889a84c887f2f965b8"
+  integrity sha512-MENLD5uMBrVH4x02evuXLTEy4m5E5NN88qBLJxvV9/140QjjRSUSqN0GRDC+q52pm4FEIdgaMWiiM1cISGze/w==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.5"
     raf "^3.4.1"
     rc-resize-observer "^0.2.0"
-    rc-util "^5.0.0"
+    rc-util "^5.0.4"
     shallowequal "^1.1.0"
 
-rc-tabs@~11.5.0:
-  version "11.5.4"
-  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-11.5.4.tgz#1fc3469605fc28d47fb64c582ec83f97113dbd5a"
-  integrity sha512-J7duEePQbF9G1VESfEDH05GYIa/5uS/tmMoTy4IXfohql/b/2mjR3YzKahxi0x/wQJovgBRrdfNQA5Ph99lwIw==
+rc-tabs@~11.6.0:
+  version "11.6.1"
+  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-11.6.1.tgz#a31a277b12f807cc7bdc31476c0d21124ce93e14"
+  integrity sha512-fJZUOmwBo2E4WTbucCSZO/N1ZK+d9K/QchgDeycTIqxl5D/xtX0Dw/vC2DFi140OFjAy2JL7H0EmsSeOFfCgzw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -14936,18 +15000,18 @@ rc-tooltip@^4.0.0, rc-tooltip@~4.2.0:
   dependencies:
     rc-trigger "^4.2.1"
 
-rc-tree-select@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-4.1.0.tgz#eb27f4bd8c36c0f89653f82410fa423f67597b4f"
-  integrity sha512-nChGXqJ81Lotgam1W1vUzORQZgL1s9B6D7p661edfar2FYmoAOCqXLg+AZrN1t6+HlCORL0AkVnSalSiZIJIjg==
+rc-tree-select@~4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-4.1.1.tgz#2d3c61f2449de72839eddf94ab876d3f6567692f"
+  integrity sha512-pawxt/W1chLpjtAEQe8mXI9C9DYNMGS/BR6eBmOY8cJDK6OWSa6M88S6F0jXc+A10D/CLfHAfF1ZIj7VGse+5Q==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
-    rc-select "^11.0.4"
+    rc-select "^11.1.1"
     rc-tree "^3.8.0"
     rc-util "^5.0.5"
 
-rc-tree@^3.8.0, rc-tree@~3.8.0:
+rc-tree@^3.8.0:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-3.8.2.tgz#e22c0a4e11726ee676a83227099f16634c5feb7f"
   integrity sha512-4RLJhiGpt/Wvj7O9mm0IX+Bv9PrcdKL3j2BIpGLQX3Xd+n4p5PcqL46mRRdGoWvvTJcZ6ZEiZDg46nSyTYLdHA==
@@ -14958,7 +15022,18 @@ rc-tree@^3.8.0, rc-tree@~3.8.0:
     rc-util "^5.0.0"
     rc-virtual-list "^1.1.0"
 
-rc-trigger@^4.0.0, rc-trigger@^4.2.0, rc-trigger@^4.2.1, rc-trigger@^4.3.0, rc-trigger@~4.3.0:
+rc-tree@~3.9.0:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-3.9.3.tgz#5f52b7b805815996d15e5446e4e367a547470ea9"
+  integrity sha512-oztfPQj7JFSoCTzzDpGTZ9sVaPvYXN8jkbZMtjSFaAGTOsLcLAIV3Ac+oUVXJg3fCM+5tj6SaW+KVxUZCKDV7A==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "2.x"
+    rc-motion "^1.0.0"
+    rc-util "^5.0.0"
+    rc-virtual-list "^3.0.1"
+
+rc-trigger@^4.0.0, rc-trigger@^4.2.0, rc-trigger@^4.2.1, rc-trigger@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-4.3.0.tgz#94ea1851d123359716d1dc3030083c015a92ecfb"
   integrity sha512-jnGNzosXmDdivMBjPCYe/AfOXTpJU2/xQ9XukgoXDQEoZq/9lcI1r7eUIfq70WlWpLxlUEqQktiV3hwyy6Nw9g==
@@ -14968,6 +15043,18 @@ rc-trigger@^4.0.0, rc-trigger@^4.2.0, rc-trigger@^4.2.1, rc-trigger@^4.3.0, rc-t
     raf "^3.4.1"
     rc-align "^4.0.0"
     rc-animate "^3.0.0"
+    rc-util "^5.0.1"
+
+rc-trigger@^4.4.0, rc-trigger@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-4.4.0.tgz#52be45c7b40327b297ebacff84d69ce9285606bc"
+  integrity sha512-09562wc5I1JUbCdWohcFYJeLTpjKjEqH+0lY7plDtyI9yFXRngrvmqsrSJyT6Nat+C35ymD7fhwCCPq3cfUI4g==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "^2.2.6"
+    raf "^3.4.1"
+    rc-align "^4.0.0"
+    rc-motion "^1.0.0"
     rc-util "^5.0.1"
 
 rc-upload@~3.2.0:
@@ -14993,6 +15080,14 @@ rc-util@^5.0.1:
     react-is "^16.12.0"
     shallowequal "^1.1.0"
 
+rc-util@^5.0.4, rc-util@^5.0.6, rc-util@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.0.7.tgz#125c3a2fd917803afbb685f9eadc789b085dc813"
+  integrity sha512-nr98b5aMqqvIqxm16nF+zC3K3f81r+HsflT5E9Encr5itRwV7Vo/5GjJMNds/WiFV33rilq7vzb3xeAbCycmwg==
+  dependencies:
+    react-is "^16.12.0"
+    shallowequal "^1.1.0"
+
 rc-util@^5.0.5:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.0.6.tgz#2b828bc87a818a66384b813f76a561ad4609e9b0"
@@ -15001,7 +15096,7 @@ rc-util@^5.0.5:
     react-is "^16.12.0"
     shallowequal "^1.1.0"
 
-rc-virtual-list@^1.1.0, rc-virtual-list@^1.1.2:
+rc-virtual-list@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/rc-virtual-list/-/rc-virtual-list-1.1.5.tgz#6edf7222830c7dd732f62698c8468b7f08ac8dec"
   integrity sha512-roZ6HE5MNKaiop+Ic7jZS7xlMnXBLp0XBElsMbE4eEL3GnnnJAet2iXoT5wjKcKMXEVyVCD0L4yQozmH7+Kgxg==
@@ -15009,6 +15104,15 @@ rc-virtual-list@^1.1.0, rc-virtual-list@^1.1.2:
     classnames "^2.2.6"
     raf "^3.4.1"
     rc-util "^5.0.0"
+
+rc-virtual-list@^3.0.1, rc-virtual-list@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/rc-virtual-list/-/rc-virtual-list-3.0.7.tgz#f911f00fc93b0433a8ff54630a059b892b60d572"
+  integrity sha512-uiv3QVJVvM9FO+/F6FBO7jN8QYVKSXFVwHPi7kvuhieDHIg0jjUKGssn5oJE+rJ8riKglML1QjTCzHF3wxM3Ng==
+  dependencies:
+    classnames "^2.2.6"
+    rc-resize-observer "^0.2.3"
+    rc-util "^5.0.7"
 
 rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
@@ -15480,7 +15584,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.0.0, react@^16.13.1, react@^16.8.3:
+react@^16.13.1, react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
- [x] Fix "Function components cannot be given refs ... " warnings
- [x] Update to latest antd
- [x] Fix `Form` issues after update to latest `antd` (Unfortunately `Form<FormValue>` does not work with `styled(Form)`)

```
No overload matches this call.
  Overload 1 of 2, '(props: Pick<Pick<FormProps<unknown> & { children?: ReactNode; } & { ref?: ((instance: FormInstance<unknown> | null) => void) | RefObject<FormInstance<unknown>> | null | undefined; }, "form" | ... 282 more ... | "hideRequiredMark"> & Partial<...>, "form" | ... 282 more ... | "hideRequiredMark"> & { ...; } & { ...; }): ReactElement<...>', gave the following error.
    Type '(data: Store) => void' is not assignable to type '(values: unknown) => void'.
      Types of parameters 'data' and 'values' are incompatible.
        Type 'unknown' is not assignable to type 'Store'.
  Overload 2 of 2, '(props: StyledComponentPropsWithAs<Form, any, {}, never>): ReactElement<StyledComponentPropsWithAs<Form, any, {}, never>, string | ... 1 more ... | (new (props: any) => Component<...>)>', gave the following error.
    Type '(data: Store) => void' is not assignable to type '(values: unknown) => void'.
```

- [x] Remove unused styles

Fix #354 