### PR TITLE
Add `liquidity units` to `PoolShare`

### DIFF
--- a/src/renderer/components/uielements/poolShare/PoolCard.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BaseAmount, baseToAsset, formatAssetAmount } from '@thorchain/asgardex-util'
+import { Asset, BaseAmount, baseToAsset, formatAssetAmount } from '@thorchain/asgardex-util'
 import { Col } from 'antd'
 
 import Label from '../label'
@@ -8,8 +8,8 @@ import * as Styled from './Poolcard.style'
 
 type PoolCardProps = {
   title: string
-  source: string
-  target: string
+  sourceAsset: Asset
+  targetAsset: Asset
   runeAmount: BaseAmount
   runePrice: BaseAmount
   assetAmount: BaseAmount
@@ -23,8 +23,8 @@ type PoolCardProps = {
 export const PoolCard: React.FC<PoolCardProps> = ({
   title,
   loading,
-  source,
-  target,
+  sourceAsset,
+  targetAsset,
   runeAmount,
   runePrice,
   assetAmount,
@@ -41,10 +41,10 @@ export const PoolCard: React.FC<PoolCardProps> = ({
         <Styled.DetailsWrapper gradient={gradient} accent="primary">
           <Styled.PoolCardRow>
             <Col>
-              <Styled.AssetName loading={loading}>{source}</Styled.AssetName>
+              <Styled.AssetName loading={loading}>{sourceAsset.ticker}</Styled.AssetName>
             </Col>
             <Col>
-              <Styled.AssetName loading={loading}>{target}</Styled.AssetName>
+              <Styled.AssetName loading={loading}>{targetAsset.ticker}</Styled.AssetName>
             </Col>
           </Styled.PoolCardRow>
         </Styled.DetailsWrapper>

--- a/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
@@ -1,28 +1,49 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { bn, assetToBase, assetAmount } from '@thorchain/asgardex-util'
+import { bn, assetToBase, assetAmount, AssetBNB, AssetRune67C, baseAmount } from '@thorchain/asgardex-util'
 
+import { ZERO_BN } from '../../../const'
 import PoolShare from './PoolShare'
 
 export const DefaultPoolShare = () => (
   <PoolShare
-    source="RUNE"
-    target="CAN"
-    poolShare={bn(100)}
+    sourceAsset={AssetRune67C}
+    targetAsset={AssetBNB}
     assetStakedPrice={assetToBase(assetAmount(120.1))}
     assetStakedShare={assetToBase(assetAmount(500))}
     basePriceSymbol="USD"
     loading={false}
     runeStakedPrice={assetToBase(assetAmount(400))}
     runeStakedShare={assetToBase(assetAmount(500))}
+    poolShare={bn(100)}
+    units={assetToBase(assetAmount(2.01))}
   />
 )
 
-storiesOf('Components/PoolShare', module).add('default', () => {
-  return (
-    <div style={{ padding: '20px' }}>
-      <DefaultPoolShare />
-    </div>
-  )
-})
+storiesOf('Components/PoolShare', module)
+  .add('default', () => {
+    return (
+      <div style={{ padding: '20px' }}>
+        <DefaultPoolShare />
+      </div>
+    )
+  })
+  .add('loading', () => {
+    return (
+      <div style={{ padding: '20px' }}>
+        <PoolShare
+          sourceAsset={AssetRune67C}
+          targetAsset={AssetBNB}
+          assetStakedPrice={baseAmount(0)}
+          assetStakedShare={baseAmount(0)}
+          basePriceSymbol=""
+          loading={true}
+          runeStakedPrice={baseAmount(0)}
+          runeStakedShare={baseAmount(0)}
+          poolShare={ZERO_BN}
+          units={baseAmount(0)}
+        />
+      </div>
+    )
+  })

--- a/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
@@ -17,7 +17,7 @@ export const DefaultPoolShare = () => (
     runeStakedPrice={assetToBase(assetAmount(400))}
     runeStakedShare={assetToBase(assetAmount(500))}
     poolShare={bn(100)}
-    units={assetToBase(assetAmount(2.01))}
+    stakeUnits={assetToBase(assetAmount(2.01))}
   />
 )
 
@@ -42,7 +42,7 @@ storiesOf('Components/PoolShare', module)
           runeStakedPrice={baseAmount(0)}
           runeStakedShare={baseAmount(0)}
           poolShare={ZERO_BN}
-          units={baseAmount(0)}
+          stakeUnits={baseAmount(0)}
         />
       </div>
     )

--- a/src/renderer/components/uielements/poolShare/PoolShare.style.ts
+++ b/src/renderer/components/uielements/poolShare/PoolShare.style.ts
@@ -9,10 +9,18 @@ export const PoolShareWrapper = styled.div`
   font-size: 16px;
 `
 
-export const SharePercent = styled(Label).attrs({
+export const ShareLabel = styled(Label).attrs({
   align: 'center',
   size: 'normal',
   colo: 'dark'
+})`
+  font-weight: bold;
+`
+
+export const ShareHeadline = styled(Label).attrs({
+  align: 'center',
+  size: 'big',
+  textTransform: 'uppercase'
 })`
   font-weight: bold;
 `

--- a/src/renderer/components/uielements/poolShare/PoolShare.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.tsx
@@ -18,7 +18,7 @@ type Props = {
   assetStakedShare: BaseAmount
   assetStakedPrice: BaseAmount
   poolShare: BigNumber
-  units: BaseAmount
+  stakeUnits: BaseAmount
 }
 
 const PoolShare: React.FC<Props> = (props): JSX.Element => {
@@ -32,7 +32,7 @@ const PoolShare: React.FC<Props> = (props): JSX.Element => {
     assetStakedShare,
     assetStakedPrice,
     poolShare,
-    units
+    stakeUnits
   } = props
 
   const intl = useIntl()
@@ -51,11 +51,14 @@ const PoolShare: React.FC<Props> = (props): JSX.Element => {
         gradient={2}
         basePriceSymbol={basePriceSymbol}>
         <>
-          <Col span={12} sm={24}>
+          <Col span={24} sm={12}>
             <Styled.ShareHeadline loading={loading}>{intl.formatMessage({ id: 'stake.units' })}</Styled.ShareHeadline>
-            <Styled.ShareLabel loading={loading}>{`${formatBaseAsAssetAmount({ amount: units })}`}</Styled.ShareLabel>
+            <Styled.ShareLabel loading={loading}>{`${formatBaseAsAssetAmount({
+              amount: stakeUnits,
+              decimal: 2
+            })}`}</Styled.ShareLabel>
           </Col>
-          <Col span={12} sm={24}>
+          <Col span={24} sm={12}>
             <Styled.ShareHeadline loading={loading}>
               {intl.formatMessage({ id: 'stake.poolShare' })}
             </Styled.ShareHeadline>

--- a/src/renderer/components/uielements/poolShare/PoolShare.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 
-import { formatBN, BaseAmount } from '@thorchain/asgardex-util'
+import { formatBN, BaseAmount, Asset, formatBaseAsAssetAmount } from '@thorchain/asgardex-util'
+import { Col } from 'antd'
 import BigNumber from 'bignumber.js'
 import { useIntl } from 'react-intl'
 
-import Label from '../label'
 import { PoolCard } from './PoolCard'
 import * as Styled from './PoolShare.style'
 
 type Props = {
-  source: string
-  target: string
+  sourceAsset: Asset
+  targetAsset: Asset
   runeStakedShare: BaseAmount
   runeStakedPrice: BaseAmount
   loading?: boolean
@@ -18,19 +18,21 @@ type Props = {
   assetStakedShare: BaseAmount
   assetStakedPrice: BaseAmount
   poolShare: BigNumber
+  units: BaseAmount
 }
 
 const PoolShare: React.FC<Props> = (props): JSX.Element => {
   const {
-    source,
+    sourceAsset,
     runeStakedShare,
     runeStakedPrice,
     loading,
     basePriceSymbol,
-    target,
+    targetAsset,
     assetStakedShare,
     assetStakedPrice,
-    poolShare
+    poolShare,
+    units
   } = props
 
   const intl = useIntl()
@@ -40,20 +42,26 @@ const PoolShare: React.FC<Props> = (props): JSX.Element => {
       <PoolCard
         title={intl.formatMessage({ id: 'stake.totalShare' })}
         loading={loading}
-        source={source}
-        target={target}
+        sourceAsset={sourceAsset}
+        targetAsset={targetAsset}
         runeAmount={runeStakedShare}
         runePrice={runeStakedPrice}
         assetAmount={assetStakedShare}
         assetPrice={assetStakedPrice}
         gradient={2}
         basePriceSymbol={basePriceSymbol}>
-        <div>
-          <Label textTransform="uppercase" size="big" align="center" loading={loading}>
-            {intl.formatMessage({ id: 'stake.poolShare' })}
-          </Label>
-          <Styled.SharePercent loading={loading}>{poolShare ? `${formatBN(poolShare)}%` : '...'}</Styled.SharePercent>
-        </div>
+        <>
+          <Col span={12} sm={24}>
+            <Styled.ShareHeadline loading={loading}>{intl.formatMessage({ id: 'stake.units' })}</Styled.ShareHeadline>
+            <Styled.ShareLabel loading={loading}>{`${formatBaseAsAssetAmount({ amount: units })}`}</Styled.ShareLabel>
+          </Col>
+          <Col span={12} sm={24}>
+            <Styled.ShareHeadline loading={loading}>
+              {intl.formatMessage({ id: 'stake.poolShare' })}
+            </Styled.ShareHeadline>
+            <Styled.ShareLabel loading={loading}>{`${formatBN(poolShare)}%`}</Styled.ShareLabel>
+          </Col>
+        </>
       </PoolCard>
     </Styled.PoolShareWrapper>
   )

--- a/src/renderer/helpers/assetHelper.ts
+++ b/src/renderer/helpers/assetHelper.ts
@@ -16,6 +16,17 @@ import { PricePoolAsset } from '../views/pools/types'
 import { eqAsset } from './fp/eq'
 
 /**
+ * Decimal for any asset handled by THORChain and provided by Midgard
+ *
+ * Note 1: THORChain will only ever treat assets to be `1e8`
+ * Note 2: `THORCHAIN_DECIMAL` has to be used for pools/swap/liquidity only,
+ * at wallet parts we will get information about decimal from agardex client libs
+ * (eg. `asgardex-binance|bitcoin|ethereum` and others)
+ *
+ * */
+export const THORCHAIN_DECIMAL = 8
+
+/**
  * Number of decimals for Binance chain assets
  * Example:
  * 1 RUNE == 100,000,000 ð (tor)

--- a/src/renderer/i18n/de/stake.ts
+++ b/src/renderer/i18n/de/stake.ts
@@ -3,7 +3,8 @@ import { StakeMessages } from '../types'
 const stake: StakeMessages = {
   'stake.totalShare': 'Dein Poolanteil',
   'stake.totalEarnings': 'Deine Gesamteinkommen vom Pool',
-  'stake.poolShare': ' Poolanteil',
+  'stake.poolShare': 'Poolanteil',
+  'stake.units': 'Liquidität Einheiten',
   'stake.withdraw': 'Abheben',
   'stake.advancedMode': 'Experten modus',
   'stake.drag': 'Ziehen um zu Staken',

--- a/src/renderer/i18n/en/stake.ts
+++ b/src/renderer/i18n/en/stake.ts
@@ -4,6 +4,7 @@ const stake: StakeMessages = {
   'stake.totalShare': 'Your total share of the pool',
   'stake.totalEarnings': 'Your total earnings from the pool',
   'stake.poolShare': ' Pool share',
+  'stake.units': 'Liquidity units',
   'stake.withdraw': 'Withdraw',
   'stake.advancedMode': 'Advanced mode',
   'stake.drag': 'Drag to stake',

--- a/src/renderer/i18n/ru/stake.ts
+++ b/src/renderer/i18n/ru/stake.ts
@@ -4,6 +4,7 @@ const stake: StakeMessages = {
   'stake.totalShare': 'Ваша общая доля в пуле',
   'stake.totalEarnings': 'Ваш общий доход от пула',
   'stake.poolShare': 'Доля  в пуле',
+  'stake.units': 'Liquidity units - RU',
   'stake.withdraw': 'Убрать',
   'stake.advancedMode': 'Расширенный режим',
   'stake.drag': 'Потяните',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -142,6 +142,7 @@ type StakeMessageKey =
   | 'stake.totalShare'
   | 'stake.totalEarnings'
   | 'stake.poolShare'
+  | 'stake.units'
   | 'stake.withdraw'
   | 'stake.advancedMode'
   | 'stake.drag'

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -88,7 +88,8 @@ const createPoolsService = (
             asset,
             view: isDetailed ? GetPoolsDetailsViewEnum.Full : GetPoolsDetailsViewEnum.Simple
           }),
-          map(RD.success),
+          // error if no pools are available
+          map((assets) => (assets.length > 0 ? RD.success(assets) : RD.failure(new Error('No pools available')))),
           catchError((e: Error) => Rx.of(RD.failure(e)))
         )
       )

--- a/src/renderer/views/stake/Share/ShareView.helper.test.ts
+++ b/src/renderer/views/stake/Share/ShareView.helper.test.ts
@@ -1,15 +1,20 @@
-import { bn } from '@thorchain/asgardex-util'
+import { baseAmount, bn } from '@thorchain/asgardex-util'
 
 import { ZERO_BN } from '../../../const'
+import { eqBaseAmount } from '../../../helpers/fp/eq'
 import { getRuneShare, getAssetShare, getAssetSharePrice, getPoolShare } from './ShareView.helper'
 
 describe('ShareView/helper', () => {
   it('getRuneShare', () => {
-    expect(getRuneShare({ units: '3' }, { runeDepth: '12', poolUnits: '2' })).toEqual(bn(18))
+    const result = getRuneShare({ units: '3' }, { runeDepth: '12', poolUnits: '2' })
+    const expected = baseAmount(18)
+    expect(eqBaseAmount.equals(result, expected)).toBeTruthy()
   })
 
   it('getAssetShare', () => {
-    expect(getAssetShare({ units: '3' }, { assetDepth: '12', poolUnits: '2' })).toEqual(bn(18))
+    const result = getAssetShare({ units: '3' }, { assetDepth: '12', poolUnits: '2' })
+    const expected = baseAmount(18)
+    expect(eqBaseAmount.equals(result, expected)).toBeTruthy()
   })
 
   it('getAssetSharePrice', () => {

--- a/src/renderer/views/stake/Share/ShareView.helper.tsx
+++ b/src/renderer/views/stake/Share/ShareView.helper.tsx
@@ -1,25 +1,8 @@
-import React from 'react'
-
-import { assetAmount, assetToBase, baseAmount, BaseAmount, bn, bnOrZero } from '@thorchain/asgardex-util'
+import { baseAmount, BaseAmount, bn, bnOrZero } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 
-import PoolShare from '../../../components/uielements/poolShare'
 import { ZERO_BN } from '../../../const'
 import { PoolDetail, StakersAssetData } from '../../../types/generated/midgard/models'
-
-export const renderPending = () => (
-  <PoolShare
-    source=""
-    target=""
-    poolShare={bn(0)}
-    assetStakedPrice={assetToBase(assetAmount(0))}
-    assetStakedShare={assetToBase(assetAmount(0))}
-    basePriceSymbol=""
-    loading={true}
-    runeStakedPrice={assetToBase(assetAmount(0))}
-    runeStakedShare={assetToBase(assetAmount(0))}
-  />
-)
 
 export const getRuneShare = ({ units }: Pick<StakersAssetData, 'units'>, pool: PoolDetail) => {
   const runeDepth = bnOrZero(pool.runeDepth)

--- a/src/renderer/views/stake/Share/ShareView.helper.tsx
+++ b/src/renderer/views/stake/Share/ShareView.helper.tsx
@@ -2,33 +2,49 @@ import { baseAmount, BaseAmount, bn, bnOrZero } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 
 import { ZERO_BN } from '../../../const'
+import { THORCHAIN_DECIMAL } from '../../../helpers/assetHelper'
 import { PoolDetail, StakersAssetData } from '../../../types/generated/midgard/models'
 
-export const getRuneShare = ({ units }: Pick<StakersAssetData, 'units'>, pool: PoolDetail) => {
+/**
+ * RUNE share of a pool in `BaseAmount`
+ */
+export const getRuneShare = ({ units }: Pick<StakersAssetData, 'units'>, pool: PoolDetail): BaseAmount => {
   const runeDepth = bnOrZero(pool.runeDepth)
   const stakeUnits = bnOrZero(units)
   // Default is 1 as neutral element for division
   const poolUnits = bn(pool.poolUnits || 1)
 
-  return runeDepth.multipliedBy(stakeUnits).div(poolUnits)
+  const runeShare = runeDepth.multipliedBy(stakeUnits).div(poolUnits)
+  return baseAmount(runeShare, THORCHAIN_DECIMAL)
 }
 
+/**
+ * Asset share of a pool in `BaseAmount`
+ */
 export const getAssetShare = (
   { units }: Pick<StakersAssetData, 'units'>,
   { assetDepth, poolUnits }: Pick<PoolDetail, 'assetDepth' | 'poolUnits'>
-) => {
+): BaseAmount => {
   const assetDepthBN = bnOrZero(assetDepth)
   const stakeUnitsBN = bnOrZero(units)
   // Default is 1 as neutral element for division
   const poolUnitsBN = bn(poolUnits || 1)
 
-  return assetDepthBN.multipliedBy(stakeUnitsBN).div(poolUnitsBN)
+  const assetShare = assetDepthBN.multipliedBy(stakeUnitsBN).div(poolUnitsBN)
+  return baseAmount(assetShare, THORCHAIN_DECIMAL)
 }
 
+// TODO (@Veado): Remove `getAssetSharePrice` - we have to calculate price in other way
+// https://github.com/thorchain/asgardex-electron/issues/513
 export const getAssetSharePrice = (assetShare: BigNumber, price: BigNumber, priceRatio: BigNumber): BaseAmount =>
   baseAmount(assetShare.multipliedBy(price).multipliedBy(priceRatio))
 
+/**
+ * Pool share in percent
+ *
+ * Note: The only reason ot use BigNumber here is for formatting it easily in UI
+ */
 export const getPoolShare = (
   { units }: Pick<StakersAssetData, 'units'>,
   { poolUnits }: Pick<PoolDetail, 'poolUnits'>
-) => (poolUnits ? bnOrZero(units).div(poolUnits).multipliedBy(100) : ZERO_BN)
+): BigNumber => (poolUnits ? bnOrZero(units).div(poolUnits).multipliedBy(100) : ZERO_BN)

--- a/src/renderer/views/stake/Share/ShareView.tsx
+++ b/src/renderer/views/stake/Share/ShareView.tsx
@@ -1,32 +1,83 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, baseAmount, bnOrZero, RUNE_TICKER } from '@thorchain/asgardex-util'
+import { Asset, baseAmount, bnOrZero } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 import * as FP from 'fp-ts/pipeable'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 
 import PoolShare from '../../../components/uielements/poolShare'
-import { ONE_BN } from '../../../const'
+import { ONE_BN, ZERO_BN } from '../../../const'
 import { useMidgardContext } from '../../../contexts/MidgardContext'
+import { getDefaultRuneAsset } from '../../../helpers/assetHelper'
 import { PoolDetailRD, StakersAssetDataRD } from '../../../services/midgard/types'
+import { PoolDetail, StakersAssetData } from '../../../types/generated/midgard'
 import * as helpers from './ShareView.helper'
 import * as Styled from './ShareView.styles'
 
 export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { poolDetailedState$, selectedPricePoolAssetSymbol$, priceRatio$ },
+    pools: { poolDetailedState$, selectedPricePoolAssetSymbol$, priceRatio$, runeAsset$ },
     stake: { stakes$ }
   } = midgardService
 
   const intl = useIntl()
 
   const stakeData = useObservableState<StakersAssetDataRD>(stakes$, RD.initial)
+  const runeAsset = useObservableState(runeAsset$, getDefaultRuneAsset())
   const poolDetailedInfo = useObservableState<PoolDetailRD>(poolDetailedState$, RD.initial)
   const runePriceRatio = useObservableState(priceRatio$, ONE_BN)
   const priceSymbol = useObservableState<O.Option<string>>(selectedPricePoolAssetSymbol$, O.none)
+
+  const renderPoolSharePending = useMemo(
+    () => (
+      <PoolShare
+        sourceAsset={runeAsset}
+        targetAsset={asset}
+        poolShare={ZERO_BN}
+        assetStakedPrice={baseAmount(0)}
+        assetStakedShare={baseAmount(0)}
+        basePriceSymbol=""
+        loading={true}
+        runeStakedPrice={baseAmount(0)}
+        runeStakedShare={baseAmount(0)}
+        units={baseAmount(0)}
+      />
+    ),
+    [asset, runeAsset]
+  )
+
+  const renderPoolShareReady = useCallback(
+    (stake: StakersAssetData, pool: PoolDetail) => {
+      const runeShare = helpers.getRuneShare(stake, pool)
+      const assetShare = helpers.getAssetShare(stake, pool)
+      const runeStakedShare = baseAmount(runeShare)
+      const runeStakedPrice = baseAmount(runePriceRatio.multipliedBy(runeShare))
+      const assetStakedShare = baseAmount(assetShare)
+      const poolShare = helpers.getPoolShare(stake, pool)
+      const units = baseAmount(bnOrZero(stake.units))
+      return (
+        <PoolShare
+          sourceAsset={runeAsset}
+          targetAsset={asset}
+          poolShare={poolShare}
+          units={units}
+          assetStakedShare={assetStakedShare}
+          basePriceSymbol={FP.pipe(
+            priceSymbol,
+            O.getOrElse(() => '')
+          )}
+          loading={false}
+          assetStakedPrice={helpers.getAssetSharePrice(assetShare, bnOrZero(pool.price), runePriceRatio)}
+          runeStakedPrice={runeStakedPrice}
+          runeStakedShare={runeStakedShare}
+        />
+      )
+    },
+    [asset, priceSymbol, runeAsset, runePriceRatio]
+  )
 
   const renderPoolShare = useMemo(
     () =>
@@ -34,36 +85,13 @@ export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
         RD.combine(stakeData, poolDetailedInfo),
         RD.fold(
           () => <Styled.EmptyData description={intl.formatMessage({ id: 'stake.pool.noStakes' })} />,
-          helpers.renderPending,
+          () => renderPoolSharePending,
           (e) => <Styled.EmptyData description={e.message} />,
-          ([stake, pool]) => {
-            const runeShare = helpers.getRuneShare(stake, pool)
-            const assetShare = helpers.getAssetShare(stake, pool)
-            const runeStakedShare = baseAmount(runeShare)
-            const runeStakedPrice = baseAmount(runePriceRatio.multipliedBy(runeShare))
-            const assetStakedShare = baseAmount(assetShare)
-            const poolShare = helpers.getPoolShare(stake, pool)
-            return (
-              <PoolShare
-                source={RUNE_TICKER}
-                target={asset.chain}
-                poolShare={poolShare}
-                assetStakedShare={assetStakedShare}
-                basePriceSymbol={FP.pipe(
-                  priceSymbol,
-                  O.getOrElse(() => '')
-                )}
-                loading={false}
-                assetStakedPrice={helpers.getAssetSharePrice(assetShare, bnOrZero(pool.price), runePriceRatio)}
-                runeStakedPrice={runeStakedPrice}
-                runeStakedShare={runeStakedShare}
-              />
-            )
-          }
+          ([stake, pool]) => renderPoolShareReady(stake, pool)
         )
       ),
 
-    [asset.chain, intl, poolDetailedInfo, priceSymbol, runePriceRatio, stakeData]
+    [intl, poolDetailedInfo, renderPoolSharePending, renderPoolShareReady, stakeData]
   )
 
   return renderPoolShare

--- a/src/renderer/views/stake/Share/ShareView.tsx
+++ b/src/renderer/views/stake/Share/ShareView.tsx
@@ -43,7 +43,7 @@ export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
         loading={true}
         runeStakedPrice={baseAmount(0)}
         runeStakedShare={baseAmount(0)}
-        units={baseAmount(0)}
+        stakeUnits={baseAmount(0)}
       />
     ),
     [asset, runeAsset]
@@ -53,26 +53,26 @@ export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
     (stake: StakersAssetData, pool: PoolDetail) => {
       const runeShare = helpers.getRuneShare(stake, pool)
       const assetShare = helpers.getAssetShare(stake, pool)
-      const runeStakedShare = baseAmount(runeShare)
-      const runeStakedPrice = baseAmount(runePriceRatio.multipliedBy(runeShare))
-      const assetStakedShare = baseAmount(assetShare)
+      const runeStakedPrice = baseAmount(runePriceRatio.multipliedBy(runeShare.amount()))
       const poolShare = helpers.getPoolShare(stake, pool)
-      const units = baseAmount(bnOrZero(stake.units))
+      const assetStakedPrice = helpers.getAssetSharePrice(assetShare.amount(), bnOrZero(pool.price), runePriceRatio)
+      // stake units are RUNE based, provided as `BaseAmount`
+      const stakeUnits = baseAmount(bnOrZero(stake.units))
       return (
         <PoolShare
           sourceAsset={runeAsset}
           targetAsset={asset}
           poolShare={poolShare}
-          units={units}
-          assetStakedShare={assetStakedShare}
+          stakeUnits={stakeUnits}
+          assetStakedShare={assetShare}
           basePriceSymbol={FP.pipe(
             priceSymbol,
             O.getOrElse(() => '')
           )}
           loading={false}
-          assetStakedPrice={helpers.getAssetSharePrice(assetShare, bnOrZero(pool.price), runePriceRatio)}
+          assetStakedPrice={assetStakedPrice}
           runeStakedPrice={runeStakedPrice}
-          runeStakedShare={runeStakedShare}
+          runeStakedShare={runeShare}
         />
       )
     },


### PR DESCRIPTION
- [x] Add `liquidity units` to `PoolShare`
- [x] Some tweaks for `ShareView.helper`
- [x] Add `THORCHAIN_DECIMAL`
- [x] Quick fix: Error if pools are empty


![Screenshot from 2020-10-09 12-19-34](https://user-images.githubusercontent.com/61792675/95572296-0690f700-0a2a-11eb-84e6-14f0d52d8d7b.png)

_Note:_ ^ Layout will be updated by #506. Also, ignore prices in pool share component - it will be fixed by #513 


Closes #512 