### PR TITLE
Refactor UI to support multi-chain txs history 

### DIFF
--- a/src/renderer/components/wallet/TransactionsTable.stories.tsx
+++ b/src/renderer/components/wallet/TransactionsTable.stories.tsx
@@ -3,14 +3,10 @@ import React from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { storiesOf } from '@storybook/react'
 import { Tx } from '@thorchain/asgardex-binance'
-import * as O from 'fp-ts/lib/Option'
 
-import TransactionsTable from './TransactionsTable'
+import TxsHistoryTableBNB from './txs/history/TxsHistoryTableBNB'
 
 storiesOf('Wallet/TransactionsTable', module).add('default', () => {
-  const address = 'tbnb13egw96d95lldrhwu56dttrpn2fth6cs0axzaad'
-  const oAddress = O.some(address)
-
   const tx: Tx = {
     blockHeight: 91158744,
     code: 0,
@@ -38,9 +34,8 @@ storiesOf('Wallet/TransactionsTable', module).add('default', () => {
   })
 
   return (
-    <TransactionsTable
+    <TxsHistoryTableBNB
       txsRD={txsRD}
-      address={oAddress}
       clickTxLinkHandler={(txHash: string) => console.log('txHash ', txHash)}
       changePaginationHandler={(page: number) => console.log('page:', page)}
     />

--- a/src/renderer/components/wallet/txs/history/TxsHistory.style.tsx
+++ b/src/renderer/components/wallet/txs/history/TxsHistory.style.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+import UIHeadline from '../../../uielements/headline'
+
+type TableHeadlineProps = {
+  isDesktop: boolean
+}
+
+export const TableHeadline = styled(UIHeadline)`
+  padding: 40px 0 20px 0;
+  width: 100%;
+  text-align: ${({ isDesktop }: TableHeadlineProps) => (isDesktop ? 'left' : 'center')};
+`

--- a/src/renderer/components/wallet/txs/history/TxsHistoryBNB.tsx
+++ b/src/renderer/components/wallet/txs/history/TxsHistoryBNB.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback, useState } from 'react'
+
+import { Row, Col, Grid } from 'antd'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import { useIntl } from 'react-intl'
+
+import { TxsRD, LoadTxsProps } from '../../../../services/binance/types'
+import { MAX_PAGINATION_ITEMS } from '../../../../services/const'
+import * as Styled from './TxsHistory.style'
+import TxsHistoryTableBNB from './TxsHistoryTableBNB'
+
+type Props = {
+  txsRD: TxsRD
+  explorerUrl?: O.Option<string>
+  reloadTxsHistoryHandler?: (_: LoadTxsProps) => void
+}
+
+const TxsHistoryBNB: React.FC<Props> = (props): JSX.Element => {
+  const { txsRD, reloadTxsHistoryHandler: reloadTxsHandler = (_: LoadTxsProps) => {}, explorerUrl = O.none } = props
+
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const isDesktopView = Grid.useBreakpoint()?.lg ?? false
+  const intl = useIntl()
+
+  const _refreshHandler = useCallback(() => {
+    reloadTxsHandler({ limit: MAX_PAGINATION_ITEMS, offset: (currentPage - 1) * MAX_PAGINATION_ITEMS })
+  }, [currentPage, reloadTxsHandler])
+
+  const clickTxLinkHandler = useCallback(
+    (txHash: string) => {
+      FP.pipe(
+        explorerUrl,
+        O.map((url) => window.apiUrl.openExternal(`${url}/tx/${txHash}`))
+      )
+    },
+    [explorerUrl]
+  )
+
+  const onChangePagination = useCallback(
+    (pageNo) => {
+      reloadTxsHandler({ limit: MAX_PAGINATION_ITEMS, offset: (pageNo - 1) * MAX_PAGINATION_ITEMS })
+      setCurrentPage(pageNo)
+    },
+    [reloadTxsHandler]
+  )
+
+  return (
+    <Row>
+      <Col span={24}>
+        <Styled.TableHeadline isDesktop={isDesktopView}>
+          {intl.formatMessage({ id: 'wallet.txs.last90days' })}
+        </Styled.TableHeadline>
+      </Col>
+      <Col span={24}>
+        <TxsHistoryTableBNB
+          txsRD={txsRD}
+          clickTxLinkHandler={clickTxLinkHandler}
+          changePaginationHandler={onChangePagination}
+        />
+      </Col>
+    </Row>
+  )
+}
+export default TxsHistoryBNB

--- a/src/renderer/components/wallet/txs/history/TxsHistoryTableBNB.tsx
+++ b/src/renderer/components/wallet/txs/history/TxsHistoryTableBNB.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback, useRef } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Txs, Tx, Address, TxPage } from '@thorchain/asgardex-binance'
+import { Txs, Tx, TxPage } from '@thorchain/asgardex-binance'
 import { assetAmount, bnOrZero, formatAssetAmount } from '@thorchain/asgardex-util'
 import { Grid, Col, Row } from 'antd'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
@@ -9,19 +9,18 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl, FormattedDate, FormattedTime } from 'react-intl'
 
