### PR TITLE
Support chaosnet in settings

### DIFF
--- a/src/renderer/components/uielements/label/label.style.ts
+++ b/src/renderer/components/uielements/label/label.style.ts
@@ -10,7 +10,7 @@ export type Props = {
   weight?: string
   textTransform?: TextTransform
   nowrap?: boolean
-  onClick?: () => void
+  onClick?: (_: React.MouseEvent<HTMLElement>) => void
 }
 
 const fontSettings: FontSettings = {

--- a/src/renderer/components/uielements/label/label.tsx
+++ b/src/renderer/components/uielements/label/label.tsx
@@ -7,7 +7,7 @@ export type ComponentProps = {
   children?: React.ReactNode
   loading?: boolean
   nowrap?: boolean
-  onClick?: () => void
+  onClick?: (_: React.MouseEvent<HTMLElement>) => void
   style?: React.CSSProperties
 }
 

--- a/src/renderer/components/wallet/AssetDetails.style.tsx
+++ b/src/renderer/components/wallet/AssetDetails.style.tsx
@@ -46,3 +46,14 @@ export const TableHeadline = styled(Headline)`
   width: 100%;
   text-align: ${({ isDesktop }: TableHeadlineProps) => (isDesktop ? 'left' : 'center')};
 `
+
+export const ActionMenu = styled(A.Menu)`
+  background-color: ${palette('background', 1)};
+`
+
+export const ActionMenuItem = styled(A.Menu.Item)`
+  background-color: ${palette('background', 1)};
+  &:hover {
+    background-color: ${palette('background', 2)};
+  }
+`

--- a/src/renderer/components/wallet/AssetDetails.tsx
+++ b/src/renderer/components/wallet/AssetDetails.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import { Address } from '@thorchain/asgardex-binance'
 import { Asset, assetToString } from '@thorchain/asgardex-util'
-import { Row, Col, Grid, Menu, Dropdown } from 'antd'
+import { Row, Col, Grid, Dropdown } from 'antd'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
@@ -14,7 +14,6 @@ import { TxsRD, BalancesRD, SendAction, isSendAction } from '../../services/bina
 import AssetInfo from '../uielements/assets/AssetInfo'
 import BackLink from '../uielements/backLink'
 import Button, { RefreshButton } from '../uielements/button'
-import Label from '../uielements/label'
 import * as Styled from './AssetDetails.style'
 import TransactionsTable from './TransactionsTable'
 
@@ -128,17 +127,15 @@ const AssetDetails: React.FC<Props> = (props: Props): JSX.Element => {
 
   const changeActionMenu = useMemo(() => {
     return (
-      <Menu onClick={changeActionMenuClickHandler}>
+      <Styled.ActionMenu onClick={changeActionMenuClickHandler}>
         {menuItems.map(({ key, label }) => (
-          <Menu.Item key={key}>
+          <Styled.ActionMenuItem key={key}>
             <Row justify="center">
-              <Label textTransform="uppercase" align="center">
-                {label}
-              </Label>
+              <Styled.Label>{label}</Styled.Label>
             </Row>
-          </Menu.Item>
+          </Styled.ActionMenuItem>
         ))}
-      </Menu>
+      </Styled.ActionMenu>
     )
   }, [menuItems])
 

--- a/src/renderer/components/wallet/Settings.stories.tsx
+++ b/src/renderer/components/wallet/Settings.stories.tsx
@@ -4,13 +4,14 @@ import { storiesOf } from '@storybook/react'
 import { some } from 'fp-ts/lib/Option'
 
 import { WALLET_ADDRESS_TESTNET } from '../../../shared/mock/address'
+import { Network } from '../../services/app/types'
 import Settings from './Settings'
 
 storiesOf('Wallet/Settings', module).add('default', () => {
   return (
     <Settings
-      network={'testnet'}
-      toggleNetwork={() => console.log('toggle network')}
+      selectedNetwork={'testnet'}
+      changeNetwork={(n: Network) => console.log('change network ', n)}
       clientUrl={some(WALLET_ADDRESS_TESTNET)}
       lockWallet={() => console.log('lock')}
       removeKeystore={() => console.log('removeKeystore')}

--- a/src/renderer/components/wallet/Settings.style.tsx
+++ b/src/renderer/components/wallet/Settings.style.tsx
@@ -1,11 +1,11 @@
-import { Divider, Row, Col, Card, List } from 'antd'
+import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
-import Button from '../uielements/button'
-import Label from '../uielements/label'
+import UIButton from '../uielements/button'
+import UILabel from '../uielements/label'
 
-export const StyledTitleWrapper = styled.div`
+export const TitleWrapper = styled.div`
   margin: 0px -8px;
   display: flex;
   justify-content: center;
@@ -14,7 +14,7 @@ export const StyledTitleWrapper = styled.div`
   min-height: 70px;
 `
 
-export const StyledTitle = styled(Label)`
+export const Title = styled(UILabel)`
   color: ${palette('text', 1)};
   text-transform: uppercase;
   font-family: 'MainFontRegular';
@@ -23,12 +23,12 @@ export const StyledTitle = styled(Label)`
   line-height: 22px;
 `
 
-export const StyledDivider = styled(Divider)`
+export const Divider = styled(A.Divider)`
   margin: 0;
   border-top: 1px solid ${palette('gray', 0)};
 `
 
-export const StyledSubtitle = styled(Label)`
+export const Subtitle = styled(UILabel)`
   margin: 10px 0px;
   color: ${palette('text', 0)};
   text-transform: uppercase;
@@ -37,7 +37,7 @@ export const StyledSubtitle = styled(Label)`
   font-size: 18px;
 `
 
-export const StyledRow = styled(Row)`
+export const Row = styled(A.Row)`
   padding: 10px 30px;
   background-color: ${palette('background', 1)};
 
@@ -46,17 +46,17 @@ export const StyledRow = styled(Row)`
   }
 `
 
-export const StyledWalletCol = styled(Col)`
+export const WalletCol = styled(A.Col)`
   width: 100%;
 `
 
-export const StyledCard = styled(Card)`
+export const Card = styled(A.Card)`
   border-radius: 5px;
   background-color: ${palette('background', 1)};
   border: 1px solid ${palette('gray', 0)};
 `
 
-export const StyledOptionCard = styled(Card)`
+export const OptionCard = styled(A.Card)`
   .ant-card-body {
     padding: 12px;
     display: flex;
@@ -67,7 +67,7 @@ export const StyledOptionCard = styled(Card)`
   }
 `
 
-export const StyledOptionLabel = styled(Label)`
+export const OptionLabel = styled(UILabel)`
   padding: 0;
   display: flex;
   align-items: center;
@@ -78,7 +78,7 @@ export const StyledOptionLabel = styled(Label)`
   min-height: 38px;
 `
 
-export const StyledButton = styled(Button)`
+export const Button = styled(UIButton)`
   font-family: 'MainFontRegular';
   text-transform: uppercase;
 
@@ -87,7 +87,7 @@ export const StyledButton = styled(Button)`
   }
 `
 
-export const StyledPlaceholder = styled(Label)`
+export const Placeholder = styled(UILabel)`
   display: block;
   padding: 0px;
   color: ${palette('text', 2)};
@@ -96,7 +96,7 @@ export const StyledPlaceholder = styled(Label)`
   text-transform: uppercase;
 `
 
-export const StyledClientLabel = styled(Label)`
+export const ClientLabel = styled(UILabel)`
   display: block;
   padding-top: 0px;
   color: ${palette('text', 1)};
@@ -105,12 +105,12 @@ export const StyledClientLabel = styled(Label)`
   text-transform: uppercase;
 `
 
-export const StyledClientButton = styled(Label)`
+export const ClientButton = styled(UILabel)`
   font-family: 'MainFontRegular';
   text-transform: uppercase;
 `
 
-export const StyledAccountCard = styled(Card)`
+export const AccountCard = styled(A.Card)`
   border: 1px solid ${palette('gray', 0)};
 
   .ant-card-body {
@@ -123,7 +123,7 @@ export const StyledAccountCard = styled(Card)`
   }
 `
 
-export const StyledListItem = styled(List.Item)`
+export const ListItem = styled(A.List.Item)`
   padding: 20px 20px 0;
   flex-direction: column;
   align-items: start;
@@ -135,7 +135,7 @@ export const StyledListItem = styled(List.Item)`
   }
 `
 
-export const StyledChainName = styled(Label)`
+export const ChainName = styled(UILabel)`
   padding: 0px;
   text-transform: uppercase;
   font-weight: normal;
@@ -144,13 +144,13 @@ export const StyledChainName = styled(Label)`
   letter-spacing: 2px;
 `
 
-export const StyledChainContent = styled.div`
+export const ChainContent = styled.div`
   margin-left: 30px;
   margin-top: 10px;
   width: 100%;
 `
 
-export const StyledAccountPlaceholder = styled(Label)`
+export const AccountPlaceholder = styled(UILabel)`
   display: block;
   padding: 0px;
   color: ${palette('text', 2)};
@@ -159,14 +159,14 @@ export const StyledAccountPlaceholder = styled(Label)`
   text-transform: uppercase;
 `
 
-export const StyledAccountContent = styled(Label)`
+export const AccountContent = styled(UILabel)`
   display: flex;
   align-items: center;
   padding: 0px;
   color: ${palette('text', 1)};
 `
 
-export const StyledAccountAddress = styled(Label)`
+export const AccountAddress = styled(UILabel)`
   display: inline-block;
   width: calc(70%);
   white-space: nowrap;
@@ -177,7 +177,7 @@ export const StyledAccountAddress = styled(Label)`
   text-transform: uppercase;
 `
 
-export const StyledDeviceText = styled(Label)`
+export const DeviceText = styled(UILabel)`
   padding: 0 0 10px;
   text-transform: uppercase;
   font-weight: 600;
@@ -187,4 +187,40 @@ export const StyledDeviceText = styled(Label)`
   span {
     margin-right: 10px;
   }
+`
+
+export const NetworkMenu = styled(A.Menu)`
+  background-color: ${palette('background', 1)};
+`
+
+export const ActionMenuItem = styled(A.Menu.Item)`
+  background-color: ${palette('background', 1)};
+  &:hover {
+    background-color: ${palette('background', 2)};
+  }
+`
+
+export const NetworkRow = styled(A.Row).attrs({
+  alignItems: 'center'
+})`
+  width: '150px';
+`
+
+export const NetworkMenuItem = styled(A.Menu.Item)`
+  color: ${palette('text', 1)};
+
+  &:hover {
+    background-color: ${palette('background', 2)};
+  }
+`
+
+export const NetworkLabel = styled(UILabel).attrs({
+  textTransform: 'uppercase',
+  size: 'big'
+})`
+  cursor: pointer;
+`
+
+export const NetworkTitle = styled(NetworkLabel)`
+  padding-right: 10px;
 `

--- a/src/renderer/components/wallet/Settings.style.tsx
+++ b/src/renderer/components/wallet/Settings.style.tsx
@@ -200,12 +200,6 @@ export const ActionMenuItem = styled(A.Menu.Item)`
   }
 `
 
-export const NetworkRow = styled(A.Row).attrs({
-  alignItems: 'center'
-})`
-  width: '150px';
-`
-
 export const NetworkMenuItem = styled(A.Menu.Item)`
   color: ${palette('text', 1)};
 

--- a/src/renderer/components/wallet/Settings.tsx
+++ b/src/renderer/components/wallet/Settings.tsx
@@ -165,7 +165,7 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
                 <Styled.ClientLabel>v{apiVersion}</Styled.ClientLabel>
                 <Styled.Placeholder>{intl.formatMessage({ id: 'common.network' })}</Styled.Placeholder>
                 <Dropdown overlay={networkMenu} trigger={['click']}>
-                  <Row align="middle" style={{ width: '130px' }} onClick={(e) => e.preventDefault()}>
+                  <Row align="middle" style={{ display: 'inline-flex' }} onClick={(e) => e.preventDefault()}>
                     <Styled.NetworkTitle>{selectedNetwork}</Styled.NetworkTitle>
                     <DownIcon />
                   </Row>

--- a/src/renderer/components/wallet/Settings.tsx
+++ b/src/renderer/components/wallet/Settings.tsx
@@ -10,6 +10,7 @@ import { useIntl } from 'react-intl'
 import { ReactComponent as DownIcon } from '../../assets/svg/icon-down.svg'
 import { ReactComponent as UnlockOutlined } from '../../assets/svg/icon-unlock-warning.svg'
 import { Network } from '../../services/app/types'
+import { AVAILABLE_NETWORKS } from '../../services/const'
 import { UserAccountType } from '../../types/wallet'
 import * as Styled from './Settings.style'
 
@@ -78,7 +79,6 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
 
   const changeNetworkHandler: MenuProps['onClick'] = useCallback(
     (param) => {
-      console.log('changeNetworkHandler:', param)
       const asset = param.key as Network
       changeNetwork(asset)
     },
@@ -88,7 +88,7 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
   const networkMenu = useMemo(
     () => (
       <Styled.NetworkMenu onClick={changeNetworkHandler}>
-        {(['testnet', 'chaosnet', 'mainnet'] as Network[]).map((network) => (
+        {AVAILABLE_NETWORKS.map((network) => (
           <Styled.NetworkMenuItem key={network}>
             <Styled.NetworkLabel>{network}</Styled.NetworkLabel>
           </Styled.NetworkMenuItem>

--- a/src/renderer/components/wallet/Settings.tsx
+++ b/src/renderer/components/wallet/Settings.tsx
@@ -1,41 +1,22 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { StopOutlined } from '@ant-design/icons'
-import { Row, Col, Button, List } from 'antd'
+import { Row, Col, Button, List, Dropdown } from 'antd'
+import { MenuProps } from 'antd/lib/menu'
 import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/pipeable'
 import { useIntl } from 'react-intl'
 
+import { ReactComponent as DownIcon } from '../../assets/svg/icon-down.svg'
 import { ReactComponent as UnlockOutlined } from '../../assets/svg/icon-unlock-warning.svg'
 import { Network } from '../../services/app/types'
 import { UserAccountType } from '../../types/wallet'
-import {
-  StyledTitleWrapper,
-  StyledRow,
-  StyledWalletCol,
-  StyledTitle,
-  StyledDivider,
-  StyledSubtitle,
-  StyledCard,
-  StyledOptionCard,
-  StyledOptionLabel,
-  StyledButton,
-  StyledPlaceholder,
-  StyledClientLabel,
-  StyledClientButton,
-  StyledAccountCard,
-  StyledListItem,
-  StyledChainName,
-  StyledChainContent,
-  StyledAccountPlaceholder,
-  StyledAccountContent,
-  StyledAccountAddress
-} from './Settings.style'
+import * as Styled from './Settings.style'
 
 type Props = {
-  network: Network
+  selectedNetwork: Network
   apiVersion?: string
-  toggleNetwork?: () => void
+  changeNetwork: (network: Network) => void
   clientUrl: O.Option<string>
   userAccounts?: O.Option<UserAccountType[]>
   lockWallet?: () => void
@@ -47,11 +28,11 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
   const {
     apiVersion = '',
     clientUrl,
-    network,
+    selectedNetwork,
     userAccounts = O.none,
-    toggleNetwork = () => {},
     lockWallet = () => {},
-    removeKeystore = () => {}
+    removeKeystore = () => {},
+    changeNetwork
   } = props
 
   const removeWallet = useCallback(() => {
@@ -64,30 +45,30 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
         userAccounts,
         O.map((accounts) => (
           <Col key={'accounts'} sm={{ span: 24 }} md={{ span: 12 }}>
-            <StyledSubtitle>{intl.formatMessage({ id: 'setting.account.management' })}</StyledSubtitle>
-            <StyledAccountCard>
+            <Styled.Subtitle>{intl.formatMessage({ id: 'setting.account.management' })}</Styled.Subtitle>
+            <Styled.AccountCard>
               <List
                 dataSource={accounts}
                 renderItem={(item, i: number) => (
-                  <StyledListItem key={i}>
-                    <StyledChainName>{item.chainName}</StyledChainName>
+                  <Styled.ListItem key={i}>
+                    <Styled.ChainName>{item.chainName}</Styled.ChainName>
                     {item.accounts.map((acc, j) => (
-                      <StyledChainContent key={j}>
-                        <StyledAccountPlaceholder>{acc.name}</StyledAccountPlaceholder>
-                        <StyledAccountContent>
-                          <StyledAccountAddress>{acc.address}</StyledAccountAddress>
+                      <Styled.ChainContent key={j}>
+                        <Styled.AccountPlaceholder>{acc.name}</Styled.AccountPlaceholder>
+                        <Styled.AccountContent>
+                          <Styled.AccountAddress>{acc.address}</Styled.AccountAddress>
                           {acc.type === 'external' && (
                             <Button type="link" danger>
                               <StopOutlined />
                             </Button>
                           )}
-                        </StyledAccountContent>
-                      </StyledChainContent>
+                        </Styled.AccountContent>
+                      </Styled.ChainContent>
                     ))}
-                  </StyledListItem>
+                  </Styled.ListItem>
                 )}
               />
-            </StyledAccountCard>
+            </Styled.AccountCard>
           </Col>
         )),
         O.getOrElse(() => <></>)
@@ -95,80 +76,106 @@ const Settings: React.FC<Props> = (props: Props): JSX.Element => {
     [intl, userAccounts]
   )
 
+  const changeNetworkHandler: MenuProps['onClick'] = useCallback(
+    (param) => {
+      console.log('changeNetworkHandler:', param)
+      const asset = param.key as Network
+      changeNetwork(asset)
+    },
+    [changeNetwork]
+  )
+
+  const networkMenu = useMemo(
+    () => (
+      <Styled.NetworkMenu onClick={changeNetworkHandler}>
+        {(['testnet', 'chaosnet', 'mainnet'] as Network[]).map((network) => (
+          <Styled.NetworkMenuItem key={network}>
+            <Styled.NetworkLabel>{network}</Styled.NetworkLabel>
+          </Styled.NetworkMenuItem>
+        ))}
+      </Styled.NetworkMenu>
+    ),
+    [changeNetworkHandler]
+  )
+
   return (
     <>
       <Row>
         <Col span={24}>
-          <StyledTitleWrapper>
-            <StyledTitle>{intl.formatMessage({ id: 'setting.title' })}</StyledTitle>
-          </StyledTitleWrapper>
-          <StyledDivider />
+          <Styled.TitleWrapper>
+            <Styled.Title>{intl.formatMessage({ id: 'setting.title' })}</Styled.Title>
+          </Styled.TitleWrapper>
+          <Styled.Divider />
         </Col>
       </Row>
-      <StyledRow gutter={[16, 16]}>
+      <Styled.Row gutter={[16, 16]}>
         <Col sm={{ span: 24 }} md={{ span: 12 }}>
-          <StyledSubtitle>{intl.formatMessage({ id: 'setting.wallet.management' })}</StyledSubtitle>
-          <StyledCard>
+          <Styled.Subtitle>{intl.formatMessage({ id: 'setting.wallet.management' })}</Styled.Subtitle>
+          <Styled.Card>
             <Row>
-              <StyledWalletCol sm={{ span: 24 }} md={{ span: 12 }}>
-                <StyledOptionCard bordered={false}>
-                  <StyledOptionLabel color="primary" size="big">
+              <Styled.WalletCol sm={{ span: 24 }} md={{ span: 12 }}>
+                <Styled.OptionCard bordered={false}>
+                  <Styled.OptionLabel color="primary" size="big">
                     {intl.formatMessage({ id: 'setting.export' })}
-                  </StyledOptionLabel>
-                </StyledOptionCard>
-              </StyledWalletCol>
-              <StyledWalletCol sm={{ span: 24 }} md={{ span: 12 }}>
-                <StyledOptionCard bordered={false}>
-                  <StyledOptionLabel color="warning" size="big" onClick={lockWallet}>
+                  </Styled.OptionLabel>
+                </Styled.OptionCard>
+              </Styled.WalletCol>
+              <Styled.WalletCol sm={{ span: 24 }} md={{ span: 12 }}>
+                <Styled.OptionCard bordered={false}>
+                  <Styled.OptionLabel color="warning" size="big" onClick={lockWallet}>
                     {intl.formatMessage({ id: 'setting.lock' })} <UnlockOutlined />
-                  </StyledOptionLabel>
-                </StyledOptionCard>
-              </StyledWalletCol>
-              <StyledWalletCol sm={{ span: 24 }} md={{ span: 12 }}>
-                <StyledOptionCard bordered={false}>
-                  <StyledButton sizevalue="xnormal" color="primary" typevalue="outline" round="true" disabled>
+                  </Styled.OptionLabel>
+                </Styled.OptionCard>
+              </Styled.WalletCol>
+              <Styled.WalletCol sm={{ span: 24 }} md={{ span: 12 }}>
+                <Styled.OptionCard bordered={false}>
+                  <Styled.Button sizevalue="xnormal" color="primary" typevalue="outline" round="true" disabled>
                     {intl.formatMessage({ id: 'setting.view.phrase' })}
-                  </StyledButton>
-                </StyledOptionCard>
-              </StyledWalletCol>
-              <StyledWalletCol sm={{ span: 24 }} md={{ span: 12 }}>
-                <StyledOptionCard bordered={false}>
-                  <StyledButton
+                  </Styled.Button>
+                </Styled.OptionCard>
+              </Styled.WalletCol>
+              <Styled.WalletCol sm={{ span: 24 }} md={{ span: 12 }}>
+                <Styled.OptionCard bordered={false}>
+                  <Styled.Button
                     sizevalue="xnormal"
                     color="error"
                     typevalue="outline"
                     round="true"
                     onClick={removeWallet}>
                     {intl.formatMessage({ id: 'wallet.action.remove' })}
-                  </StyledButton>
-                </StyledOptionCard>
-              </StyledWalletCol>
+                  </Styled.Button>
+                </Styled.OptionCard>
+              </Styled.WalletCol>
             </Row>
-          </StyledCard>
-          <StyledSubtitle>{intl.formatMessage({ id: 'setting.client' })}</StyledSubtitle>
-          <StyledCard>
+          </Styled.Card>
+          <Styled.Subtitle>{intl.formatMessage({ id: 'setting.client' })}</Styled.Subtitle>
+          <Styled.Card>
             <Row>
               <Col span={24}>
-                <StyledPlaceholder>{intl.formatMessage({ id: 'setting.midgard' })}</StyledPlaceholder>
+                <Styled.Placeholder>{intl.formatMessage({ id: 'setting.midgard' })}</Styled.Placeholder>
 
-                <StyledClientLabel>
+                <Styled.ClientLabel>
                   {pipe(
                     clientUrl,
                     O.getOrElse(() => intl.formatMessage({ id: 'setting.notconnected' }))
                   )}
-                </StyledClientLabel>
+                </Styled.ClientLabel>
 
-                <StyledPlaceholder>{intl.formatMessage({ id: 'setting.version' })}</StyledPlaceholder>
-                <StyledClientLabel>v{apiVersion}</StyledClientLabel>
-                <StyledClientButton color="warning" size="big" onClick={toggleNetwork}>
-                  Change to {network === 'mainnet' ? 'testnet' : 'mainnet'}
-                </StyledClientButton>
+                <Styled.Placeholder>{intl.formatMessage({ id: 'setting.version' })}</Styled.Placeholder>
+                <Styled.ClientLabel>v{apiVersion}</Styled.ClientLabel>
+                <Styled.Placeholder>{intl.formatMessage({ id: 'common.network' })}</Styled.Placeholder>
+                <Dropdown overlay={networkMenu} trigger={['click']}>
+                  <Row align="middle" style={{ width: '130px' }} onClick={(e) => e.preventDefault()}>
+                    <Styled.NetworkTitle>{selectedNetwork}</Styled.NetworkTitle>
+                    <DownIcon />
+                  </Row>
+                </Dropdown>
               </Col>
             </Row>
-          </StyledCard>
+          </Styled.Card>
         </Col>
         {accounts}
-      </StyledRow>
+      </Styled.Row>
     </>
   )
 }

--- a/src/renderer/contexts/AppContext.tsx
+++ b/src/renderer/contexts/AppContext.tsx
@@ -1,16 +1,16 @@
 import React, { createContext, useContext } from 'react'
 
-import { onlineStatus$, network$, toggleNetwork } from '../services/app/service'
+import { onlineStatus$, network$, changeNetwork } from '../services/app/service'
 
 type AppContextValue = {
   onlineStatus$: typeof onlineStatus$
   network$: typeof network$
-  toggleNetwork: typeof toggleNetwork
+  changeNetwork: typeof changeNetwork
 }
 const initialContext: AppContextValue = {
   onlineStatus$,
   network$,
-  toggleNetwork
+  changeNetwork
 }
 
 const AppContext = createContext<AppContextValue | null>(null)

--- a/src/renderer/services/app/service.test.ts
+++ b/src/renderer/services/app/service.test.ts
@@ -1,6 +1,6 @@
-import { tap, map, withLatestFrom } from 'rxjs/operators'
+import { map, withLatestFrom } from 'rxjs/operators'
 
-import { network$, toggleNetwork, onlineStatus$ } from './service'
+import { network$, changeNetwork, onlineStatus$ } from './service'
 import { OnlineStatus } from './types'
 
 describe('services/app/service/', () => {
@@ -11,24 +11,17 @@ describe('services/app/service/', () => {
       })
     })
 
-    it('returns mainnet by toggleNetwork() before', () => {
+    it('returns mainnet ', () => {
       runObservable(({ expectObservable }) => {
-        toggleNetwork()
+        changeNetwork('mainnet')
         expectObservable(network$).toBe('a', { a: 'mainnet' })
       })
     })
 
-    it('calling toggleNetwork() four times changes network four times', () => {
-      runObservable(({ cold, expectObservable }) => {
-        const values = { a: 1, b: 'testnet', c: 'mainnet' }
-        const toggle = '--a----a--a--a'
-        const result = '--b----c--b--c'
-        const result$ = cold(toggle, values).pipe(
-          tap(() => toggleNetwork()),
-          withLatestFrom(network$),
-          map(([_, network]) => network)
-        )
-        expectObservable(result$).toBe(result, values)
+    it('returns chaosnet ', () => {
+      runObservable(({ expectObservable }) => {
+        changeNetwork('chaosnet')
+        expectObservable(network$).toBe('a', { a: 'chaosnet' })
       })
     })
   })

--- a/src/renderer/services/app/service.ts
+++ b/src/renderer/services/app/service.ts
@@ -2,6 +2,7 @@ import * as Rx from 'rxjs'
 import { startWith, mapTo } from 'rxjs/operators'
 
 import { observableState } from '../../helpers/stateHelper'
+import { DEFAULT_NETWORK } from '../const'
 import { OnlineStatus, Network } from './types'
 
 // Check online status
@@ -14,11 +15,6 @@ const onlineStatus$ = Rx.merge(online$, offline$).pipe(startWith(navigator.onLin
 /**
  * State of `Network`
  */
-const { get$: network$, get: getNetwork, set: changeNetwork } = observableState<Network>('testnet')
+const { get$: network$, set: changeNetwork } = observableState<Network>(DEFAULT_NETWORK)
 
-const toggleNetwork = () => {
-  const next = getNetwork() === 'mainnet' ? 'testnet' : 'mainnet'
-  changeNetwork(next)
-}
-
-export { onlineStatus$, network$, toggleNetwork }
+export { onlineStatus$, network$, changeNetwork }

--- a/src/renderer/services/binance/service.ts
+++ b/src/renderer/services/binance/service.ts
@@ -27,6 +27,7 @@ import * as fpHelpers from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
 import { observableState, triggerStream } from '../../helpers/stateHelper'
 import { Network } from '../app/types'
+import { DEFAULT_NETWORK } from '../const'
 import { KeystoreState } from '../wallet/types'
 import { getPhrase } from '../wallet/util'
 import { createFreezeService } from './freeze'
@@ -52,16 +53,16 @@ const BINANCE_MAINET_WS_URI = envOrDefault(process.env.REACT_APP_BINANCE_MAINNET
 /**
  * Observable state of `Network`
  */
-const { get$: getNetworkState$, set: setNetworkState } = observableState<Network>('testnet')
+const { get$: getNetworkState$, set: setNetworkState } = observableState<Network>(DEFAULT_NETWORK)
 
 /**
  * Websocket endpoint depending on `Network`
  */
 const wsEndpoint$ = getNetworkState$.pipe(
   mergeMap((network) => {
-    if (network === 'mainnet') return Rx.of(BINANCE_MAINET_WS_URI)
-    // all other networks use testnet url for now
-    return Rx.of(BINANCE_TESTNET_WS_URI)
+    if (network === 'testnet') return Rx.of(BINANCE_TESTNET_WS_URI)
+    // chaosnet + mainnet will use Binance mainet url
+    return Rx.of(BINANCE_MAINET_WS_URI)
   })
 )
 
@@ -157,9 +158,9 @@ const BINANCE_MAX_RETRY = 3
  */
 const binanceNetwork$: Observable<BinanceNetwork> = getNetworkState$.pipe(
   mergeMap((network) => {
-    if (network === 'mainnet') return Rx.of('mainnet' as BinanceNetwork)
-    // all other networks use testnet url for now
-    return Rx.of('testnet' as BinanceNetwork)
+    if (network === 'testnet') return Rx.of('testnet' as BinanceNetwork)
+    // chaosnet + mainnet are using Binance mainnet url
+    return Rx.of('mainnet' as BinanceNetwork)
   })
 )
 

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -1,4 +1,7 @@
 import { PricePoolAssets, PoolAsset } from '../views/pools/types'
+import { Network } from './app/types'
 
 // Whitelist of pools for pricing things
 export const PRICE_POOLS_WHITELIST: PricePoolAssets = [PoolAsset.BTC, PoolAsset.ETH, PoolAsset.TUSDB]
+
+export const DEFAULT_NETWORK: Network = 'testnet'

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -5,3 +5,9 @@ import { Network } from './app/types'
 export const PRICE_POOLS_WHITELIST: PricePoolAssets = [PoolAsset.BTC, PoolAsset.ETH, PoolAsset.TUSDB]
 
 export const DEFAULT_NETWORK: Network = 'testnet'
+export const AVAILABLE_NETWORKS: Network[] = ['testnet', 'chaosnet', 'mainnet']
+
+type Network2 = typeof AVAILABLE_NETWORKS[0]
+
+export const availableNetwork3 = ['testnet', 'chaosnet', 'mainnet']
+export type Network3 = typeof availableNetwork3[0]

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -6,8 +6,3 @@ export const PRICE_POOLS_WHITELIST: PricePoolAssets = [PoolAsset.BTC, PoolAsset.
 
 export const DEFAULT_NETWORK: Network = 'testnet'
 export const AVAILABLE_NETWORKS: Network[] = ['testnet', 'chaosnet', 'mainnet']
-
-type Network2 = typeof AVAILABLE_NETWORKS[0]
-
-export const availableNetwork3 = ['testnet', 'chaosnet', 'mainnet']
-export type Network3 = typeof availableNetwork3[0]

--- a/src/renderer/services/midgard/service.ts
+++ b/src/renderer/services/midgard/service.ts
@@ -16,6 +16,7 @@ import { Configuration, DefaultApi, GetPoolsDetailsViewEnum } from '../../types/
 import { PricePoolAsset } from '../../views/pools/types'
 import { isPricePoolAsset } from '../../views/pools/types'
 import { Network } from '../app/types'
+import { DEFAULT_NETWORK } from '../const'
 import {
   PoolsStateRD,
   NetworkInfoRD,

--- a/src/renderer/services/midgard/service.ts
+++ b/src/renderer/services/midgard/service.ts
@@ -31,7 +31,7 @@ const BYZANTINE_MAX_RETRY = 5
 /**
  * Observable state of `Network`
  */
-const { get$: getNetworkState$, set: setNetworkState } = observableState<Network>('testnet')
+const { get$: getNetworkState$, set: setNetworkState } = observableState<Network>(DEFAULT_NETWORK)
 
 /**
  * Helper to get `DefaultApi` instance for Midgard using custom basePath

--- a/src/renderer/views/wallet/SettingsView.tsx
+++ b/src/renderer/views/wallet/SettingsView.tsx
@@ -17,11 +17,17 @@ import { useWalletContext } from '../../contexts/WalletContext'
 import { envOrDefault } from '../../helpers/envHelper'
 import { sequenceTOptionFromArray } from '../../helpers/fpHelpers'
 import { OnlineStatus, Network } from '../../services/app/types'
+import { DEFAULT_NETWORK } from '../../services/const'
+
+type NetworkMenuItem = {
+  key: string
+  label: string
+}
 
 const SettingsView: React.FC = (): JSX.Element => {
   const { keystoreService } = useWalletContext()
   const { lock, removeKeystore } = keystoreService
-  const { network$, toggleNetwork } = useAppContext()
+  const { network$, changeNetwork } = useAppContext()
   const binanceContext = useBinanceContext()
 
   const binanceAddress$ = useMemo(
@@ -50,7 +56,7 @@ const SettingsView: React.FC = (): JSX.Element => {
 
   const onlineStatus = useObservableState<OnlineStatus>(onlineStatus$, OnlineStatus.OFF)
 
-  const network = useObservableState<Network>(network$, 'testnet')
+  const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
 
   const midgardEndpoint$ = useMemo(() => pipe(midgardService.apiEndpoint$, RxOperators.map(RD.toOption)), [
     midgardService.apiEndpoint$
@@ -82,8 +88,8 @@ const SettingsView: React.FC = (): JSX.Element => {
       <Col span={24}>
         <Settings
           apiVersion={apiVersion}
-          network={network}
-          toggleNetwork={toggleNetwork}
+          selectedNetwork={network}
+          changeNetwork={changeNetwork}
           clientUrl={clientUrl}
           lockWallet={lock}
           removeKeystore={removeKeystore}


### PR DESCRIPTION
- [x] Add menu to select `testnet` | `chaosnet` | `mainnet` in `Settings`
- [x] Quick fix for styles of menu in `AssetDetail` (dark mode)
- [x] Update `binanceNetwork$` + `wsEndpoint$` to support `chaosnet`  

Closes #402 