### PR TITLE
Fix: Sorting in PoolsTable and AssetTable pools

### DIFF
--- a/src/renderer/components/wallet/AssetsTable.tsx
+++ b/src/renderer/components/wallet/AssetsTable.tsx
@@ -8,6 +8,7 @@ import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
 import { RUNE_PRICE_POOL } from '../../const'
+import { ordBaseAmount } from '../../helpers/fp/ord'
 import { sequenceTOption } from '../../helpers/fpHelpers'
 import { getPoolPriceValue } from '../../services/binance/utils'
 import { PoolDetails } from '../../services/midgard/types'
@@ -88,7 +89,7 @@ const AssetsTable: React.FC<Props> = (props: Props): JSX.Element => {
       title: intl.formatMessage({ id: 'wallet.column.balance' }),
       align: 'left',
       render: renderBalanceColumn,
-      sorter: (a: AssetWithBalance, b: AssetWithBalance) => a.amount.amount().comparedTo(b.amount.amount()),
+      sorter: (a: AssetWithBalance, b: AssetWithBalance) => ordBaseAmount.compare(a.amount, b.amount),
       sortDirections: ['descend', 'ascend']
     }),
     [intl]
@@ -120,7 +121,7 @@ const AssetsTable: React.FC<Props> = (props: Props): JSX.Element => {
           sequenceTOption(oPriceA, oPriceB),
           O.fold(
             () => 0,
-            ([priceA, priceB]) => priceA.amount().comparedTo(priceB.amount())
+            ([priceA, priceB]) => ordBaseAmount.compare(priceA, priceB)
           )
         )
       },

