### PR TITLE
Load / display BTC balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@thorchain/asgardex-ethereum": "https://gitlab.com/thorchain/asgardex-common/asgardex-ethereum.git#672ee67d71eaebd95d9580ca753e2cc8c45a5e12",
     "@thorchain/asgardex-midgard": "^1.0.0",
     "@thorchain/asgardex-theme": "^0.1.1",
-    "@thorchain/asgardex-util": "^0.3.0",
+    "@thorchain/asgardex-util": "^0.4.0",
     "@types/electron-devtools-installer": "^2.2.0",
     "antd": "^4.6.1",
     "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@devexperts/utils": "^1.0.0-alpha.14",
     "@openapitools/openapi-generator-cli": "^1.0.15-4.3.1",
     "@thorchain/asgardex-binance": "^3.0.1",
-    "@thorchain/asgardex-bitcoin": "^0.3.0",
+    "@thorchain/asgardex-bitcoin": "https://gitlab.com/thorchain/asgardex-common/asgardex-bitcoin.git#1356f4512d8e1be28103c294bfca6d62730b008c",
     "@thorchain/asgardex-crypto": "https://gitlab.com/thorchain/asgardex-common/asgardex-crypto.git",
     "@thorchain/asgardex-ethereum": "https://gitlab.com/thorchain/asgardex-common/asgardex-ethereum.git#672ee67d71eaebd95d9580ca753e2cc8c45a5e12",
     "@thorchain/asgardex-midgard": "^1.0.0",

--- a/src/renderer/components/uielements/assets/assetIcon/AssetIcon.tsx
+++ b/src/renderer/components/uielements/assets/assetIcon/AssetIcon.tsx
@@ -5,6 +5,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Asset, AssetTicker } from '@thorchain/asgardex-util'
 
 import bnbIcon from '../../../../assets/svg/coin-bnb.svg'
+import btcIcon from '../../../../assets/svg/coin-btc.svg'
 import runeIcon from '../../../../assets/svg/rune-flash-icon.svg'
 import { getIntFromName, rainbowStop } from '../../../../helpers/colorHelpers'
 import { useRemoteImage } from '../../../../hooks/useRemoteImage'
