### PR TITLE
Fix BignumberInput: Function components cannot be given refs.

### DIFF
--- a/src/renderer/components/uielements/input/InputBigNumber.stories.tsx
+++ b/src/renderer/components/uielements/input/InputBigNumber.stories.tsx
@@ -63,6 +63,7 @@ storiesOf('Components/input/InputBigNumber', module)
         form={form}
         onFinish={onFinish}
         initialValues={{
+          // initial value for amount
           amount: bn('1')
         }}>
         <Form.Item name="amount" label="Amount" rules={[{ validator: checkValue }]}>

--- a/src/renderer/components/uielements/input/InputBigNumber.tsx
+++ b/src/renderer/components/uielements/input/InputBigNumber.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useCallback, useState, useRef, useEffect } from 'react'
+import React, { useMemo, useCallback, useState, useRef, useEffect, forwardRef } from 'react'
 
 import { delay, bn, fixedBN } from '@thorchain/asgardex-util'
+import { Input } from 'antd'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
@@ -16,101 +17,104 @@ type Props = Omit<Styled.InputProps, 'value' | 'onChange'> & {
   decimal?: number
 }
 
-export const InputBigNumber: React.FC<Props> = (props: Props): JSX.Element => {
-  const {
-    decimal = 2,
-    value = ZERO_BN,
-    onChange = () => {},
-    ...otherProps /* any props of `InputNumberProps` */
-  } = props
+export const InputBigNumber = forwardRef<Input, Props>(
+  (props: Props, ref): JSX.Element => {
+    const {
+      decimal = 2,
+      value = ZERO_BN,
+      onChange = () => {},
+      ...otherProps /* any props of `InputNumberProps` */
+    } = props
 
-  // value as string (unformatted) - it supports empty string for an empty input
-  const [enteredValue, setEnteredValue] = useState<O.Option<string>>(O.none)
-  const [focus, setFocus] = useState(false)
-  const broadcastValue = useRef<BigNumber>(bn(0))
+    // value as string (unformatted) - it supports empty string for an empty input
+    const [enteredValue, setEnteredValue] = useState<O.Option<string>>(O.none)
+    const [focus, setFocus] = useState(false)
+    const broadcastValue = useRef<BigNumber>(bn(0))
 
-  const inputValue = useMemo(
-    () =>
-      FP.pipe(
-        enteredValue,
-        O.getOrElse(() => value.toString()),
-        (v) => (focus ? v : formatValue(v, decimal))
-      ),
-    [enteredValue, focus, decimal, value]
-  )
-
-  useEffect(() => {
-    setEnteredValue(O.some(value.toString()))
-  }, [value])
-
-  const onFocusHandler = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const { target } = event
-      setFocus(true)
-      // short delay is needed before selecting to keep its reference
-      // (it will be lost in other cases due React rendering)
-      await delay(1)
-      target.select()
-    },
-    [setFocus]
-  )
-
-  const onBlurHandler = useCallback(() => {
-    setFocus(false)
-    // Clean up value - it can't be done in onChangeHandler due race conditions!!
-    setEnteredValue((v) =>
-      FP.pipe(
-        v,
-        // convert empty string to '0'
-        O.map((v) => (v === '' ? VALUE_ZERO : v)),
-        // format value based on supported decimals
-        O.map((v) => fixedBN(v, decimal).toString()),
-        // remove uneeded zeros
-        O.map(trimZeros)
-      )
+    const inputValue = useMemo(
+      () =>
+        FP.pipe(
+          enteredValue,
+          O.getOrElse(() => value.toString()),
+          (v) => (focus ? v : formatValue(v, decimal))
+        ),
+      [enteredValue, focus, decimal, value]
     )
-  }, [decimal])
 
-  const onPressEnterHandler = useCallback(() => {
-    onBlurHandler()
-  }, [onBlurHandler])
+    useEffect(() => {
+      setEnteredValue(O.some(value.toString()))
+    }, [value])
 
-  const onChangeHandler = useCallback(
-    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-      const { value: newValue } = target
-      if (validInputValue(newValue)) {
-        const valueToBroadcast = FP.pipe(
-          O.some(newValue),
-          // ignore empty input
-          O.filter((v) => v !== ''),
-          O.alt(() => O.some('0')),
-          // format value
-          O.map((v) => fixedBN(v, decimal)),
-          // different value as before?
-          O.filter((v) => !broadcastValue.current.isEqualTo(v))
+    const onFocusHandler = useCallback(
+      async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { target } = event
+        setFocus(true)
+        // short delay is needed before selecting to keep its reference
+        // (it will be lost in other cases due React rendering)
+        await delay(1)
+        target.select()
+      },
+      [setFocus]
+    )
+
+    const onBlurHandler = useCallback(() => {
+      setFocus(false)
+      // Clean up value - it can't be done in onChangeHandler due race conditions!!
+      setEnteredValue((v) =>
+        FP.pipe(
+          v,
+          // convert empty string to '0'
+          O.map((v) => (v === '' ? VALUE_ZERO : v)),
+          // format value based on supported decimals
+          O.map((v) => fixedBN(v, decimal).toString()),
+          // remove uneeded zeros
+          O.map(trimZeros)
         )
+      )
+    }, [decimal])
 
-        setEnteredValue(O.some(newValue))
+    const onPressEnterHandler = useCallback(() => {
+      onBlurHandler()
+    }, [onBlurHandler])
 
-        if (O.isSome(valueToBroadcast)) {
-          const v = valueToBroadcast.value
-          broadcastValue.current = v
+    const onChangeHandler = useCallback(
+      ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+        const { value: newValue } = target
+        if (validInputValue(newValue)) {
+          const valueToBroadcast = FP.pipe(
+            O.some(newValue),
+            // ignore empty input
+            O.filter((v) => v !== ''),
+            O.alt(() => O.some('0')),
+            // format value
+            O.map((v) => fixedBN(v, decimal)),
+            // different value as before?
+            O.filter((v) => !broadcastValue.current.isEqualTo(v))
+          )
 
-          onChange(bn(v))
+          setEnteredValue(O.some(newValue))
+
+          if (O.isSome(valueToBroadcast)) {
+            const v = valueToBroadcast.value
+            broadcastValue.current = v
+
+            onChange(bn(v))
+          }
         }
-      }
-    },
-    [broadcastValue, decimal, onChange]
-  )
+      },
+      [broadcastValue, decimal, onChange]
+    )
 
-  return (
-    <Styled.InputBigNumber
-      value={inputValue}
-      onChange={onChangeHandler}
-      onFocus={onFocusHandler}
-      onBlur={onBlurHandler}
-      onPressEnter={onPressEnterHandler}
-      {...otherProps}
-    />
-  )
-}
+    return (
+      <Styled.InputBigNumber
+        ref={ref}
+        value={inputValue}
+        onChange={onChangeHandler}
+        onFocus={onFocusHandler}
+        onBlur={onBlurHandler}
+        onPressEnter={onPressEnterHandler}
+        {...otherProps}
+      />
+    )
+  }
+)