--- a/src/renderer/components/wallet/AssetsTable.tsx
+++ b/src/renderer/components/wallet/AssetsTable.tsx
@@ -56,6 +56,7 @@ const AssetsTable: React.FC<Props> = (props: Props): JSX.Element => {
       align: 'left',
       render: renderNameColumn,
       sorter: sortNameColumn,
+      defaultSortOrder: 'ascend',
       sortDirections: ['descend', 'ascend']
     }),
     [intl]

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -1,11 +1,19 @@
-import { baseAmount } from '@thorchain/asgardex-util'
+import { baseAmount, bn } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { AssetWithBalance, ApiError, ErrorId } from '../../services/wallet/types'
-import { eqAsset, eqBaseAmount, eqAssetWithBalance, eqAssetsWithBalance, eqApiError } from './eq'
+import { eqAsset, eqBaseAmount, eqAssetWithBalance, eqAssetsWithBalance, eqApiError, egBigNumber } from './eq'
 
 describe('helpers/fp/eq', () => {
+  describe('egBigNumber', () => {
+    it('is equal', () => {
+      expect(egBigNumber.equals(bn(1.01), bn(1.01))).toBeTruthy()
+    })
+    it('is not equal', () => {
+      expect(egBigNumber.equals(bn(1), bn(1.01))).toBeFalsy()
+    })
+  })
   describe('eqAsset', () => {
     it('is equal', () => {
       const a = ASSETS_TESTNET.RUNE

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -1,5 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Asset, BaseAmount, assetToString } from '@thorchain/asgardex-util'
+import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
 import * as Eq from 'fp-ts/lib/Eq'
 import * as O from 'fp-ts/lib/Option'
@@ -8,12 +9,16 @@ import { AssetWithBalance, ApiError, AssetsWithBalance } from '../../services/wa
 
 export const eqOString = O.getEq(Eq.eqString)
 
+export const egBigNumber: Eq.Eq<BigNumber> = {
+  equals: (x, y) => x.isEqualTo(y)
+}
+
 export const eqAsset: Eq.Eq<Asset> = {
   equals: (x, y) => assetToString(x) === assetToString(y)
 }
 
 export const eqBaseAmount: Eq.Eq<BaseAmount> = {
-  equals: (x, y) => x.amount().isEqualTo(y.amount()) && x.decimal === y.decimal
+  equals: (x, y) => egBigNumber.equals(x.amount(), y.amount()) && x.decimal === y.decimal
 }
 
 const eqOptionBaseAmount = O.getEq(eqBaseAmount)

--- a/src/renderer/helpers/fp/ord.test.ts
+++ b/src/renderer/helpers/fp/ord.test.ts
@@ -1,0 +1,22 @@
+import { bn, baseAmount } from '@thorchain/asgardex-util'
+
+import { ordBigNumber, ordBaseAmount } from './ord'
+
+describe('helpers/fp/ord', () => {
+  describe('ordBigNumber', () => {
+    it('is greater', () => {
+      expect(ordBigNumber.compare(bn(1.01), bn(1))).toEqual(1)
+    })
+    it('is less', () => {
+      expect(ordBigNumber.compare(bn(1), bn(1.01))).toEqual(-1)
+    })
+  })
+  describe('ordBaseAmount', () => {
+    it('is greater', () => {
+      expect(ordBaseAmount.compare(baseAmount(101), baseAmount(1))).toEqual(1)
+    })
+    it('is less', () => {
+      expect(ordBaseAmount.compare(baseAmount(1), baseAmount(101))).toEqual(-1)
+    })
+  })
+})

--- a/src/renderer/helpers/fp/ord.ts
+++ b/src/renderer/helpers/fp/ord.ts
@@ -1,0 +1,15 @@
+import { BaseAmount } from '@thorchain/asgardex-util'
+import BigNumber from 'bignumber.js'
+import * as Ord from 'fp-ts/lib/Ord'
+
+import { eqBaseAmount, egBigNumber } from './eq'
+
+export const ordBigNumber: Ord.Ord<BigNumber> = {
+  equals: egBigNumber.equals,
+  compare: (x, y) => (x.isLessThan(y) ? -1 : x.isGreaterThan(y) ? 1 : 0)
+}
+
+export const ordBaseAmount: Ord.Ord<BaseAmount> = {
+  equals: eqBaseAmount.equals,
+  compare: (x, y) => ordBigNumber.compare(x.amount(), y.amount())
+}

--- a/src/renderer/helpers/poolHelper.test.ts
+++ b/src/renderer/helpers/poolHelper.test.ts
@@ -57,7 +57,7 @@ describe('helpers/poolHelper/', () => {
     })
   })
 
-  describe('getPoolViewData', () => {
+  describe('getPoolTableRowsData', () => {
     const poolDetails: PoolDetails = [
       {
         asset: 'BNB.TOMOB-1E1',
@@ -87,12 +87,12 @@ describe('helpers/poolHelper/', () => {
     it('returns data for available pools', () => {
       const result = getPoolTableRowsData(poolDetails, pricePoolData, PoolDetailStatusEnum.Enabled)
       expect(result.length).toEqual(2)
-      expect(result[0].pool.target).toEqual(ASSETS_TESTNET.TOMO)
-      expect(result[1].pool.target).toEqual(ASSETS_TESTNET.FTM)
+      expect(result[0].pool.target).toEqual(ASSETS_TESTNET.FTM)
+      expect(result[1].pool.target).toEqual(ASSETS_TESTNET.TOMO)
     })
   })
 
-  describe('getPoolViewData', () => {
+  describe('toPoolData', () => {
     const poolDetail: PoolDetail = {
       assetDepth: '11000000000',
       runeDepth: '10000000000'

--- a/src/renderer/helpers/poolHelper.ts
+++ b/src/renderer/helpers/poolHelper.ts
@@ -28,7 +28,7 @@ export const getPoolTableRowsData = (
     A.filter((poolDetail) => poolDetail.status === poolStatus)
   )
   // get symbol of deepest pool
-  const deepestPoolSymbol: O.Option<string> = FP.pipe(
+  const oDeepestPoolSymbol: O.Option<string> = FP.pipe(
     filteredPoolDetails,
     getDeepestPool,
     O.chain((poolDetail) => O.fromNullable(poolDetail.asset)),
@@ -41,16 +41,16 @@ export const getPoolTableRowsData = (
     filteredPoolDetails,
     A.mapWithIndex<PoolDetail, PoolTableRowData>((index, poolDetail) => {
       // get symbol of PoolDetail
-      const poolDetailSymbol: O.Option<string> = FP.pipe(
+      const oPoolDetailSymbol: O.Option<string> = FP.pipe(
         O.fromNullable(assetFromString(poolDetail.asset ?? '')),
         O.map(({ symbol }) => symbol)
       )
-      // check deepest pool
+      // compare symbols to set deepest pool
       const deepest = FP.pipe(
-        sequenceTOption(deepestPoolSymbol, poolDetailSymbol),
+        sequenceTOption(oDeepestPoolSymbol, oPoolDetailSymbol),
         O.fold(
           () => false,
-          ([a, b]) => Eq.eqString.equals(a, b)
+          ([deepestPoolSymbol, poolDetailSymbol]) => Eq.eqString.equals(deepestPoolSymbol, poolDetailSymbol)
         )
       )
       return {

--- a/src/renderer/services/wallet/util.ts
+++ b/src/renderer/services/wallet/util.ts
@@ -1,4 +1,4 @@
-import { assetToString, AssetTicker } from '@thorchain/asgardex-util'
+import { assetToString, AssetTicker, baseAmount } from '@thorchain/asgardex-util'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import { pipe, identity } from 'fp-ts/lib/function'
@@ -6,7 +6,7 @@ import * as O from 'fp-ts/lib/Option'
 import { isSome, Option } from 'fp-ts/lib/Option'
 import * as Ord from 'fp-ts/Ord'
 
-import { ZERO_BN } from '../const'
+import { ordBaseAmount } from '../../helpers/fp/ord'
 import {
   KeystoreState,
   KeystoreContent,
@@ -33,7 +33,7 @@ export const isLocked = (state: KeystoreState): boolean => !hasImportedKeystore(
 export const filterNullableBalances = (balances: AssetsWithBalance) => {
   return FP.pipe(
     balances,
-    A.filter((balance) => balance.amount.amount().isGreaterThan(ZERO_BN))
+    A.filter(({ amount }) => Ord.gt(ordBaseAmount)(amount, baseAmount(0)))
   )
 }
 

--- a/src/renderer/views/pools/PoolsOverview.tsx
+++ b/src/renderer/views/pools/PoolsOverview.tsx
@@ -322,8 +322,8 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     volumeColumn,
     transactionColumn,
     slipColumn,
-    tradeColumn
-    // btnPoolsColumn
+    tradeColumn,
+    btnPoolsColumn
   ]
 
   const mobilePoolsColumns: ColumnsType<PoolTableRowData> = [poolColumnMobile, btnPoolsColumn]
@@ -452,8 +452,6 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
               pricePool.poolData,
               PoolDetailStatusEnum.Bootstrapped
             )
-
-            console.log('poolViewData:', poolViewData)
             previousPendingPools.current = some(poolViewData)
             return renderPendingPoolsTable(poolViewData)
           }

--- a/src/renderer/views/pools/PoolsOverview.tsx
+++ b/src/renderer/views/pools/PoolsOverview.tsx
@@ -19,7 +19,7 @@ import Label from '../../components/uielements/label'
 import Table from '../../components/uielements/table'
 import Trend from '../../components/uielements/trend'
 import { useMidgardContext } from '../../contexts/MidgardContext'
-import { ordBaseAmount } from '../../helpers/fp/ord'
+import { ordBaseAmount, ordBigNumber } from '../../helpers/fp/ord'
 import { getPoolTableRowsData, hasPendingPools, sortByDepth } from '../../helpers/poolHelper'
 import useInterval, { INACTIVE_INTERVAL } from '../../hooks/useInterval'
 import * as stakeRoutes from '../../routes/stake'
@@ -205,11 +205,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     ),
     [pricePool]
   )
-  const sortPriceColumn = useCallback((a: PoolTableRowData, b: PoolTableRowData) => {
-    const aAmount = a.poolPrice.amount()
-    const bAmount = b.poolPrice.amount()
-    return aAmount.minus(bAmount).toNumber()
-  }, [])
+  const sortPriceColumn = useCallback(
+    (a: PoolTableRowData, b: PoolTableRowData) => ordBaseAmount.compare(a.poolPrice, b.poolPrice),
+    []
+  )
 
   const priceColumn: ColumnType<PoolTableRowData> = {
     key: 'poolprice',
@@ -272,11 +271,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     ),
     [pricePool]
   )
-  const sortTransactionColumn = useCallback((a: PoolTableRowData, b: PoolTableRowData) => {
-    const aAmount = a.transactionPrice.amount()
-    const bAmount = b.transactionPrice.amount()
-    return aAmount.minus(bAmount).toNumber()
-  }, [])
+  const sortTransactionColumn = useCallback(
+    (a: PoolTableRowData, b: PoolTableRowData) => ordBaseAmount.compare(a.transactionPrice, b.transactionPrice),
+    []
+  )
   const transactionColumn: ColumnType<PoolTableRowData> = {
     key: 'transaction',
     align: 'right',
@@ -288,7 +286,10 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
   }
 
   const renderSlipColumn = useCallback((slip: BigNumber) => <Trend amount={slip} />, [])
-  const sortSlipColumn = useCallback((a: PoolTableRowData, b: PoolTableRowData) => a.slip.minus(b.slip).toNumber(), [])
+  const sortSlipColumn = useCallback(
+    (a: PoolTableRowData, b: PoolTableRowData) => ordBigNumber.compare(a.slip, b.slip),
+    []
+  )
 
   const slipColumn: ColumnType<PoolTableRowData> = {
     key: 'slip',
@@ -306,11 +307,7 @@ const PoolsOverview: React.FC<Props> = (_): JSX.Element => {
     title: intl.formatMessage({ id: 'pools.trades' }),
     dataIndex: 'trades',
     render: (trades: BigNumber) => <Label align="center">{trades.toString()}</Label>,
-    sorter: (a: PoolTableRowData, b: PoolTableRowData) => {
-      const aAmount = a.trades
-      const bAmount = b.trades
-      return aAmount.minus(bAmount).toNumber()
-    },
+    sorter: (a: PoolTableRowData, b: PoolTableRowData) => ordBigNumber.compare(a.trades, b.trades),
     sortDirections: ['descend', 'ascend']
   }
 


### PR DESCRIPTION
- [x] PoolsTabe: Sort pools by depth
- [x] AssetsTable: Filter out assets w/ zero balances + sort by BTC -> RUNE -> BTC -> others (ETH will be added in another PR...) Note: We already had this feature implemented, but I have removed it by accident with a previous PR ...
- [x] Add `ord` instances for `BaseAmount` + `BigNumber` (incl. tests)
- [x] Add `eqBigNumber`