@@ -19,21 +20,26 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 const AssetIcon: React.FC<Props> = ({ asset, size = 'normal', ...rest }): JSX.Element => {
   const imgUrl = useMemo(() => {
     const { symbol, ticker } = asset
+    // BTC
+    if (ticker === AssetTicker.BTC) {
+      return btcIcon
+    }
+    // RUNE
+    if (ticker === AssetTicker.RUNE) {
+      // Always use "our" Rune asset
+      return runeIcon
+    }
+    // BNB
+    if (ticker === AssetTicker.BNB) {
+      // Since BNB is blacklisted at TrustWallet's asset, we have to use "our" own BNB icon
+      // (see https://github.com/trustwallet/assets/blob/master/blockchains/binance/blacklist.json)
+      return bnbIcon
+    }
+
     const assetId = symbol
     // currently we do load assets for Binance chain only
     // Note: Trustwallet supports asset names for mainnet only. For testnet we will use the `IconFallback` component
-    let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/${assetId}/logo.png`
-
-    if (ticker === AssetTicker.RUNE) {
-      // Always use "our" Rune asset
-      url = runeIcon
-    }
-    if (ticker === 'BNB') {
-      // Since BNB is blacklisted at TrustWallet's asset, we have to use "our" own BNB icon
-      // (see https://github.com/trustwallet/assets/blob/master/blockchains/binance/blacklist.json)
-      url = bnbIcon
-    }
-    return url
+    return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/${assetId}/logo.png`
   }, [asset])
 
   const remoteIconImage = useRemoteImage(imgUrl)

--- a/src/renderer/components/wallet/AssetsTable.tsx
+++ b/src/renderer/components/wallet/AssetsTable.tsx
@@ -137,7 +137,15 @@ const AssetsTable: React.FC<Props> = (props: Props): JSX.Element => {
   )
   const renderAssetsTable = useCallback(
     (balances: AssetsWithBalance, loading = false) => {
-      return <TableWrapper dataSource={balances} loading={loading} rowKey={'tx'} onRow={onRow} columns={columns} />
+      return (
+        <TableWrapper
+          dataSource={balances}
+          loading={loading}
+          rowKey={({ asset }) => asset.symbol}
+          onRow={onRow}
+          columns={columns}
+        />
+      )
     },
     [columns, onRow]
   )

--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -1,4 +1,4 @@
-import { AssetSymbol, assetToBase, assetAmount } from '@thorchain/asgardex-util'
+import { AssetSymbol, assetToBase, assetAmount, Asset } from '@thorchain/asgardex-util'
 
 import {
   PricePoolCurrencySymbols,
@@ -7,6 +7,8 @@ import {
   PricePool,
   PricePoolAssets
 } from './views/pools/types'
+
+export const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC' }
 
 // Currency symbols used for pricing
 export const CURRENCY_SYMBOLS: PricePoolCurrencySymbols = {

--- a/src/renderer/contexts/BinanceContext.tsx
+++ b/src/renderer/contexts/BinanceContext.tsx
@@ -3,8 +3,6 @@ import React, { createContext, useContext } from 'react'
 import {
   subscribeTransfers,
   miniTickers$,
-  reloadBalances,
-  assetsWB$,
   client$,
   clientViewState$,
   address$,
@@ -23,8 +21,6 @@ export type BinanceContextValue = {
   subscribeTransfers: typeof subscribeTransfers
   miniTickers$: typeof miniTickers$
   clientViewState$: typeof clientViewState$
-  reloadBalances: typeof reloadBalances
-  assetsWB$: typeof assetsWB$
   setSelectedAsset: typeof setSelectedAsset
   txsSelectedAsset$: typeof txsSelectedAsset$
   loadTxsSelectedAsset: typeof loadTxsSelectedAsset
@@ -43,8 +39,6 @@ const initialContext: BinanceContextValue = {
   miniTickers$,
   client$,
   clientViewState$,
-  reloadBalances,
-  assetsWB$,
   setSelectedAsset,
   txsSelectedAsset$,
   loadTxsSelectedAsset,

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -3,14 +3,19 @@ import React, { createContext, useContext } from 'react'
 import * as O from 'fp-ts/lib/Option'
 import { none, Option, some } from 'fp-ts/lib/Option'
 
+import { reloadBalances, assetsWB$ } from '../services/wallet/balances'
 import { keystoreService } from '../services/wallet/service'
 
 type WalletContextValue = {
   keystoreService: typeof keystoreService
+  reloadBalances: typeof reloadBalances
+  assetsWB$: typeof assetsWB$
 }
 
 const initialContext: WalletContextValue = {
-  keystoreService
+  keystoreService,
+  reloadBalances,
+  assetsWB$
 }
 const WalletContext = createContext<Option<WalletContextValue>>(none)
 

--- a/src/renderer/helpers/assetHelper.ts
+++ b/src/renderer/helpers/assetHelper.ts
@@ -7,6 +7,20 @@ export const RUNE_SYMBOL_TESTNET = 'RUNE-67C'
 export const BNB_SYMBOL = 'BNB'
 
 /**
+ * Number of decimals for Binance chain assets
+ * Example:
+ * 1 RUNE == 100000000 ð (tor)
+ * 0.00000001 RUNE == 1 ð (tor)
+ * */
+export const BNB_DECIMAL = 8
+
+/**
+ * 1 BTC == 100000000 satoshi
+ * 0.00000001 BTC == 1 satoshi
+ * */
+export const BTC_DECIMAL = 8
+
+/**
  * Check whether is RUNE asset or not
  */
 export const isRuneAsset = ({ symbol }: Asset): boolean =>

--- a/src/renderer/services/binance/service.ts
+++ b/src/renderer/services/binance/service.ts
@@ -4,7 +4,6 @@ import { Asset } from '@thorchain/asgardex-util'
 import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
-import { pipe } from 'fp-ts/pipeable'
 import * as Rx from 'rxjs'
 import { Observable, Observer } from 'rxjs'
 import {
@@ -225,10 +224,10 @@ const { stream$: reloadBalances$, trigger: reloadBalances } = triggerStream()
  * Data will be loaded by first subscription only
  * If a client is not available (e.g. by removing keystore), it returns an `initial` state
  */
-const assetsWB$: Observable<AssetsWithBalanceRD> = Rx.combineLatest(
+const assetsWB$: Observable<AssetsWithBalanceRD> = Rx.combineLatest([
   reloadBalances$.pipe(debounceTime(300)),
   client$
-).pipe(
+]).pipe(
   mergeMap(([_, client]) => {
     return FP.pipe(
       client,
@@ -370,7 +369,7 @@ const freezeFee$: Observable<FeeRD> = FP.pipe(
   shareReplay(1)
 )
 
-const wsTransfer$ = pipe(
+const wsTransfer$ = FP.pipe(
   address$,
   switchMap(O.fold(() => Rx.EMPTY, subscribeTransfers)),
   RxOperators.map(O.some),

--- a/src/renderer/services/binance/utils.ts
+++ b/src/renderer/services/binance/utils.ts
@@ -16,6 +16,7 @@ import {
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
+import { BNB_DECIMAL } from '../../helpers/assetHelper'
 import { PoolDetails } from '../midgard/types'
 import { getPoolDetail, toPoolData } from '../midgard/utils'
 import { AssetWithBalance, AssetsWithBalance } from '../wallet/types'
@@ -63,7 +64,7 @@ export const getWalletBalances = (balances: Balances): AssetsWithBalance =>
       oAsset,
       O.map((asset) => {
         const amountBN = bnOrZero(free)
-        const amount = assetToBase(assetAmount(amountBN))
+        const amount = assetToBase(assetAmount(amountBN, BNB_DECIMAL))
         const frozenAmountBN = bn(frozen)
         const frozenAmount = isValidBN(frozenAmountBN) ? O.some(assetToBase(assetAmount(frozenAmountBN))) : O.none
 

--- a/src/renderer/services/bitcoin/service.ts
+++ b/src/renderer/services/bitcoin/service.ts
@@ -9,6 +9,7 @@ import { Observable, Observer } from 'rxjs'
 import { map, mergeMap, catchError, shareReplay, startWith, distinctUntilChanged, debounceTime } from 'rxjs/operators'
 
 import { AssetBTC } from '../../const'
+import { BTC_DECIMAL } from '../../helpers/assetHelper'
 import { envOrDefault } from '../../helpers/envHelper'
 import * as fpHelpers from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
@@ -95,7 +96,7 @@ const loadBalances$ = (client: BitcoinClient): Observable<AssetWithBalanceRD> =>
       Rx.of(
         RD.success({
           asset: AssetBTC,
-          amount: baseAmount(balance),
+          amount: baseAmount(balance, BTC_DECIMAL),
           frozenAmount: O.none
         } as AssetWithBalance)
       )

--- a/src/renderer/services/bitcoin/service.ts
+++ b/src/renderer/services/bitcoin/service.ts
@@ -1,17 +1,23 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client as BitcoinClient, Network as BitcoinNetwork } from '@thorchain/asgardex-bitcoin'
+import { baseAmount } from '@thorchain/asgardex-util'
 import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay, distinctUntilChanged } from 'rxjs/operators'
+import { map, mergeMap, catchError, shareReplay, startWith, distinctUntilChanged, debounceTime } from 'rxjs/operators'
 
+import { AssetBTC } from '../../const'
 import { envOrDefault } from '../../helpers/envHelper'
 import * as fpHelpers from '../../helpers/fpHelpers'
+import { liveData } from '../../helpers/rx/liveData'
+import { triggerStream } from '../../helpers/stateHelper'
 import { network$ } from '../app/service'
 import { ClientStateForViews } from '../types'
 import { getClientStateForViews, getClient } from '../utils'
 import { keystoreService } from '../wallet/service'
+import { AssetWithBalanceRD, AssetWithBalance, AssetsWithBalanceRD } from '../wallet/types'
 import { getPhrase } from '../wallet/util'
 import { BitcoinClientState } from './types'
 
@@ -80,6 +86,56 @@ const address$: Observable<O.Option<string>> = client$.pipe(
 )
 
 /**
+ * Observable to load balances from Binance API endpoint
+ * If client is not available, it returns an `initial` state
+ */
+const loadBalances$ = (client: BitcoinClient): Observable<AssetWithBalanceRD> =>
+  Rx.from(client.getBalance()).pipe(
+    mergeMap((balance) =>
+      Rx.of(
+        RD.success({
+          asset: AssetBTC,
+          amount: baseAmount(balance),
+          frozenAmount: O.none
+        } as AssetWithBalance)
+      )
+    ),
+    catchError((error) => Rx.of(RD.failure(error))),
+    startWith(RD.pending)
+  )
+
+// `TriggerStream` to reload `Balances`
+const { stream$: reloadBalances$, trigger: reloadBalances } = triggerStream()
+
+/**
+ * State of `Balance`s provided as `AssetsWithBalanceRD`
+ *
+ * Data will be loaded by first subscription only
+ * If a client is not available (e.g. by removing keystore), it returns an `initial` state
+ */
+const assetWB$: Observable<AssetWithBalanceRD> = Rx.combineLatest(
+  reloadBalances$.pipe(debounceTime(300)),
+  client$
+).pipe(
+  mergeMap(([_, client]) => {
+    return FP.pipe(
+      client,
+      O.fold(
+        // if a client is not available, "reset" state to "initial"
+        () => Rx.of(RD.initial),
+        // or start request and return state
+        loadBalances$
+      )
+    )
+  }),
+  // cache it to avoid reloading data by every subscription
+  shareReplay(1)
+)
+
+// Map `AssetWB` into `[AssetsWB]` - needed
+const assetsWB$: Observable<AssetsWithBalanceRD> = assetWB$.pipe(liveData.map((asset) => [asset]))
+
+/**
  * Object with all "public" functions and observables
  */
-export { client$, clientViewState$, address$ }
+export { client$, clientViewState$, address$, reloadBalances, assetsWB$ }

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -1,0 +1,26 @@
+import * as RD from '@devexperts/remote-data-ts'
+import * as A from 'fp-ts/lib/Array'
+import * as FP from 'fp-ts/lib/function'
+import * as Rx from 'rxjs'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { sequenceTRD } from '../../helpers/fpHelpers'
+import * as BNB from '../binance/service'
+import * as BTC from '../bitcoin/service'
+import { AssetsWithBalanceRD } from './types'
+
+const reloadBalances = () => {
+  BTC.reloadBalances()
+  BNB.reloadBalances()
+}
+
+const assetsWB$: Observable<AssetsWithBalanceRD> = Rx.combineLatest([BNB.assetsWB$, BTC.assetsWB$]).pipe(
+  map(([bnbAssetsWB, btcAssetsWB]) => {
+    return FP.pipe(sequenceTRD(bnbAssetsWB, btcAssetsWB), RD.map(A.flatten))
+  })
+)
+
+assetsWB$.subscribe(console.log)
+
+export { reloadBalances, assetsWB$ }

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -21,6 +21,4 @@ const assetsWB$: Observable<AssetsWithBalanceRD> = Rx.combineLatest([BNB.assetsW
   })
 )
 
-assetsWB$.subscribe(console.log)
-
 export { reloadBalances, assetsWB$ }

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -33,3 +33,4 @@ export type AssetWithBalance = {
 export type AssetsWithBalance = AssetWithBalance[]
 
 export type AssetsWithBalanceRD = RD.RemoteData<Error, AssetsWithBalance>
+export type AssetWithBalanceRD = RD.RemoteData<Error, AssetWithBalance>

--- a/src/renderer/services/wallet/util.ts
+++ b/src/renderer/services/wallet/util.ts
@@ -1,4 +1,4 @@
-import { assetToString } from '@thorchain/asgardex-util'
+import { assetToString, AssetTicker } from '@thorchain/asgardex-util'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import { pipe, identity } from 'fp-ts/lib/function'
@@ -37,7 +37,7 @@ export const filterNullableBalances = (balances: AssetsWithBalance) => {
   )
 }
 
-const TICKERS_ORDER = ['BTC', 'RUNE', 'BNB']
+const TICKERS_ORDER: string[] = [AssetTicker.BTC, AssetTicker.RUNE, AssetTicker.BNB]
 
 const getBalanceIndex = (balance: AssetWithBalance) =>
   TICKERS_ORDER.findIndex((ticker) => ticker === balance.asset.ticker)

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -21,6 +21,7 @@ import Button from '../../components/uielements/button'
 import { getRunePricePool } from '../../const'
 import { useBinanceContext } from '../../contexts/BinanceContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
+import { useWalletContext } from '../../contexts/WalletContext'
 import { rdFromOption } from '../../helpers/fpHelpers'
 import { SwapRouteParams } from '../../routes/swap'
 import { pricePoolSelectorFromRD } from '../../services/midgard/utils'
@@ -36,7 +37,8 @@ const SwapView: React.FC<Props> = (_): JSX.Element => {
   const {
     pools: { poolsState$, poolAddresses$, reloadPoolsState, selectedPricePoolAsset$, runeAsset$ }
   } = midgardService
-  const { transaction, assetsWB$, explorerUrl$ } = useBinanceContext()
+  const { transaction, explorerUrl$ } = useBinanceContext()
+  const { assetsWB$ } = useWalletContext()
   const poolsState = useObservableState(poolsState$, initial)
   const [poolAddresses] = useObservableState(() => poolAddresses$, initial)
 

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -8,18 +8,12 @@ import { useParams } from 'react-router-dom'
 
 import AssetDetails from '../../components/wallet/AssetDetails'
 import { useBinanceContext } from '../../contexts/BinanceContext'
+import { useWalletContext } from '../../contexts/WalletContext'
 import { AssetDetailsParams } from '../../routes/wallet'
 
 const AssetDetailsView: React.FC = (): JSX.Element => {
-  const {
-    txsSelectedAsset$,
-    address$,
-    assetsWB$,
-    reloadBalances,
-    loadTxsSelectedAsset,
-    explorerUrl$,
-    setSelectedAsset
-  } = useBinanceContext()
+  const { txsSelectedAsset$, address$, loadTxsSelectedAsset, explorerUrl$, setSelectedAsset } = useBinanceContext()
+  const { assetsWB$, reloadBalances } = useWalletContext()
 
   const { asset } = useParams<AssetDetailsParams>()
   const selectedAsset = O.fromNullable(assetFromString(asset))

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -7,15 +7,15 @@ import { useObservableState } from 'observable-hooks'
 import { useHistory } from 'react-router-dom'
 
 import AssetsTable from '../../components/wallet/AssetsTable'
-import { useBinanceContext } from '../../contexts/BinanceContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
+import { useWalletContext } from '../../contexts/WalletContext'
 import * as walletRoutes from '../../routes/wallet'
 import { pricePoolSelectorFromRD } from '../../services/midgard/utils'
 import { PricePoolAsset } from '../pools/types'
 
 const AssetsView: React.FC = (): JSX.Element => {
   const history = useHistory()
-  const { assetsWB$ } = useBinanceContext()
+  const { assetsWB$ } = useWalletContext()
   const balancesRD = useObservableState(assetsWB$, RD.initial)
 
   const {

--- a/src/renderer/views/wallet/FreezeView.tsx
+++ b/src/renderer/views/wallet/FreezeView.tsx
@@ -12,6 +12,7 @@ import * as Rx from 'rxjs/operators'
 import BackLink from '../../components/uielements/backLink'
 import Freeze from '../../components/wallet/txs/Freeze'
 import { useBinanceContext } from '../../contexts/BinanceContext'
+import { useWalletContext } from '../../contexts/WalletContext'
 import { getBnbAmountFromBalances, getAssetWBByAsset } from '../../helpers/walletHelper'
 import { SendParams } from '../../routes/wallet'
 import * as walletRoutes from '../../routes/wallet'
@@ -26,7 +27,8 @@ const FreezeView: React.FC<Props> = ({ freezeAction }): JSX.Element => {
   const { asset } = useParams<SendParams>()
   const oSelectedAsset = O.fromNullable(assetFromString(asset))
 
-  const { freeze: freezeService, assetsWB$, explorerUrl$, freezeFee$ } = useBinanceContext()
+  const { freeze: freezeService, explorerUrl$, freezeFee$ } = useBinanceContext()
+  const { assetsWB$ } = useWalletContext()
   const fee = useObservableState<O.Option<AssetAmount>>(() => freezeFee$.pipe(Rx.map(RD.toOption)), O.none)[0]
   const balancesState = useObservableState(assetsWB$, initial)
   const explorerUrl = useObservableState(explorerUrl$, O.none)

--- a/src/renderer/views/wallet/SendView.tsx
+++ b/src/renderer/views/wallet/SendView.tsx
@@ -12,6 +12,7 @@ import ErrorView from '../../components/shared/error/ErrorView'
 import BackLink from '../../components/uielements/backLink'
 import Send from '../../components/wallet/txs/Send'
 import { useBinanceContext } from '../../contexts/BinanceContext'
+import { useWalletContext } from '../../contexts/WalletContext'
 import { getAssetWBByAsset } from '../../helpers/walletHelper'
 import { useSingleTxFee } from '../../hooks/useSingleTxFee'
 import { SendParams } from '../../routes/wallet'
@@ -25,7 +26,9 @@ const SendView: React.FC<Props> = (): JSX.Element => {
   const { asset } = useParams<SendParams>()
   const oSelectedAsset = O.fromNullable(assetFromString(asset))
 
-  const { transaction: transactionService, assetsWB$, explorerUrl$, client$, transferFees$ } = useBinanceContext()
+  const { transaction: transactionService, explorerUrl$, client$, transferFees$ } = useBinanceContext()
+  const { assetsWB$ } = useWalletContext()
+
   const balancesState = useObservableState(assetsWB$, RD.initial)
   const explorerUrl = useObservableState(explorerUrl$, O.none)
   const client = useObservableState<O.Option<BinanceClient>>(client$, O.none)

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -7,7 +7,6 @@ import { Switch, Route, Redirect } from 'react-router-dom'
 
 import { RefreshButton } from '../../components/uielements/button/'
 import AssetsNav from '../../components/wallet/AssetsNav'
-import { useBinanceContext } from '../../contexts/BinanceContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import { RedirectRouteState } from '../../routes/types'
 import * as walletRoutes from '../../routes/wallet'
@@ -26,8 +25,7 @@ import StakesView from './StakesView'
 import UnlockView from './UnlockView'
 
 const WalletView: React.FC = (): JSX.Element => {
-  const { keystoreService } = useWalletContext()
-  const { reloadBalances } = useBinanceContext()
+  const { keystoreService, reloadBalances } = useWalletContext()
 
   // Important note:
   // Since `useObservableState` is set after first render

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@
   dependencies:
     polished "^3.6.3"
 
-"@thorchain/asgardex-util@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@thorchain/asgardex-util/-/asgardex-util-0.3.0.tgz#7a9b57ae1736f47cec125b29e423f9f0ded1a15f"
-  integrity sha512-2d72flkoMuxARDLY1JTAwnhUbPCz+6dbGoG2EO6FrpIWLeOXAoQHhZ5wB+q0zWb4w6dlg+kqkFMjvdm7sVBu4g==
+"@thorchain/asgardex-util@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@thorchain/asgardex-util/-/asgardex-util-0.4.0.tgz#8ccc71a26ae566772f94d14ee137cec703b5cbe4"
+  integrity sha512-FY8uq+o2mgT3jQjVGMme1zAUzqrnuhrxIFukpLLHFxMLAvNct2Sv0661oc/st9f0VhwxAHP0cNwE0IW9L9z9Kg==
 
 "@types/anymatch@*":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,10 +2895,9 @@
   resolved "https://registry.yarnpkg.com/@thorchain/asgardex-binance/-/asgardex-binance-3.0.1.tgz#ef516851b1f7d9fde28b43bb1bc0aab7bd1e1abc"
   integrity sha512-Pg7jbDJlyvOe46QMFJKADwhe3xXkWQ0c754e6BulBJsXDLw8lzodOsP98hlJwukJXe7AE5jjyAiS/jfWA2WDiQ==
 
-"@thorchain/asgardex-bitcoin@^0.3.0":
+"@thorchain/asgardex-bitcoin@https://gitlab.com/thorchain/asgardex-common/asgardex-bitcoin.git#1356f4512d8e1be28103c294bfca6d62730b008c":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@thorchain/asgardex-bitcoin/-/asgardex-bitcoin-0.3.0.tgz#94f8379a606b9b810a70f6826636e433bb2d60ab"
-  integrity sha512-sEQ0M/4uMP6V47r5HihOnhnNFM2JNu/OBUDZYKwMnGEr9nvyOH7lEUISYsbO8yaKmXgbhK0Tz+Tg/KKKG9Mwhw==
+  resolved "https://gitlab.com/thorchain/asgardex-common/asgardex-bitcoin.git#1356f4512d8e1be28103c294bfca6d62730b008c"
   dependencies:
     axios "^0.19.2"
     bip39 "^3.0.2"


### PR DESCRIPTION
- [x] Handle `loadBalances` of BTCClient
- [x] Expose `assetsWB$` / `reloadBalances` from `WalletService` to get all balances of all supported chains
- [x] Don't expose `assetsWB$` / `reloadBalances` from `BinanceService` 
- [x] Use embedded icon for BTC
- [x] Set decimal explicit while parsing balances
- [x] Use latest `asgardex-util@0.4.0`
- [x] Fix React warn messages about missing key

![Screenshot from 2020-09-10 16-06-54](https://user-images.githubusercontent.com/61792675/92742310-cd5c5d00-f37f-11ea-84ae-99610be4cd7e.png)

Closes #349 