-import { TxsRD } from '../../services/binance/types'
-import { MAX_PAGINATION_ITEMS } from '../../services/const'
-import ErrorView from '../shared/error/ErrorView'
-import Pagination from '../uielements/Pagination'
-import * as Styled from './TransactionTable.style'
+import { TxsRD } from '../../../../services/binance/types'
+import { MAX_PAGINATION_ITEMS } from '../../../../services/const'
+import ErrorView from '../../../shared/error/ErrorView'
+import Pagination from '../../../uielements/Pagination'
+import * as Styled from '../../TransactionTable.style'
 
 type Props = {
   txsRD: TxsRD
-  address: O.Option<Address>
   clickTxLinkHandler: (txHash: string) => void
   changePaginationHandler: (page: number) => void
 }
-const TransactionsTable: React.FC<Props> = (props): JSX.Element => {
+const TxsHistoryTableBNB: React.FC<Props> = (props): JSX.Element => {
   const { txsRD, clickTxLinkHandler, changePaginationHandler } = props
   const intl = useIntl()
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
@@ -185,4 +184,4 @@ const TransactionsTable: React.FC<Props> = (props): JSX.Element => {
 
   return renderContent
 }
-export default TransactionsTable
+export default TxsHistoryTableBNB

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -13,8 +13,7 @@ import { AssetWithBalanceRD, AssetWithBalance, ApiError, ErrorId } from '../wall
 import { client$ } from './common'
 
 /**
- * Observable to load balances from Binance API endpoint
- * If client is not available, it returns an `initial` state
+ * Observable to load BTC balances
  */
 const loadBalances$ = (client: BitcoinClient): Observable<AssetWithBalanceRD> =>
   Rx.from(client.getBalance()).pipe(

--- a/src/renderer/services/wallet/transactions.ts
+++ b/src/renderer/services/wallet/transactions.ts
@@ -1,0 +1,152 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { AssetBNB, Chain } from '@thorchain/asgardex-util'
+import * as A from 'fp-ts/lib/Array'
+import * as FP from 'fp-ts/lib/function'
+import * as NEA from 'fp-ts/lib/NonEmptyArray'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
+import { Observable } from 'rxjs'
+import { map, startWith } from 'rxjs/operators'
+
+import { getRuneAsset } from '../../helpers/assetHelper'
+import { eqAssetsWithBalanceRD } from '../../helpers/fp/eq'
+import { sequenceTOptionFromArray } from '../../helpers/fpHelpers'
+import { liveData } from '../../helpers/rx/liveData'
+import { network$ } from '../app/service'
+import * as BNB from '../binance/service'
+import * as BTC from '../bitcoin'
+import * as ETH from '../ethereum/service'
+import { INITIAL_ASSETS_WB_STATE } from './const'
+import { AssetsWBChain, AssetsWithBalanceRD, AssetsWithBalanceState } from './types'
+import { sortBalances } from './util'
+
+const reloadBalances = () => {
+  BTC.reloadBalances()
+  BNB.reloadBalances()
+  ETH.reloadBalances()
+}
+
+const reloadBalancesByChain = (chain: Chain) => {
+  switch (chain) {
+    case 'BNB':
+      BNB.reloadBalances()
+      break
+    case 'BTC':
+      BTC.reloadBalances()
+      break
+    case 'ETH':
+      ETH.reloadBalances()
+      break
+    case 'THOR':
+      // reload THOR balances - not available yet
+      break
+    default:
+    // nothing to do
+  }
+}
+
+/**
+ * Transforms BNB data (address + `AssetsWB`) into `AssetsWBChain`
+ */
+const bnbAssetsWBChain$: Observable<AssetsWBChain> = Rx.combineLatest([BNB.address$, BNB.assetsWB$, network$]).pipe(
+  map(
+    ([address, assetsWB, network]) =>
+      ({
+        chain: 'BNB',
+        address: FP.pipe(
+          address,
+          O.getOrElse(() => '')
+        ),
+        assetsWB: FP.pipe(
+          assetsWB,
+          RD.map((assets) => sortBalances(assets, [AssetBNB.ticker, getRuneAsset({ network, chain: 'BNB' }).ticker]))
+        )
+      } as AssetsWBChain)
+  )
+)
+
+/**
+ * Transforms BTC data (address + `AssetWB`) into `AssetsWBChain`
+ */
+const btcAssetsWBChain$: Observable<AssetsWBChain> = Rx.combineLatest([BTC.address$, BTC.assetWB$]).pipe(
+  map(
+    ([address, assetWB]) =>
+      ({
+        chain: 'BTC',
+        address: FP.pipe(
+          address,
+          O.getOrElse(() => '')
+        ),
+        assetsWB: FP.pipe(
+          assetWB,
+          RD.map((assets) => [assets])
+        )
+      } as AssetsWBChain)
+  )
+)
+
+/**
+ * Transforms ETH data (address + `AssetsWBChain`) into `AssetsWBChain`
+ */
+const ethAssetsWBChain$: Observable<AssetsWBChain> = Rx.combineLatest([ETH.address$, ETH.assetWB$]).pipe(
+  map(
+    ([address, assetWBRD]) =>
+      ({
+        chain: 'ETH',
+        address: FP.pipe(
+          address,
+          O.getOrElse(() => '')
+        ),
+        assetsWB: FP.pipe(
+          assetWBRD,
+          RD.map((assetWB) => [assetWB])
+        )
+      } as AssetsWBChain)
+  )
+)
+
+/**
+ * List of `AssetsWBChain` for all available chains (order is important)
+ */
+const assetsWBChains$ = Rx.combineLatest([btcAssetsWBChain$, ethAssetsWBChain$, bnbAssetsWBChain$])
+
+// Map single `AssetWB` into `[AssetsWB]`
+const btcAssetsWB$: Observable<AssetsWithBalanceRD> = BTC.assetWB$.pipe(liveData.map((asset) => [asset]))
+const ethAssetsWB$: Observable<AssetsWithBalanceRD> = ETH.assetWB$.pipe(liveData.map((asset) => [asset]))
+
+/**
+ * Transform a list of AssetsWithBalanceRD
+ * into a "single" state of `AssetsWithBalanceState`
+ * Because we need to have loading / error / data combined in one "state" object in some cases
+ */
+const assetsWBState$: Observable<AssetsWithBalanceState> = Rx.combineLatest([
+  BNB.assetsWB$,
+  btcAssetsWB$,
+  ethAssetsWB$
+]).pipe(
+  map((assetsWBList) => ({
+    assetsWB: FP.pipe(
+      assetsWBList,
+      // filter results out
+      // Transformation: RD<Error, AssetsWithBalance>`-> `AssetsWithBalance)[]`
+      A.filterMap(RD.toOption),
+      A.flatten,
+      NEA.fromArray
+    ),
+    loading: FP.pipe(assetsWBList, A.elem(eqAssetsWithBalanceRD)(RD.pending)),
+    errors: FP.pipe(
+      assetsWBList,
+      // filter errors out
+      A.filter(RD.isFailure),
+      // Transformation to get Errors out of RD:
+      // `RemoteData<Error, never>[]` -> `RemoteData<never, Error>[]` -> `O.some(Error)[]`
+      A.map(FP.flow(RD.recover(O.some), RD.toOption)),
+      // Transformation: `O.some(Error)[]` -> `O.some(Error[])`
+      sequenceTOptionFromArray,
+      O.chain(NEA.fromArray)
+    )
+  })),
+  startWith(INITIAL_ASSETS_WB_STATE)
+)
+
+export { reloadBalances, reloadBalancesByChain, assetsWBState$, assetsWBChains$ }

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -1,27 +1,30 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { assetFromString } from '@thorchain/asgardex-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
+import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
 
 import AssetDetails from '../../components/wallet/assets/AssetDetails'
+import TxsHistoryBNB from '../../components/wallet/txs/history/TxsHistoryBNB'
 import { useBinanceContext } from '../../contexts/BinanceContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import { AssetDetailsParams } from '../../routes/wallet'
 import { INITIAL_ASSETS_WB_STATE } from '../../services/wallet/const'
 
 const AssetDetailsView: React.FC = (): JSX.Element => {
-  const { txsSelectedAsset$, address$, loadTxsSelectedAsset, explorerUrl$, setSelectedAsset } = useBinanceContext()
+  const intl = useIntl()
+
+  const { txsSelectedAsset$, explorerUrl$, setSelectedAsset } = useBinanceContext()
   const { assetsWBState$, reloadBalancesByChain } = useWalletContext()
 
   const { asset } = useParams<AssetDetailsParams>()
   const selectedAsset = O.fromNullable(assetFromString(asset))
 
   const txsRD = useObservableState(txsSelectedAsset$, RD.initial)
-  const address = useObservableState(address$, O.none)
   const { assetsWB } = useObservableState(assetsWBState$, INITIAL_ASSETS_WB_STATE)
 
   const explorerUrl = useObservableState(explorerUrl$, O.none)
@@ -36,17 +39,44 @@ const AssetDetailsView: React.FC = (): JSX.Element => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setSelectedAsset(selectedAsset), [])
 
+  const renderTxsHistoryBNB = useMemo(() => {
+    return <TxsHistoryBNB txsRD={txsRD} explorerUrl={explorerUrl} />
+  }, [explorerUrl, txsRD])
+
+  const renderTxHistory = useMemo(
+    () =>
+      FP.pipe(
+        selectedAsset,
+        O.map(({ chain }) => {
+          switch (chain) {
+            case 'BNB':
+              return renderTxsHistoryBNB
+            case 'BTC':
+              return <h1>Txs history BTC</h1>
+            case 'ETH':
+              return <h1>Txs history ETH</h1>
+            default:
+              return (
+                <h1>
+                  {intl.formatMessage(
+                    { id: 'wallet.errors.invalidChain' },
+                    {
+                      chain: chain
+                    }
+                  )}
+                </h1>
+              )
+          }
+        }),
+        O.getOrElse(() => <></>)
+      ),
+    [intl, renderTxsHistoryBNB, selectedAsset]
+  )
+
   return (
     <>
-      <AssetDetails
-        txsRD={txsRD}
-        address={address}
-        assetsWB={assetsWB}
-        asset={selectedAsset}
-        loadSelectedAssetTxsHandler={loadTxsSelectedAsset}
-        reloadBalancesHandler={reloadBalancesHandler}
-        explorerUrl={explorerUrl}
-      />
+      <AssetDetails assetsWB={assetsWB} asset={selectedAsset} reloadBalancesHandler={reloadBalancesHandler} />
+      {renderTxHistory}
     </>
   )
 }


### PR DESCRIPTION
Currently we support transaction history for assets of BNC only, but we do need to support other chains as well (next will be BTC).

Needed for #501 