### PR TITLE
Fix cached value of previous balances in `AssetDetail`.

### DIFF
--- a/src/renderer/components/uielements/assets/AssetInfo/Component.tsx
+++ b/src/renderer/components/uielements/assets/AssetInfo/Component.tsx
@@ -51,8 +51,8 @@ const Component: React.FC<Props> = (props): JSX.Element => {
           ([assetsWB, asset]) =>
             FP.pipe(
               getAssetAmountByAsset(assetsWB, asset),
+              // save latest amount (if available only)
               O.map((amount) => {
-                // save latest amount
                 previousBalance.current = O.some(amount)
                 return amount
               }),
@@ -60,7 +60,7 @@ const Component: React.FC<Props> = (props): JSX.Element => {
               // because `assetsWB` is loaded in parallel for all assets of different chains
               O.alt(() => previousBalance.current),
               O.map((amount) => formatAssetAmount({ amount, trimZeros: true })),
-              O.getOrElse(() => '')
+              O.getOrElse(() => loadingString)
             )
         )
       ),

--- a/src/renderer/components/uielements/assets/AssetInfo/Component.tsx
+++ b/src/renderer/components/uielements/assets/AssetInfo/Component.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useRef } from 'react'
 
-import { Asset, formatAssetAmount, assetToString } from '@thorchain/asgardex-util'
+import { Asset, formatAssetAmount, assetToString, AssetAmount } from '@thorchain/asgardex-util'
 import { Grid } from 'antd'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { sequenceTOption } from '../../../../helpers/fpHelpers'
+import { loadingString } from '../../../../helpers/stringHelper'
 import { getAssetAmountByAsset } from '../../../../helpers/walletHelper'
 import { NonEmptyAssetsWithBalance } from '../../../../services/wallet/types'
 import AssetIcon from '../assetIcon'