### PR DESCRIPTION
By entering `SendForm` (which includes `BignumberInput`) for the first time, following warn message occured:

> Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

## Solution
[
Forwarding refs](https://reactjs.org/docs/forwarding-refs.html) by using `forwardRef` could fix this issue. 

BTW: We had a similar issue at other place https://github.com/thorchain/asgardex-electron/issues/354 and fixed it by [wrapping components with `<div>...</div>`](https://github.com/thorchain/asgardex-electron/pull/380/commits/1468f077729bdffdd692a8d8212abb9dfe87a099). `forwardRef` should be a better way...

## Screen shot

![Screenshot from 2020-09-23 21-16-15](https://user-images.githubusercontent.com/61792675/94059547-dff47e80-fde2-11ea-8035-3fece95369d1.png)


## Full warn message

```
index.js:1 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `Field`.
    in InputBigNumber (at SendForm.tsx:183)
    in Unknown
    in Unknown (created by Field)
    in div (created by FormItemInput)
    in div (created by FormItemInput)
    in div (created by Context.Consumer)
    in Col (created by FormItemInput)
    in FormItemInput (created by Field)
    in div (created by Context.Consumer)
    in Row (created by Field)
    in Field (created by WrapperField)
    in WrapperField (created by FormItem)
    in FormItem (created by Styled(FormItem))
    in Styled(FormItem) (at SendForm.tsx:181)
    in div (created by styled.div)
    in styled.div (at SendForm.tsx:175)
    in form (created by ForwardRef(Form))
    in ForwardRef(Form) (created by ForwardRef(InternalForm))
    in SizeContextProvider (created by ForwardRef(InternalForm))
    in ForwardRef(InternalForm) (at SendForm.tsx:169)
    in div (created by Context.Consumer)
    in Col (created by Styled(Col))
    in Styled(Col) (at SendForm.tsx:166)
    in div (created by Context.Consumer)
    in Row (at SendForm.tsx:165)
    in SendForm (at Send.tsx:76)
    in Send (at SendViewBNB.tsx:50)
    in SendViewBNB (at SendView.tsx:45)
    in SendView (at WalletView.tsx:76)
    in Route (at WalletView.tsx:84)
    in Switch (at WalletView.tsx:50)
    in Route (at WalletView.tsx:142)
    in Switch (at WalletView.tsx:129)
    in WalletView (at ViewRoutes.tsx:24)
    in Route (at ViewRoutes.tsx:23)
    in Switch (at ViewRoutes.tsx:16)
    in ViewRoutes (at App.tsx:29)
    in main (created by Basic)
    in Basic (created by Context.Consumer)
    in Content (created by Styled(Content))
    in Styled(Content) (at View.tsx:11)
    in View (at App.tsx:28)
    in section (created by Context.Consumer)
    in BasicLayout (created by Context.Consumer)
    in Layout (created by Styled(Layout))
    in Styled(Layout) (at App.tsx:26)
    in div (created by styled.div)
    in styled.div (at App.tsx:25)
    in AppView (at App.tsx:49)
    in ThemeProvider (at ThemeContext.tsx:55)
    in ThemeProvider (at App.tsx:48)
    in Router (created by HashRouter)
    in HashRouter (at App.tsx:47)
    in IntlProvider (at I18nContext.tsx:32)
    in I18nProvider (at App.tsx:46)
    in MidgardProvider (at App.tsx:45)
    in EthereumProvider (at App.tsx:44)
    in BitcoinProvider (at App.tsx:43)
    in BinanceProvider (at App.tsx:42)
    in WalletProvider (at App.tsx:41)
    in AppProvider (at App.tsx:40)
    in App (at renderer/index.tsx:9)
```