### PR TITLE
Fix handling of pool detail data

### DIFF
--- a/src/renderer/components/stake/Stake.styles.tsx
+++ b/src/renderer/components/stake/Stake.styles.tsx
@@ -32,7 +32,11 @@ export const ShareContentCol = styled(Col).attrs({})`
 
 export const ShareContentWrapper = styled.div`
   background: ${palette('background', 0)};
-  min-height: auto;
+  /* min-height for spin loader + empty data icons  */
+  min-height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   ${media.xl`
       min-height: 100%;
   `};

--- a/src/renderer/components/uielements/drag/Drag.style.tsx
+++ b/src/renderer/components/uielements/drag/Drag.style.tsx
@@ -16,7 +16,7 @@ export const DragContainer = styled.div`
   position: relative;
   display: flex;
   align-items: center;
-  width: 244px;
+  min-width: 244px;
   height: 40px;
   border: 1px solid ${palette('primary', 0)};
   padding: 0 4px;

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -20,8 +20,7 @@ const wallet: WalletMessages = {
   'wallet.unlock.title': 'Wallet entsperren',
   'wallet.unlock.instruction': 'Bitte entsperre Deine Wallet',
   'wallet.unlock.phrase': 'Bitte gebe Deine Phrase ein',
-  'wallet.unlock.error':
-    'Die Wallet konnte nicht entsperrt werden. Bitte überprüfe Dein Passwort und versuche es noch einmal',
+  'wallet.unlock.error': 'Die Wallet konnte nicht entsperrt werden. Bitte überprüfe Dein Passwort und versuche es .',
   'wallet.imports.phrase': 'Phrase',
   'wallet.imports.wallet': 'Importiere eine bestehende Wallet',
   'wallet.imports.enterphrase': 'Phrase eingeben',

--- a/src/renderer/services/midgard/common.ts
+++ b/src/renderer/services/midgard/common.ts
@@ -1,0 +1,14 @@
+import { Asset } from '@thorchain/asgardex-util'
+import * as O from 'fp-ts/lib/Option'
+import { distinctUntilChanged } from 'rxjs/operators'
+
+import { eqOAsset } from '../../helpers/fp/eq'
+import { observableState } from '../../helpers/stateHelper'
+
+/** Selected pool asset */
+const { get$: getSelectedPoolAsset$, set: setSelectedPoolAsset } = observableState<O.Option<Asset>>(O.none)
+
+// "dirty check" to trigger "real" changes of an asset only
+const selectedPoolAsset$ = getSelectedPoolAsset$.pipe(distinctUntilChanged(eqOAsset.equals))
+
+export { selectedPoolAsset$, setSelectedPoolAsset }

--- a/src/renderer/services/midgard/service.ts
+++ b/src/renderer/services/midgard/service.ts
@@ -12,6 +12,7 @@ import { Configuration, DefaultApi } from '../../types/generated/midgard'
 import { network$ } from '../app/service'
 import { Network } from '../app/types'
 import { MIDGARD_MAX_RETRY } from '../const'
+import { selectedPoolAsset$, setSelectedPoolAsset } from './common'
 import { createPoolsService } from './pools'
 import { createStakeService } from './stake'
 import { NetworkInfoRD, NetworkInfoLD, ThorchainConstantsLD, ByzantineLD, ThorchainLastblockLD } from './types'
@@ -144,6 +145,7 @@ export type MidgardService = {
   thorchainConstantsState$: ThorchainConstantsLD
   thorchainLastblockState$: ThorchainLastblockLD
   reloadThorchainLastblock: () => void
+  setSelectedPoolAsset: () => void
   apiEndpoint$: ByzantineLD
 }
 /**
@@ -155,7 +157,8 @@ export const service = {
   thorchainConstantsState$,
   thorchainLastblockState$,
   reloadThorchainLastblock,
+  setSelectedPoolAsset,
   apiEndpoint$: byzantine$,
-  pools: createPoolsService(byzantine$, getMidgardDefaultApi),
-  stake: createStakeService(byzantine$, getMidgardDefaultApi)
+  pools: createPoolsService(byzantine$, getMidgardDefaultApi, selectedPoolAsset$),
+  stake: createStakeService(byzantine$, getMidgardDefaultApi, selectedPoolAsset$)
 }

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -2,7 +2,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Asset, Chain } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 import { Option } from 'fp-ts/lib/Option'
-import * as O from 'fp-ts/Option'
 import * as Rx from 'rxjs'
 
 import { LiveData } from '../../helpers/rx/liveData'
@@ -77,7 +76,7 @@ export type PoolsService = {
   poolAddresses$: ThorchainEndpointsLD
   runeAsset$: Rx.Observable<Asset>
   poolDetail$: PoolDetailLD
-  reloadPoolDetail: (value: O.Option<Asset>) => void
+  reloadPoolDetail: () => void
   priceRatio$: Rx.Observable<BigNumber>
   availableAssets$: PoolAssetsLD
 }

--- a/src/renderer/views/stake/Share/ShareView.styles.ts
+++ b/src/renderer/views/stake/Share/ShareView.styles.ts
@@ -5,23 +5,6 @@ import { palette } from 'styled-theme'
 export const EmptyData = styled(A.Empty).attrs({
   image: A.Empty.PRESENTED_IMAGE_SIMPLE
 })`
