### PR TITLE
Get rid of `EMPTY_ASSET` and other improvements 

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -11,7 +11,6 @@ import {
   assetToString,
   baseAmount,
   bn,
-  EMPTY_ASSET,
   formatBN,
   getValueOfAsset1InAsset2,
   PoolData,
@@ -406,14 +405,13 @@ export const Swap = ({
               onChange={setChangeAmount}
               amount={changeAmount}
             />
-            <AssetSelect
-              onSelect={setSourceAsset}
-              asset={FP.pipe(
-                sourceAsset,
-                O.getOrElse(() => EMPTY_ASSET)
-              )}
-              assetData={assetsToSwapFrom}
-            />
+            {FP.pipe(
+              sourceAsset,
+              O.fold(
+                () => <></>,
+                (asset) => <AssetSelect onSelect={setSourceAsset} asset={asset} assetData={assetsToSwapFrom} />
+              )
+            )}
           </Styled.ValueItemContainer>
 
           <Styled.ValueItemContainer className={'valueItemContainer-percent'}>
@@ -426,38 +424,46 @@ export const Swap = ({
               <Styled.InValueTitle>{intl.formatMessage({ id: 'swap.output' })}:</Styled.InValueTitle>
               <div>{formatBN(swapData.swapResult, 7)}</div>
             </Styled.InValue>
-            <AssetSelect
-              onSelect={setTargetAsset}
-              asset={FP.pipe(
-                targetAsset,
-                O.getOrElse(() => EMPTY_ASSET)
-              )}
-              assetData={assetsToSwapTo}
-              priceIndex={availableAssets.reduce((acc, asset) => {
-                return {
-                  ...acc,
-                  [asset.asset.ticker]: baseAmount(asset.priceRune).amount()
-                }
-              }, {})}
-            />
+            {FP.pipe(
+              targetAsset,
+              O.fold(
+                () => <></>,
+                (asset) => (
+                  <AssetSelect
+                    onSelect={setTargetAsset}
+                    asset={asset}
+                    assetData={assetsToSwapTo}
+                    priceIndex={availableAssets.reduce((acc, asset) => {
+                      return {
+                        ...acc,
+                        [asset.asset.ticker]: baseAmount(asset.priceRune).amount()
+                      }
+                    }, {})}
+                  />
+                )
+              )
+            )}
           </Styled.ValueItemContainer>
         </Styled.FormContainer>
       </Styled.ContentContainer>
 
       <Styled.SubmitContainer>
-        <Drag
-          disabled={isSwapDisabled}
-          onConfirm={onSwapConfirmed}
-          title={intl.formatMessage({ id: 'swap.drag' })}
-          source={FP.pipe(
-            sourceAsset,
-            O.getOrElse(() => EMPTY_ASSET)
-          )}
-          target={FP.pipe(
-            targetAsset,
-            O.getOrElse(() => EMPTY_ASSET)
-          )}
-        />
+        {FP.pipe(
+          sequenceTOption(sourceAsset, targetAsset),
+          O.fold(
+            () => <></>,
+            ([source, target]) => (
+              <Drag
+                disabled={isSwapDisabled}
+                onConfirm={onSwapConfirmed}
+                title={intl.formatMessage({ id: 'swap.drag' })}
+                source={source}
+                target={target}
+              />
+            )
+          )
+        )}
+        {/* TODO (@thatThorchainGuy): Get 'BNB' fee from service  */}
         <div>fee: 0.000375 + 1 RUNE</div>
       </Styled.SubmitContainer>
     </Styled.Container>

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { storiesOf } from '@storybook/react'
-import { Asset, assetFromString, assetToString, baseAmount, EMPTY_ASSET } from '@thorchain/asgardex-util'
+import { Asset, AssetBNB, AssetBTC, AssetETH, AssetRune67C, assetToString, baseAmount } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ApiError, AssetsWBChain, AssetsWBChains, ErrorId } from '../../../services/wallet/types'
@@ -33,7 +33,7 @@ const assetsWBChains: AssetsWBChains = [
       {
         amount: baseAmount('12200000000'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.RUNE-67C') || EMPTY_ASSET
+        asset: AssetRune67C
       }
     ])
   },
@@ -43,7 +43,7 @@ const assetsWBChains: AssetsWBChains = [
       {
         amount: baseAmount('1230000'),
         frozenAmount: O.none,
-        asset: assetFromString('BTC.BTC') || EMPTY_ASSET
+        asset: AssetBTC
       }
     ])
   },
@@ -53,12 +53,12 @@ const assetsWBChains: AssetsWBChains = [
       {
         amount: baseAmount('1000000'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.BNB') || EMPTY_ASSET
+        asset: AssetBNB
       },
       {
         amount: baseAmount('300000000'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.FTM-585') || EMPTY_ASSET
+        asset: AssetETH
       }
     ])
   }

--- a/src/renderer/components/wallet/txs/FreezeForm.tsx
+++ b/src/renderer/components/wallet/txs/FreezeForm.tsx
@@ -7,7 +7,8 @@ import {
   AssetAmount,
   formatAssetAmount,
   bn,
-  baseToAsset
+  baseToAsset,
+  AssetBNB
 } from '@thorchain/asgardex-util'
 import { Row, Form } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -16,7 +17,6 @@ import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
 import { ZERO_ASSET_AMOUNT } from '../../../const'
-import { BNB_SYMBOL } from '../../../helpers/assetHelper'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { trimZeros } from '../../../helpers/stringHelper'
 import { FreezeAction, FreezeTxParams } from '../../../services/binance/types'
@@ -82,7 +82,7 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
         oFee,
         O.fold(
           () => '--',
-          (f) => `${trimZeros(formatAssetAmount(f, 8))} ${BNB_SYMBOL}`
+          (f) => `${trimZeros(formatAssetAmount(f, 8))} ${AssetBNB.symbol}`
         )
       ),
     [oFee]