@@ -22,38 +23,68 @@ type Props = {
 const Component: React.FC<Props> = (props): JSX.Element => {
   const { assetsWB = O.none, asset: oAsset } = props
 
-  const asset = O.toNullable(oAsset)
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
 
-  // TODO (@Veado): Improve caching of previous loaded data
-  // https://github.com/thorchain/asgardex-electron/issues/286
-  const previousBalance = useRef<string>('--')
+  const previousBalance = useRef<O.Option<AssetAmount>>(O.none)
 
-  const renderAssetIcon = useMemo(() => asset && <AssetIcon asset={asset} size="large" />, [asset])
+  const renderAssetIcon = useMemo(
+    () =>
+      FP.pipe(
+        oAsset,
+        O.map((asset) => <AssetIcon asset={asset} size="large" key={assetToString(asset)} />),
+        O.getOrElse(() => <></>)
+      ),
+    [oAsset]
+  )
 
-  const renderBalance = useMemo(() => {
-    if (O.isNone(assetsWB)) return React.Fragment
-
-    return FP.pipe(
-      sequenceTOption(assetsWB, oAsset),
-      O.fold(
-        () => previousBalance.current,
-        ([assetsWB, asset]) => {
-          const amount = getAssetAmountByAsset(assetsWB, asset)
-          const balance = formatAssetAmount({ amount, trimZeros: true })
-          previousBalance.current = balance
-          return balance
-        }
-      )
-    )
-  }, [oAsset, assetsWB])
+  const renderBalance = useMemo(
+    () =>
+      FP.pipe(
+        sequenceTOption(assetsWB, oAsset),
+        O.fold(
+          () =>
+            FP.pipe(
+              previousBalance.current,
+              O.map((amount) => formatAssetAmount({ amount, trimZeros: true })),
+              O.getOrElse(() => loadingString)
+            ),
+          ([assetsWB, asset]) =>
+            FP.pipe(
+              getAssetAmountByAsset(assetsWB, asset),
+              O.map((amount) => {
+                // save latest amount
+                previousBalance.current = O.some(amount)
+                return amount
+              }),
+              // use previous stored balances if amount is not available,
+              // because `assetsWB` is loaded in parallel for all assets of different chains
+              O.alt(() => previousBalance.current),
+              O.map((amount) => formatAssetAmount({ amount, trimZeros: true })),
+              O.getOrElse(() => '')
+            )
+        )
+      ),
+    [oAsset, assetsWB]
+  )
 
   return (
     <Styled.Card bordered={false} bodyStyle={{ display: 'flex', flexDirection: 'row' }}>
       {renderAssetIcon}
       <Styled.CoinInfoWrapper>
-        <Styled.CoinTitle>{asset?.ticker ?? '--'}</Styled.CoinTitle>
-        <Styled.CoinSubtitle>{asset ? assetToString(asset) : '--'}</Styled.CoinSubtitle>
+        <Styled.CoinTitle>
+          {FP.pipe(
+            oAsset,
+            O.map(({ ticker }) => ticker),
+            O.getOrElse(() => loadingString)
+          )}
+        </Styled.CoinTitle>
+        <Styled.CoinSubtitle>
+          {FP.pipe(
+            oAsset,
+            O.map(assetToString),
+            O.getOrElse(() => loadingString)
+          )}
+        </Styled.CoinSubtitle>
         {!isDesktopView && <Styled.CoinMobilePrice>{renderBalance}</Styled.CoinMobilePrice>}
       </Styled.CoinInfoWrapper>
       {isDesktopView && <Styled.CoinPrice>{renderBalance}</Styled.CoinPrice>}

--- a/src/renderer/components/wallet/assets/AssetDetails.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.tsx
@@ -38,8 +38,8 @@ const AssetDetails: React.FC<Props> = (props): JSX.Element => {
   const {
     txsRD,
     address,
-    assetsWB,
-    asset,
+    assetsWB: oAssetsWB,
+    asset: oAsset,
     reloadBalancesHandler = () => {},
     loadSelectedAssetTxsHandler = (_: LoadTxsProps) => {},
     explorerUrl = O.none
@@ -51,14 +51,14 @@ const AssetDetails: React.FC<Props> = (props): JSX.Element => {
   const assetAsString = useMemo(
     () =>
       FP.pipe(
-        asset,
+        oAsset,
         O.map((a) => assetToString(a)),
         O.getOrElse(() => '')
       ),
-    [asset]
+    [oAsset]
   )
 
-  const isRuneAsset = useMemo(() => FP.pipe(asset, O.filter(AH.isRuneAsset), O.isSome), [asset])
+  const isRuneAsset = useMemo(() => FP.pipe(oAsset, O.filter(AH.isRuneAsset), O.isSome), [oAsset])
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
   const history = useHistory()
   const intl = useIntl()
@@ -162,7 +162,7 @@ const AssetDetails: React.FC<Props> = (props): JSX.Element => {
       </Row>
       <Row>
         <Col span={24}>
-          <AssetInfo asset={asset} assetsWB={assetsWB} />
+          <AssetInfo asset={oAsset} assetsWB={oAssetsWB} />
         </Col>
 
         <Styled.Divider />

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -3,12 +3,13 @@ import React, { createContext, useContext } from 'react'
 import * as O from 'fp-ts/lib/Option'
 import { none, Option, some } from 'fp-ts/lib/Option'
 
-import { reloadBalances, assetsWBState$, assetsWBChains$ } from '../services/wallet/balances'
+import { reloadBalances, assetsWBState$, assetsWBChains$, reloadBalancesByChain } from '../services/wallet/balances'
 import { keystoreService } from '../services/wallet/service'
 
 type WalletContextValue = {
   keystoreService: typeof keystoreService
   reloadBalances: typeof reloadBalances
+  reloadBalancesByChain: typeof reloadBalancesByChain
   assetsWBState$: typeof assetsWBState$
   assetsWBChains$: typeof assetsWBChains$
 }
@@ -16,6 +17,7 @@ type WalletContextValue = {
 const initialContext: WalletContextValue = {
   keystoreService,
   reloadBalances,
+  reloadBalancesByChain,
   assetsWBState$,
   assetsWBChains$
 }

--- a/src/renderer/helpers/stringHelper.ts
+++ b/src/renderer/helpers/stringHelper.ts
@@ -25,3 +25,4 @@ export const compareShallowStr = (str1: string, str2: string): boolean => {
 }
 
 export const emptyString = ''
+export const loadingString = '...'

--- a/src/renderer/helpers/walletHelper.test.ts
+++ b/src/renderer/helpers/walletHelper.test.ts
@@ -16,15 +16,21 @@ describe('walletHelper', () => {
   describe('amountByAsset', () => {
     it('returns amount of RUNE', () => {
       const result = getAssetAmountByAsset([RUNE_WB, BOLT_WB, BNB_WB], ASSETS_TESTNET.RUNE)
-      expect(result.amount().toNumber()).toEqual(123)
+      expect(
+        FP.pipe(
+          result,
+          O.map((a) => a.amount().toNumber()),
+          O.getOrElse(() => NaN)
+        )
+      ).toEqual(123)
     })
-    it('returns 0 for an unknown asset', () => {
+    it('returns None for an unknown asset', () => {
       const result = getAssetAmountByAsset([RUNE_WB, BNB_WB], ASSETS_TESTNET.FTM)
-      expect(result.amount().toNumber()).toEqual(0)
+      expect(result).toBeNone()
     })
-    it('returns 0 for an empty list of assets', () => {
+    it('returns None for an empty list of assets', () => {
       const result = getAssetAmountByAsset([], ASSETS_TESTNET.FTM)
-      expect(result.amount().toNumber()).toEqual(0)
+      expect(result).toBeNone()
     })
   })
 

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -3,17 +3,22 @@ import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
-import { ZERO_ASSET_AMOUNT } from '../const'
 import { NonEmptyAssetsWithBalance, AssetWithBalance, AssetsWithBalance } from '../services/wallet/types'
 import { isBnbAsset } from './assetHelper'
+import { eqAsset } from './fp/eq'
 import { sequenceTOption } from './fpHelpers'
 
-export const getAssetAmountByAsset = (balances: AssetsWithBalance, assetToFind: Asset): AssetAmount =>
+/**
+ * Tries to find an `AssetAmount` of an `Asset`
+ * in a given list of `AssetWithBalance`
+ *
+ * Note: Returns `None` if `Asset` has not been found this list.
+ * */
+export const getAssetAmountByAsset = (balances: AssetsWithBalance, assetToFind: Asset): O.Option<AssetAmount> =>
   FP.pipe(
     balances,
-    A.findFirst(({ asset }) => asset.symbol === assetToFind.symbol),
-    O.map((b) => baseToAsset(b.amount)),
-    O.getOrElse(() => ZERO_ASSET_AMOUNT)
+    A.findFirst(({ asset }) => eqAsset.equals(asset, assetToFind)),
+    O.map((assetWB) => baseToAsset(assetWB.amount))
   )
 
 export const getAssetWBByAsset = (

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -1,5 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { AssetBNB } from '@thorchain/asgardex-util'
+import { AssetBNB, Chain } from '@thorchain/asgardex-util'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
@@ -24,6 +24,25 @@ const reloadBalances = () => {
   BTC.reloadBalances()
   BNB.reloadBalances()
   ETH.reloadBalances()
+}
+
+const reloadBalancesByChain = (chain: Chain) => {
+  switch (chain) {
+    case 'BNB':
+      BNB.reloadBalances()
+      break
+    case 'BTC':
+      BTC.reloadBalances()
+      break
+    case 'ETH':
+      ETH.reloadBalances()
+      break
+    case 'THOR':
+      // reload THOR balances - not available yet
+      break
+    default:
+    // nothing to do
+  }
 }
 
 /**
@@ -130,4 +149,4 @@ const assetsWBState$: Observable<AssetsWithBalanceState> = Rx.combineLatest([
   startWith(INITIAL_ASSETS_WB_STATE)
 )
 
-export { reloadBalances, assetsWBState$, assetsWBChains$ }
+export { reloadBalances, reloadBalancesByChain, assetsWBState$, assetsWBChains$ }

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { assetFromString } from '@thorchain/asgardex-util'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useParams } from 'react-router-dom'
@@ -14,7 +15,7 @@ import { INITIAL_ASSETS_WB_STATE } from '../../services/wallet/const'
 
 const AssetDetailsView: React.FC = (): JSX.Element => {
   const { txsSelectedAsset$, address$, loadTxsSelectedAsset, explorerUrl$, setSelectedAsset } = useBinanceContext()
-  const { assetsWBState$, reloadBalances } = useWalletContext()
+  const { assetsWBState$, reloadBalancesByChain } = useWalletContext()
 
   const { asset } = useParams<AssetDetailsParams>()
   const selectedAsset = O.fromNullable(assetFromString(asset))
@@ -24,6 +25,12 @@ const AssetDetailsView: React.FC = (): JSX.Element => {
   const { assetsWB } = useObservableState(assetsWBState$, INITIAL_ASSETS_WB_STATE)
 
   const explorerUrl = useObservableState(explorerUrl$, O.none)
+
+  const reloadBalancesHandler = FP.pipe(
+    selectedAsset,
+    O.map(({ chain }) => () => reloadBalancesByChain(chain)),
+    O.toUndefined
+  )
 
   // Set selected asset to trigger dependent streams to get all needed data (such as its transactions)
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -37,7 +44,7 @@ const AssetDetailsView: React.FC = (): JSX.Element => {
         assetsWB={assetsWB}
         asset={selectedAsset}
         loadSelectedAssetTxsHandler={loadTxsSelectedAsset}
-        reloadBalancesHandler={reloadBalances}
+        reloadBalancesHandler={reloadBalancesHandler}
         explorerUrl={explorerUrl}
       />
     </>


### PR DESCRIPTION
**Some background:** 

A cached value was already stored as a `Ref`, but it was not used while re-loading balances of all assets of users wallet. Because the balances are loaded in parallel and the result comes step by step in `assetsWBState$` stream, in some cases we got balances for other assets only, but not for the selected asset. In this case we displayed just a value of `ZERO_ASSET_AMOUNT`, but that's not correct. 

The fix is pretty simple (but it was not easy to find): Check if selected asset is in latest loaded balances - if not, use cached value as long as we have all balances loaded from all chains. 

Close #498 