-  height: 100%;
-  width: 100%;
-  padding: 20px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
   text-transform: uppercase;
   color: ${palette('text', 0)};
-`
-
-export const EmptyContainer = styled.div`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  background: ${palette('background', 0)};
 `

--- a/src/renderer/views/stake/Share/ShareView.tsx
+++ b/src/renderer/views/stake/Share/ShareView.tsx
@@ -21,16 +21,19 @@ import * as Styled from './ShareView.styles'
 export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { poolDetail$, selectedPricePoolAsset$, selectedPricePool$, runeAsset$ }
+    pools: { poolDetail$, selectedPricePoolAsset$, selectedPricePool$, runeAsset$ },
+    stake: { getStakes$ }
   } = midgardService
 
   const intl = useIntl()
 
   /**
    * We have to get a new stake-stream for every new asset
+   * DON'T remove `slint-disable-next-line ...` ;)
    * @description /src/renderer/services/midgard/stake.ts
    */
-  const stakeData$ = useMemo(() => midgardService.stake.getStakes$(asset), [asset, midgardService.stake])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stakeData$ = useMemo(() => getStakes$(), [asset])
   const stakeData = useObservableState<StakersAssetDataRD>(stakeData$, RD.initial)
 
   const runeAsset = useObservableState(runeAsset$, getDefaultRuneAsset())
@@ -76,11 +79,7 @@ export const ShareView: React.FC<{ asset: Asset }> = ({ asset }) => {
         RD.combine(stakeData, poolDetailRD),
         RD.fold(
           () => <Styled.EmptyData description={intl.formatMessage({ id: 'stake.pool.noStakes' })} />,
-          () => (
-            <Styled.EmptyContainer>
-              <Spin />
-            </Styled.EmptyContainer>
-          ),
+          () => <Spin />,
           () => <Styled.EmptyData description={intl.formatMessage({ id: 'stake.pool.noStakes' })} />,
           ([stake, pool]) => renderPoolShareReady(stake, pool)
         )

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { assetFromString } from '@thorchain/asgardex-util'
@@ -23,12 +23,12 @@ const AssetDetailsView: React.FC = (): JSX.Element => {
   } = useWalletContext()
 
   const { asset } = useParams<AssetDetailsParams>()
-  const selectedAsset = O.fromNullable(assetFromString(asset))
+  const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset)), [asset])
 
   // Set selected asset once
   // Needed to get all data for this asset (transactions etc.)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => setSelectedAsset(selectedAsset), [])
+  useEffect(() => setSelectedAsset(oSelectedAsset), [])
 
   const txsRD = useObservableState(assetTxs$, RD.initial)
   const { assetsWB } = useObservableState(assetsWBState$, INITIAL_ASSETS_WB_STATE)
@@ -43,7 +43,7 @@ const AssetDetailsView: React.FC = (): JSX.Element => {
       <AssetDetails
         txsPageRD={txsRD}
         assetsWB={assetsWB}
-        asset={selectedAsset}
+        asset={oSelectedAsset}
         loadAssetTxsHandler={loadAssetTxsHandler}
         reloadBalancesHandler={reloadBalances}
         explorerTxUrl={explorerTxUrl}

--- a/src/renderer/views/wallet/FreezeView.tsx
+++ b/src/renderer/views/wallet/FreezeView.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 const FreezeView: React.FC<Props> = ({ freezeAction }): JSX.Element => {
   const { asset } = useParams<SendParams>()
-  const oSelectedAsset = O.fromNullable(assetFromString(asset))
+  const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset)), [asset])
 
   const { freeze: freezeService, explorerUrl$, freezeFee$ } = useBinanceContext()
   const { assetsWBState$ } = useWalletContext()

--- a/src/renderer/views/wallet/ReceiveView.tsx
+++ b/src/renderer/views/wallet/ReceiveView.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { assetFromString } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
@@ -11,12 +11,12 @@ import { ReceiveParams } from '../../routes/wallet'
 
 const ReceiveView: React.FC = (): JSX.Element => {
   const { asset } = useParams<ReceiveParams>()
-  const selectedAsset = O.fromNullable(assetFromString(asset))
+  const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset)), [asset])
 
   const { address$ } = useBinanceContext()
   const address = useObservableState(address$, O.none)
 
-  return <Receive address={address} asset={selectedAsset} />
+  return <Receive address={address} asset={oSelectedAsset} />
 }
 
 export default ReceiveView

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -23,7 +23,7 @@ type Props = {}
 const SendView: React.FC<Props> = (): JSX.Element => {
   const { asset } = useParams<SendParams>()
   const intl = useIntl()
-  const oSelectedAsset = O.fromNullable(assetFromString(asset))
+  const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset)), [asset])
 
   const { assetsWBState$ } = useWalletContext()
   const { assetsWB } = useObservableState(assetsWBState$, INITIAL_ASSETS_WB_STATE)


### PR DESCRIPTION
- [x] Fix reload of pool detail data while selecting another language #527  
- [x] Provide `selectedPoolAsset$` stream to be more reactive for reloading data needed for any selected pool
- [x] Fix layout for loading / no data state of  `PoolShare` 
- [x] Memorize selected asset parsed from route in different views

Fix #527 