@@ -128,7 +128,7 @@ export const FreezeForm: React.FC<Props> = (props): JSX.Element => {
 
     const msg = intl.formatMessage(
       { id: 'wallet.errors.fee.notCovered' },
-      { fee: formatAssetAmount(amount, 6), balance: `${formatAssetAmount(amount, 8)} ${BNB_SYMBOL}` }
+      { fee: formatAssetAmount(amount, 6), balance: `${formatAssetAmount(amount, 8)} ${AssetBNB.symbol}` }
     )
 
     return (

--- a/src/renderer/components/wallet/txs/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/SendForm.tsx
@@ -9,7 +9,8 @@ import {
   AssetAmount,
   formatAssetAmount,
   bn,
-  baseToAsset
+  baseToAsset,
+  AssetBNB
 } from '@thorchain/asgardex-util'
 import { Row, Form } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -18,7 +19,7 @@ import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
 import { ZERO_ASSET_AMOUNT, ZERO_BN } from '../../../const'
-import { isBnbAsset, BNB_SYMBOL } from '../../../helpers/assetHelper'
+import { isBnbAsset } from '../../../helpers/assetHelper'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { trimZeros } from '../../../helpers/stringHelper'
 import { getBnbAmountFromBalances } from '../../../helpers/walletHelper'
@@ -75,7 +76,7 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
         oFee,
         O.fold(
           () => '--',
-          (f) => `${trimZeros(formatAssetAmount(f, 6))} ${BNB_SYMBOL}`
+          (f) => `${trimZeros(formatAssetAmount(f, 6))} ${AssetBNB.symbol}`
         )
       ),
     [oFee]
@@ -105,7 +106,7 @@ export const SendForm: React.FC<Props> = (props): JSX.Element => {
       { id: 'wallet.errors.fee.notCovered' },
       {
         fee: formatAssetAmount(amount, 6),
-        balance: `${formatAssetAmount(amount, 8)} ${BNB_SYMBOL}`
+        balance: `${formatAssetAmount(amount, 8)} ${AssetBNB.symbol}`
       }
     )
 

--- a/src/renderer/helpers/assetHelper.test.ts
+++ b/src/renderer/helpers/assetHelper.test.ts
@@ -1,4 +1,4 @@
-import { assetFromString, EMPTY_ASSET } from '@thorchain/asgardex-util'
+import { AssetBNB, AssetRune67C, AssetRuneB1A } from '@thorchain/asgardex-util'
 
 import { CURRENCY_SYMBOLS } from '../const'
 import { PoolAsset } from '../views/pools/types'
@@ -7,29 +7,24 @@ import { isRuneAsset, isBnbAsset, getCurrencySymbolByAssetString } from './asset
 describe('helpers/assetHelper', () => {
   describe('isRuneAsset', () => {
     it('checks rune asset for testnet', () => {
-      const asset = assetFromString('BNB.RUNE-B1A') || EMPTY_ASSET
-      expect(isRuneAsset(asset)).toBeTruthy()
+      expect(isRuneAsset(AssetRuneB1A)).toBeTruthy()
     })
 
     it('checks rune asset (mainnet)', () => {
-      const asset = assetFromString('BNB.RUNE-67C') || EMPTY_ASSET
-      expect(isRuneAsset(asset)).toBeTruthy()
+      expect(isRuneAsset(AssetRune67C)).toBeTruthy()
     })
 
     it('returns false for any other asset than RUNE', () => {
-      const asset = assetFromString('BNB.BNB') || EMPTY_ASSET
-      expect(isRuneAsset(asset)).toBeFalsy()
+      expect(isRuneAsset(AssetBNB)).toBeFalsy()
     })
   })
   describe('isBnbAsset', () => {
     it('checks BNB asset', () => {
-      const asset = assetFromString('BNB.BNB') || EMPTY_ASSET
-      expect(isBnbAsset(asset)).toBeTruthy()
+      expect(isBnbAsset(AssetBNB)).toBeTruthy()
     })
 
     it('returns false for any other asset than BNB', () => {
-      const asset = assetFromString('BNB.RUNE-B1A') || EMPTY_ASSET
-      expect(isBnbAsset(asset)).toBeFalsy()
+      expect(isBnbAsset(AssetRuneB1A)).toBeFalsy()
     })
   })
 

--- a/src/renderer/helpers/assetHelper.ts
+++ b/src/renderer/helpers/assetHelper.ts
@@ -1,10 +1,7 @@
-import { Asset, assetFromString } from '@thorchain/asgardex-util'
+import { Asset, AssetBNB, assetFromString, AssetRune67C, AssetRuneB1A } from '@thorchain/asgardex-util'
 
 import { CURRENCY_SYMBOLS } from '../const'
-
-export const RUNE_SYMBOL_MAINNET = 'RUNE-B1A'
-export const RUNE_SYMBOL_TESTNET = 'RUNE-67C'
-export const BNB_SYMBOL = 'BNB'
+import { Network } from '../services/app/types'
 
 /**
  * Number of decimals for Binance chain assets
@@ -27,12 +24,18 @@ export const BTC_DECIMAL = 8
 export const ETH_DECIMAL = 18
 
 /**
+ * Returns RUNE asset depending on network
+ */
+// TODO (@Veado) Add test
+export const getRuneAsset = (net: Network) => (net === 'testnet' ? AssetRune67C : AssetRuneB1A)
+
+/**
  * Check whether is RUNE asset or not
  */
 export const isRuneAsset = ({ symbol }: Asset): boolean =>
-  symbol === RUNE_SYMBOL_MAINNET || symbol === RUNE_SYMBOL_TESTNET
+  symbol === AssetRune67C.symbol || symbol === AssetRuneB1A.symbol
 
-export const isBnbAsset = ({ symbol }: Asset): boolean => symbol === BNB_SYMBOL
+export const isBnbAsset = ({ symbol }: Asset): boolean => symbol === AssetBNB.symbol
 
 export const getCurrencySymbolByAssetString = (asset: string) => {
   if (asset in CURRENCY_SYMBOLS) {

--- a/src/renderer/helpers/binanceHelper.test.ts
+++ b/src/renderer/helpers/binanceHelper.test.ts
@@ -1,5 +1,5 @@
 import { Fees, Fee, DexFees, TransferFee } from '@thorchain/asgardex-binance'
-import { EMPTY_ASSET, assetAmount } from '@thorchain/asgardex-util'
+import { assetAmount } from '@thorchain/asgardex-util'
 import * as E from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 
@@ -16,8 +16,8 @@ describe('binanceHelper', () => {
     it('is false for BNB asset', () => {
       expect(isMiniToken({ symbol: 'BNB' })).toBeFalsy()
     })
-    it('is false for EMTPY asset', () => {
-      expect(isMiniToken(EMPTY_ASSET)).toBeFalsy()
+    it('is false for empty symbol', () => {
+      expect(isMiniToken({ symbol: '' })).toBeFalsy()
     })
   })
 
@@ -28,8 +28,8 @@ describe('binanceHelper', () => {
     it('is false for others', () => {
       expect(isBinanceChain({ chain: 'ETH' })).toBeFalsy()
     })
-    it('is false for EMTPY asset', () => {
-      expect(isBinanceChain(EMPTY_ASSET)).toBeFalsy()
+    it('is false for empty chain', () => {
+      expect(isBinanceChain({ chain: '' })).toBeFalsy()
     })
   })
 

--- a/src/renderer/helpers/poolHelper.test.ts
+++ b/src/renderer/helpers/poolHelper.test.ts
@@ -1,12 +1,10 @@
-import { PoolData, assetAmount, assetToBase, assetToString } from '@thorchain/asgardex-util'
-import * as FP from 'fp-ts/lib/function'
+import { PoolData, assetAmount, assetToBase, AssetRune67C } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../shared/mock/assets'
 import { PoolDetails } from '../services/midgard/types'
 import { toPoolData } from '../services/midgard/utils'
 import { PoolDetailStatusEnum, PoolDetail } from '../types/generated/midgard'
-import { Pool } from '../views/pools/types'
 import { filterPendingPools, getDeepestPool, getPoolTableRowsData } from './poolHelper'
 
 describe('helpers/poolHelper/', () => {
@@ -80,13 +78,6 @@ describe('helpers/poolHelper/', () => {
       assetBalance: assetToBase(assetAmount(100))
     }
 
-    const poolTargetAsString = (oPool: O.Option<Pool>) =>
-      FP.pipe(
-        oPool,
-        O.map((pool) => assetToString(pool.target)),
-        O.getOrElse(() => 'unknown')
-      )
-
     it('returns data for pending pools', () => {
       const result = getPoolTableRowsData({
         poolDetails,
@@ -95,7 +86,8 @@ describe('helpers/poolHelper/', () => {
         network: 'testnet'
       })
       expect(result.length).toEqual(1)
-      expect(poolTargetAsString(result[0].pool)).toEqual(assetToString(ASSETS_TESTNET.BOLT))
+      expect(result[0].pool.asset).toEqual(AssetRune67C)
+      expect(result[0].pool.target).toEqual(ASSETS_TESTNET.BOLT)
     })
 
     it('returns data for available pools', () => {
@@ -107,9 +99,10 @@ describe('helpers/poolHelper/', () => {
       })
       expect(result.length).toEqual(2)
 
-      expect(O.isSome(result[0].pool)).toBeTruthy()
-      expect(poolTargetAsString(result[0].pool)).toEqual(assetToString(ASSETS_TESTNET.FTM))
-      expect(poolTargetAsString(result[1].pool)).toEqual(assetToString(ASSETS_TESTNET.TOMO))
+      expect(result[0].pool.asset).toEqual(AssetRune67C)
+      expect(result[0].pool.target).toEqual(ASSETS_TESTNET.FTM)
+      expect(result[1].pool.asset).toEqual(AssetRune67C)
+      expect(result[1].pool.target).toEqual(ASSETS_TESTNET.TOMO)
     })
   })
 

--- a/src/renderer/helpers/poolHelper.ts
+++ b/src/renderer/helpers/poolHelper.ts
@@ -5,6 +5,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Ord from 'fp-ts/lib/Ord'
 
+import { Network } from '../services/app/types'
 import { PoolDetails } from '../services/midgard/types'
 import { PoolDetailStatusEnum, PoolDetail } from '../types/generated/midgard'
 import { PoolTableRowData, PoolTableRowsData } from '../views/pools/types'
@@ -17,11 +18,17 @@ export const sortByDepth = (a: PoolTableRowData, b: PoolTableRowData) =>
 
 const ordByDepth = Ord.ord.contramap(ordBaseAmount, ({ depthPrice }: PoolTableRowData) => depthPrice)
 
-export const getPoolTableRowsData = (
-  poolDetails: PoolDetails,
-  pricePool: PoolData,
+export const getPoolTableRowsData = ({
+  poolDetails,
+  pricePoolData,
+  poolStatus,
+  network
+}: {
+  poolDetails: PoolDetails
+  pricePoolData: PoolData
   poolStatus: PoolDetailStatusEnum
-): PoolTableRowsData => {
+  network: Network
+}): PoolTableRowsData => {
   // filter pool details
   const filteredPoolDetails: PoolDetails = FP.pipe(
     poolDetails,
@@ -54,7 +61,7 @@ export const getPoolTableRowsData = (
         )
       )
       return {
-        ...getPoolTableRowData(poolDetail, pricePool),
+        ...getPoolTableRowData({ poolDetail, pricePoolData, network }),
         key: poolDetail?.asset || index.toString(),
         deepest
       }

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -41,7 +41,9 @@ const common: CommonMessages = {
   'common.max': 'Max',
   'common.search': 'Suche',
   'common.retry': 'Wiederholen',
-  'common.add': 'Einzahlen'
+  'common.add': 'Einzahlen',
+  'common.swap': 'Swap',
+  'common.liquidity': 'Liquidität'
 }
 
 export default common

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -41,7 +41,9 @@ const common: CommonMessages = {
   'common.max': 'Max',
   'common.search': 'Search',
   'common.retry': 'Retry',
-  'common.add': 'Add'
+  'common.add': 'Add',
+  'common.swap': 'Swap',
+  'common.liquidity': 'Liquidity'
 }
 
 export default common

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -41,7 +41,9 @@ const common: CommonMessages = {
   'common.max': 'Макс.',
   'common.search': 'Поиск',
   'common.retry': 'Повторить',
-  'common.add': 'Добавить'
+  'common.add': 'Добавить',
+  'common.swap': 'Swap - RU',
+  'common.liquidity': 'Liquidity - RU'
 }
 
 export default common

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -42,8 +42,8 @@ const common: CommonMessages = {
   'common.search': 'Поиск',
   'common.retry': 'Повторить',
   'common.add': 'Добавить',
-  'common.swap': 'Swap - RU',
-  'common.liquidity': 'Liquidity - RU'
+  'common.swap': 'Обмен',
+  'common.liquidity': 'Ликвиидиность'
 }
 
 export default common

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -40,6 +40,8 @@ type CommonMessageKey =
   | 'common.search'
   | 'common.retry'
   | 'common.add'
+  | 'common.swap'
+  | 'common.liquidity'
 
 export type CommonMessages = {
   [key in CommonMessageKey]: string

--- a/src/renderer/services/binance/utils.test.ts
+++ b/src/renderer/services/binance/utils.test.ts
@@ -1,5 +1,5 @@
 import { Balances } from '@thorchain/asgardex-binance'
-import { assetToBase, assetAmount, PoolData, EMPTY_ASSET, baseAmount, assetFromString } from '@thorchain/asgardex-util'
+import { Asset, assetToBase, assetAmount, PoolData, baseAmount, AssetBNB, AssetRune67C } from '@thorchain/asgardex-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
@@ -26,7 +26,7 @@ describe('services/binance/utils/', () => {
       const balance: AssetWithBalance = {
         amount: baseAmount('1'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.BNB') || EMPTY_ASSET
+        asset: AssetBNB
       }
       const result = FP.pipe(
         getPoolPriceValue(balance, poolDetails, usdPool),
@@ -42,7 +42,7 @@ describe('services/binance/utils/', () => {
       const balance: AssetWithBalance = {
         amount: baseAmount('1'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.RUNE-67C') || EMPTY_ASSET
+        asset: AssetRune67C
       }
       const result = FP.pipe(
         getPoolPriceValue(balance, [], usdPool),
@@ -58,7 +58,7 @@ describe('services/binance/utils/', () => {
       const balance: AssetWithBalance = {
         amount: baseAmount('1'),
         frozenAmount: O.none,
-        asset: assetFromString('BNB.BNB') || EMPTY_ASSET
+        asset: AssetBNB
       }
       const result = getPoolPriceValue(balance, [], usdPool)
       expect(result).toBeNone()
@@ -76,7 +76,7 @@ describe('services/binance/utils/', () => {
     it('creates a RUNE `Asset`', () => {
       const result = FP.pipe(
         bncSymbolToAsset('RUNE-B1A'),
-        O.getOrElse(() => EMPTY_ASSET)
+        O.getOrElse(() => ({ chain: 'BNB', symbol: 'invalid', ticker: 'invalid' } as Asset))
       )
       expect(result).toEqual({
         chain: 'BNB',

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -1,5 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { assetFromString, bnOrZero, baseAmount, PoolData, EMPTY_ASSET } from '@thorchain/asgardex-util'
+import { assetFromString, bnOrZero, baseAmount, PoolData } from '@thorchain/asgardex-util'
 import * as FP from 'fp-ts/lib/function'
 import { head } from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -135,5 +135,5 @@ export const toPoolData = (detail: PoolDetail): PoolData => ({
  * Filter out mini tokens from pool assets
  */
 export const filterPoolAssets = (poolAssets: string[]) => {
-  return poolAssets.filter((poolAsset) => !isMiniToken(assetFromString(poolAsset) || EMPTY_ASSET))
+  return poolAssets.filter((poolAsset) => !isMiniToken(assetFromString(poolAsset) || { symbol: '' }))
 }

--- a/src/renderer/views/pools/types.ts
+++ b/src/renderer/views/pools/types.ts
@@ -1,6 +1,7 @@
 import { BaseAmount, PoolData, Asset } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import * as O from 'fp-ts/lib/Option'
 
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 
@@ -65,7 +66,7 @@ export type PricePool = {
 export type PricePools = NonEmptyArray<PricePool>
 
 export type PoolTableRowData = {
-  pool: Pool
+  pool: O.Option<Pool>
   depthPrice: BaseAmount
   volumePrice: BaseAmount
   transactionPrice: BaseAmount

--- a/src/renderer/views/pools/types.ts
+++ b/src/renderer/views/pools/types.ts
@@ -1,7 +1,6 @@
 import { BaseAmount, PoolData, Asset } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
-import * as O from 'fp-ts/lib/Option'
 
 import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 
@@ -66,7 +65,7 @@ export type PricePool = {
 export type PricePools = NonEmptyArray<PricePool>
 
 export type PoolTableRowData = {
-  pool: O.Option<Pool>
+  pool: Pool
   depthPrice: BaseAmount
   volumePrice: BaseAmount
   transactionPrice: BaseAmount

--- a/src/renderer/views/pools/util.test.ts
+++ b/src/renderer/views/pools/util.test.ts
@@ -1,10 +1,11 @@
-import { bn, assetAmount, PoolData, assetToBase } from '@thorchain/asgardex-util'
+import { bn, assetAmount, PoolData, assetToBase, AssetRune67C, assetToString } from '@thorchain/asgardex-util'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { ThorchainConstants, ThorchainLastblock } from '../../types/generated/midgard'
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard/models/PoolDetail'
-import { PoolTableRowData } from './types'
+import { Pool, PoolTableRowData } from './types'
 import { getPoolTableRowData, getBlocksLeftForPendingPool, getBlocksLeftForPendingPoolAsString } from './utils'
 
 describe('poolUtil', () => {
@@ -27,10 +28,10 @@ describe('poolUtil', () => {
 
     it('transforms data for a FTM pool', () => {
       const expected: PoolTableRowData = {
-        pool: {
-          asset: ASSETS_TESTNET.RUNE,
+        pool: O.some({
+          asset: AssetRune67C,
           target: ASSETS_TESTNET.FTM
-        },
+        }),
         poolPrice: assetToBase(assetAmount(2)),
         depthPrice: assetToBase(assetAmount(1000)),
         volumePrice: assetToBase(assetAmount(1000)),
@@ -42,10 +43,28 @@ describe('poolUtil', () => {
         key: 'hi'
       }
 
-      const result = getPoolTableRowData(lokPoolDetail, pricePoolData)
+      const poolAssetString = (oPool: O.Option<Pool>) =>
+        FP.pipe(
+          oPool,
+          O.map((pool) => assetToString(pool.asset)),
+          O.getOrElse(() => 'unknown')
+        )
+      const poolTargetString = (oPool: O.Option<Pool>) =>
+        FP.pipe(
+          oPool,
+          O.map((pool) => assetToString(pool.target)),
+          O.getOrElse(() => 'unknown')
+        )
 
-      expect(result.pool.asset).toEqual(expected.pool.asset)
-      expect(result.pool.target).toEqual(expected.pool.target)
+      const result = getPoolTableRowData({
+        poolDetail: lokPoolDetail,
+        pricePoolData: pricePoolData,
+        network: 'testnet'
+      })
+
+      expect(O.isSome(result.pool)).toBeTruthy()
+      expect(poolAssetString(result.pool)).toEqual(poolAssetString(expected.pool))
+      expect(poolTargetString(result.pool)).toEqual(poolTargetString(expected.pool))
       expect(result.depthPrice.amount().toNumber()).toEqual(expected.depthPrice.amount().toNumber())
       expect(result.volumePrice.amount().toNumber()).toEqual(expected.volumePrice.amount().toNumber())
       expect(result.transactionPrice.amount().toNumber()).toEqual(expected.transactionPrice.amount().toNumber())

--- a/src/renderer/views/pools/util.test.ts
+++ b/src/renderer/views/pools/util.test.ts
@@ -1,11 +1,11 @@
-import { bn, assetAmount, PoolData, assetToBase, AssetRune67C, assetToString } from '@thorchain/asgardex-util'
+import { bn, assetAmount, PoolData, assetToBase, AssetRune67C } from '@thorchain/asgardex-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { ThorchainConstants, ThorchainLastblock } from '../../types/generated/midgard'
 import { PoolDetail, PoolDetailStatusEnum } from '../../types/generated/midgard/models/PoolDetail'
-import { Pool, PoolTableRowData } from './types'
+import { PoolTableRowData } from './types'
 import { getPoolTableRowData, getBlocksLeftForPendingPool, getBlocksLeftForPendingPoolAsString } from './utils'
 
 describe('poolUtil', () => {
@@ -28,10 +28,10 @@ describe('poolUtil', () => {
 
     it('transforms data for a FTM pool', () => {
       const expected: PoolTableRowData = {
-        pool: O.some({
+        pool: {
           asset: AssetRune67C,
           target: ASSETS_TESTNET.FTM
-        }),
+        },
         poolPrice: assetToBase(assetAmount(2)),
         depthPrice: assetToBase(assetAmount(1000)),
         volumePrice: assetToBase(assetAmount(1000)),
@@ -43,33 +43,26 @@ describe('poolUtil', () => {
         key: 'hi'
       }
 
-      const poolAssetString = (oPool: O.Option<Pool>) =>
-        FP.pipe(
-          oPool,
-          O.map((pool) => assetToString(pool.asset)),
-          O.getOrElse(() => 'unknown')
-        )
-      const poolTargetString = (oPool: O.Option<Pool>) =>
-        FP.pipe(
-          oPool,
-          O.map((pool) => assetToString(pool.target)),
-          O.getOrElse(() => 'unknown')
-        )
-
       const result = getPoolTableRowData({
         poolDetail: lokPoolDetail,
         pricePoolData: pricePoolData,
         network: 'testnet'
       })
 
-      expect(O.isSome(result.pool)).toBeTruthy()
-      expect(poolAssetString(result.pool)).toEqual(poolAssetString(expected.pool))
-      expect(poolTargetString(result.pool)).toEqual(poolTargetString(expected.pool))
-      expect(result.depthPrice.amount().toNumber()).toEqual(expected.depthPrice.amount().toNumber())
-      expect(result.volumePrice.amount().toNumber()).toEqual(expected.volumePrice.amount().toNumber())
-      expect(result.transactionPrice.amount().toNumber()).toEqual(expected.transactionPrice.amount().toNumber())
-      expect(result.slip.toNumber()).toEqual(expected.slip.toNumber())
-      expect(result.trades.toNumber()).toEqual(expected.trades.toNumber())
+      expect(O.isSome(result)).toBeTruthy()
+      FP.pipe(
+        result,
+        O.map((data) => {
+          expect(data.pool).toEqual(expected.pool)
+          expect(data.pool).toEqual(expected.pool)
+          expect(data.depthPrice.amount().toNumber()).toEqual(expected.depthPrice.amount().toNumber())
+          expect(data.volumePrice.amount().toNumber()).toEqual(expected.volumePrice.amount().toNumber())
+          expect(data.transactionPrice.amount().toNumber()).toEqual(expected.transactionPrice.amount().toNumber())
+          expect(data.slip.toNumber()).toEqual(expected.slip.toNumber())
+          expect(data.trades.toNumber()).toEqual(expected.trades.toNumber())
+          return true
+        })
+      )
     })
   })
 

--- a/src/shared/mock/assets.ts
+++ b/src/shared/mock/assets.ts
@@ -1,6 +1,4 @@
-import { Asset } from '@thorchain/asgardex-util'
-
-import { RUNE_SYMBOL_MAINNET, RUNE_SYMBOL_TESTNET, BNB_SYMBOL } from '../../renderer/helpers/assetHelper'
+import { Asset, AssetBNB, AssetRune67C, AssetRuneB1A } from '@thorchain/asgardex-util'
 
 type Assets = 'RUNE' | 'BNB' | 'FTM' | 'TOMO' | 'BOLT'
 
@@ -8,16 +6,16 @@ type AssetsTestnet = Record<Assets, Asset>
 type AssetsMainnet = Record<Assets, Asset>
 
 export const ASSETS_TESTNET: AssetsTestnet = {
-  RUNE: { chain: 'BNB', symbol: RUNE_SYMBOL_TESTNET, ticker: 'RUNE' },
-  BNB: { chain: 'BNB', symbol: BNB_SYMBOL, ticker: 'BNB' },
+  RUNE: AssetRuneB1A,
+  BNB: AssetBNB,
   FTM: { chain: 'BNB', symbol: 'FTM-585', ticker: 'FTM' },
   TOMO: { chain: 'BNB', symbol: 'TOMOB-1E1', ticker: 'TOMOB' },
   BOLT: { chain: 'BNB', symbol: 'BOLT-E42', ticker: 'BOLT' }
 }
 
 export const ASSETS_MAINNET: AssetsMainnet = {
-  RUNE: { chain: 'BNB', symbol: RUNE_SYMBOL_MAINNET, ticker: 'RUNE' },
-  BNB: { chain: 'BNB', symbol: BNB_SYMBOL, ticker: 'BNB' },
+  RUNE: AssetRune67C,
+  BNB: AssetBNB,
   FTM: { chain: 'BNB', symbol: 'FTM-A64', ticker: 'FTM' },
   TOMO: { chain: 'BNB', symbol: 'TOMOB-4BC', ticker: 'TOMOB' },
   BOLT: { chain: 'BNB', symbol: 'BOLT-4C6', ticker: 'BOLT' }


### PR DESCRIPTION
All changes are needed for type-safety multi-chain support.

- [x] Get rid of `EMPTY_ASSET` ([it will be removed](https://gitlab.com/thorchain/asgardex-common/asgardex-util/-/issues/12) from `asgardex-util`, to provide `Asset` based on supported chains only)
- [x] Removet use `dataIndex` in table of `PoolsOverview` - it's just unsafe!
- [x] Use `AssetXYZ` provided by `asgardex-util` only
- [x] `getPoolTableRowData` returns `O.Option<PoolTableRowData>` (before `PoolTableRowData`) to get rid invalid (empty) assets
- [x] Few i18n updates
- [x] Update tests