### PR TITLE
Resolve: Business logic for "Add Liquidity" fees

### DIFF
--- a/src/renderer/contexts/AppContext.tsx
+++ b/src/renderer/contexts/AppContext.tsx
@@ -15,11 +15,7 @@ const initialContext: AppContextValue = {
 
 const AppContext = createContext<AppContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const AppProvider: React.FC<Props> = ({ children }: Props): JSX.Element => (
+export const AppProvider: React.FC = ({ children }): JSX.Element => (
   <AppContext.Provider value={initialContext}>{children}</AppContext.Provider>
 )
 

--- a/src/renderer/contexts/BinanceContext.tsx
+++ b/src/renderer/contexts/BinanceContext.tsx
@@ -44,11 +44,7 @@ const initialContext: BinanceContextValue = {
 
 const BinanceContext = createContext<BinanceContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const BinanceProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const BinanceProvider: React.FC = ({ children }): JSX.Element => {
   return <BinanceContext.Provider value={initialContext}>{children}</BinanceContext.Provider>
 }
 

--- a/src/renderer/contexts/BitcoinContext.tsx
+++ b/src/renderer/contexts/BitcoinContext.tsx
@@ -41,11 +41,7 @@ const initialContext: BitcoinContextValue = {
 
 const BitcoinContext = createContext<BitcoinContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const BitcoinProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const BitcoinProvider: React.FC = ({ children }): JSX.Element => {
   return <BitcoinContext.Provider value={initialContext}>{children}</BitcoinContext.Provider>
 }
 

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -13,11 +13,7 @@ const initialContext: ChainContextValue = {
 }
 const ChainContext = createContext<ChainContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const ChainProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const ChainProvider: React.FC = ({ children }): JSX.Element => {
   return <ChainContext.Provider value={initialContext}>{children}</ChainContext.Provider>
 }
 

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -17,7 +17,7 @@ type Props = {
   children: React.ReactNode
 }
 
-export const MidgardProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const ChainProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
   return <ChainContext.Provider value={initialContext}>{children}</ChainContext.Provider>
 }
 

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext } from 'react'
+
+import { stakeFee$, reloadFees } from '../services/chain/context'
+
+type ChainContextValue = {
+  stakeFee$: typeof stakeFee$
+  reloadFees: typeof reloadFees
+}
+
+const initialContext: ChainContextValue = {
+  stakeFee$,
+  reloadFees
+}
+const ChainContext = createContext<ChainContextValue | null>(null)
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const MidgardProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+  return <ChainContext.Provider value={initialContext}>{children}</ChainContext.Provider>
+}
+
+export const useChainContext = () => {
+  const context = useContext(ChainContext)
+  if (!context) {
+    throw new Error('Context must be used within a ChainProvider.')
+  }
+  return context
+}

--- a/src/renderer/contexts/EthereumContext.tsx
+++ b/src/renderer/contexts/EthereumContext.tsx
@@ -17,11 +17,7 @@ const initialContext: EthereumContextValue = {
 
 const EthereumContext = createContext<EthereumContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const EthereumProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const EthereumProvider: React.FC = ({ children }): JSX.Element => {
   const { network$ } = useAppContext()
   useSubscription(network$, (network) => setNetworkState(network))
   return <EthereumContext.Provider value={initialContext}>{children}</EthereumContext.Provider>

--- a/src/renderer/contexts/I18nContext.tsx
+++ b/src/renderer/contexts/I18nContext.tsx
@@ -20,11 +20,7 @@ export const initialContext: I18nContextValue = {
 
 const I18nContext = createContext<I18nContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const I18nProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const I18nProvider: React.FC = ({ children }): JSX.Element => {
   const locale = useObservableState(locale$, initialLocale())
   const messages = useMemo(() => getMessagesByLocale(locale), [locale])
   return (

--- a/src/renderer/contexts/MidgardContext.tsx
+++ b/src/renderer/contexts/MidgardContext.tsx
@@ -11,11 +11,7 @@ const initialContext: MidgardContextValue = {
 }
 const MidgardContext = createContext<MidgardContextValue | null>(null)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const MidgardProvider: React.FC<Props> = ({ children }: Props): JSX.Element => {
+export const MidgardProvider: React.FC = ({ children }): JSX.Element => {
   return <MidgardContext.Provider value={initialContext}>{children}</MidgardContext.Provider>
 }
 

--- a/src/renderer/contexts/ThemeContext.tsx
+++ b/src/renderer/contexts/ThemeContext.tsx
@@ -44,10 +44,9 @@ const ThemeContext = createContext<ThemeContextValue | null>(null)
 
 type Props = {
   theme?: Theme // needed for storybook only
-  children: React.ReactNode
 }
 
-export const ThemeProvider: React.FC<Props> = ({ children, theme }: Props): JSX.Element => {
+export const ThemeProvider: React.FC<Props> = ({ children, theme }): JSX.Element => {
   const themeFromObservable = useObservableState(theme$)
   const selectedTheme = theme || themeFromObservable
   return (

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -46,11 +46,7 @@ const initialContext: WalletContextValue = {
 }
 const WalletContext = createContext<Option<WalletContextValue>>(none)
 
-type Props = {
-  children: React.ReactNode
-}
-
-export const WalletProvider: React.FC<Props> = ({ children }: Props): JSX.Element => (
+export const WalletProvider: React.FC = ({ children }): JSX.Element => (
   <WalletContext.Provider value={some(initialContext)}>{children}</WalletContext.Provider>
 )
 

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -1,9 +1,19 @@
-import { baseAmount, bn } from '@thorchain/asgardex-util'
+import { baseAmount, bn, Chain } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { AssetWithBalance, ApiError, ErrorId } from '../../services/wallet/types'
-import { eqAsset, eqBaseAmount, eqAssetWithBalance, eqAssetsWithBalance, eqApiError, egBigNumber, eqOAsset } from './eq'
+import {
+  eqAsset,
+  eqBaseAmount,
+  eqAssetWithBalance,
+  eqAssetsWithBalance,
+  eqApiError,
+  egBigNumber,
+  eqOAsset,
+  eqChain,
+  eqOChain
+} from './eq'
 
 describe('helpers/fp/eq', () => {
   describe('egBigNumber', () => {
@@ -43,6 +53,34 @@ describe('helpers/fp/eq', () => {
     })
     it('none/none are equal', () => {
       expect(eqOAsset.equals(O.none, O.none)).toBeTruthy()
+    })
+  })
+
+  describe('eqChain', () => {
+    it('is equal', () => {
+      expect(eqChain.equals('THOR', 'THOR')).toBeTruthy()
+    })
+    it('is not equal', () => {
+      expect(eqChain.equals('THOR', 'BNB')).toBeFalsy()
+    })
+  })
+
+  describe('eqOChain', () => {
+    it('same some(chain) are equal', () => {
+      const a: O.Option<Chain> = O.some('THOR')
+      expect(eqOChain.equals(a, a)).toBeTruthy()
+    })
+    it('different some(chain) are not equal', () => {
+      const a: O.Option<Chain> = O.some('THOR')
+      const b: O.Option<Chain> = O.some('BNB')
+      expect(eqOChain.equals(a, b)).toBeFalsy()
+    })
+    it('none/some are not equal', () => {
+      const b: O.Option<Chain> = O.some('BNB')
+      expect(eqOChain.equals(O.none, b)).toBeFalsy()
+    })
+    it('none/none are equal', () => {
+      expect(eqOChain.equals(O.none, O.none)).toBeTruthy()
     })
   })
 

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -1,5 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, BaseAmount, assetToString } from '@thorchain/asgardex-util'
+import { Asset, BaseAmount, assetToString, Chain } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
 import * as Eq from 'fp-ts/lib/Eq'
@@ -18,6 +18,12 @@ export const eqAsset: Eq.Eq<Asset> = {
 }
 
 export const eqOAsset = O.getEq(eqAsset)
+
+export const eqChain: Eq.Eq<Chain> = {
+  equals: (x, y) => Eq.eqString.equals(x, y)
+}
+
+export const eqOChain = O.getEq(eqChain)
 
 export const eqBaseAmount: Eq.Eq<BaseAmount> = {
   equals: (x, y) => egBigNumber.equals(x.amount(), y.amount()) && x.decimal === y.decimal

--- a/src/renderer/services/binance/service.ts
+++ b/src/renderer/services/binance/service.ts
@@ -384,19 +384,13 @@ const transferFees$: Observable<TransferFeesRD> = fees$.pipe(
       fees,
       RD.chain((fee) => RD.fromEither(getTransferFees(fee)))
     )
-  ),
-  shareReplay(1)
+  )
 )
 
 /**
  * Amount of feeze `Fee`
  */
-const freezeFee$: Observable<FeeRD> = FP.pipe(
-  fees$,
-  liveData.map(getFreezeFee),
-  liveData.chain(liveData.fromEither),
-  shareReplay(1)
-)
+const freezeFee$: Observable<FeeRD> = FP.pipe(fees$, liveData.map(getFreezeFee), liveData.chain(liveData.fromEither))
 
 /**
  * Amount of stake `Fee`
@@ -404,8 +398,7 @@ const freezeFee$: Observable<FeeRD> = FP.pipe(
 export const stakeFee$: FeeLD = FP.pipe(
   transferFees$,
   liveData.map((fees) => fees.single),
-  liveData.map(assetToBase),
-  shareReplay(1)
+  liveData.map(assetToBase)
 )
 
 const wsTransfer$ = FP.pipe(

--- a/src/renderer/services/binance/service.ts
+++ b/src/renderer/services/binance/service.ts
@@ -1,6 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { WS, Client, Network as BinanceNetwork, BinanceClient, Address } from '@thorchain/asgardex-binance'
-import { Asset, BNBChain } from '@thorchain/asgardex-util'
+import { Asset, assetToBase, BNBChain } from '@thorchain/asgardex-util'
 import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
@@ -27,9 +27,10 @@ import { sequenceTOption } from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
 import { observableState, triggerStream } from '../../helpers/stateHelper'
 import { network$ } from '../app/service'
+import { FeeLD } from '../chain/types'
 import { ClientStateForViews } from '../types'
 import { getClient, getClientStateForViews } from '../utils'
-import { keystoreService, selectedAsset$ } from '../wallet/common'
+import { keystoreService, selectedAsset$ as selectedWalletAsset$ } from '../wallet/common'
 import { INITIAL_LOAD_TXS_PROPS } from '../wallet/const'
 import {
   AssetsWithBalanceRD,
@@ -42,7 +43,7 @@ import {
 import { getPhrase } from '../wallet/util'
 import { createFreezeService } from './freeze'
 import { createTransactionService } from './transaction'
-import { BinanceClientState, FeeRD, FeesRD, TransferFeesRD, BinanceClientState$ } from './types'
+import { BinanceClientState, FeeRD, TransferFeesRD, BinanceClientState$, FeesLD } from './types'
 import { getWalletBalances, toTxsPage } from './utils'
 
 const BINANCE_TESTNET_WS_URI = envOrDefault(
@@ -304,7 +305,7 @@ const { get$: reloadAssetTxs$, set: reloadAssetTxs } = observableState<LoadAsset
 const assetTxs$: AssetTxsPageLD = Rx.combineLatest([
   client$,
   reloadAssetTxs$.pipe(debounceTime(300), startWith(INITIAL_LOAD_TXS_PROPS)),
-  selectedAsset$
+  selectedWalletAsset$
 ]).pipe(
   switchMap(([client, { limit, offset }, oAsset]) => {
     return FP.pipe(
@@ -339,11 +340,14 @@ const explorerUrl$: Observable<O.Option<string>> = client$.pipe(
   shareReplay(1)
 )
 
+// `TriggerStream` to reload `Fees`
+const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
+
 /**
  * Observable to load transaction fees from Binance API endpoint
  * If client is not available, it returns an `initial` state
  */
-const loadFees$ = (client: BinanceClient): Observable<FeesRD> =>
+const loadFees$ = (client: BinanceClient) =>
   Rx.from(client.getFees()).pipe(
     map(RD.success),
     catchError((error) => Rx.of(RD.failure(error))),
@@ -355,8 +359,19 @@ const loadFees$ = (client: BinanceClient): Observable<FeesRD> =>
  * Transaction fees
  * If a client is not available, it returns `None`
  */
-const fees$: Observable<FeesRD> = client$.pipe(
-  mergeMap(FP.pipe(O.fold(() => Rx.of(RD.initial), loadFees$))),
+const fees$: FeesLD = Rx.combineLatest([reloadFees$, client$]).pipe(
+  mergeMap(([_, oClient]) =>
+    FP.pipe(
+      // client and asset has to be available
+      oClient,
+      // ignore all assets from other chains than BNB
+      O.fold(
+        () => Rx.of(RD.initial),
+        (client) => loadFees$(client)
+      )
+    )
+  ),
+  startWith(RD.initial),
   shareReplay(1)
 )
 
@@ -380,6 +395,16 @@ const freezeFee$: Observable<FeeRD> = FP.pipe(
   fees$,
   liveData.map(getFreezeFee),
   liveData.chain(liveData.fromEither),
+  shareReplay(1)
+)
+
+/**
+ * Amount of stake `Fee`
+ */
+export const stakeFee$: FeeLD = FP.pipe(
+  transferFees$,
+  liveData.map((fees) => fees.single),
+  liveData.map(assetToBase),
   shareReplay(1)
 )
 
@@ -412,5 +437,6 @@ export {
   transaction,
   freeze,
   transferFees$,
-  freezeFee$
+  freezeFee$,
+  reloadFees
 }

--- a/src/renderer/services/binance/service.ts
+++ b/src/renderer/services/binance/service.ts
@@ -347,7 +347,7 @@ const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
  * Observable to load transaction fees from Binance API endpoint
  * If client is not available, it returns an `initial` state
  */
-const loadFees$ = (client: BinanceClient) =>
+const loadFees$ = (client: BinanceClient): FeesLD =>
   Rx.from(client.getFees()).pipe(
     map(RD.success),
     catchError((error) => Rx.of(RD.failure(error))),

--- a/src/renderer/services/binance/types.ts
+++ b/src/renderer/services/binance/types.ts
@@ -68,6 +68,7 @@ export type TransferFees = {
 
 export type FeeRD = RD.RemoteData<Error, AssetAmount>
 export type FeesRD = RD.RemoteData<Error, Fees>
+export type FeesLD = LiveData<Error, Fees>
 export type TransferFeesRD = RD.RemoteData<Error, TransferFees>
 
 export type LoadTxsProps = {

--- a/src/renderer/services/bitcoin/context.ts
+++ b/src/renderer/services/bitcoin/context.ts
@@ -1,8 +1,10 @@
 import { assetWB$, reloadBalances } from './balances'
 import { client$, clientViewState$, address$, explorerUrl$ } from './common'
+import { createFeesService } from './fees'
 import { createTransactionService } from './transaction'
 
-const { fees$, pushTx, reloadFees, txRD$, resetTx, loadAssetTxs, assetTxs$ } = createTransactionService(client$)
+const { pushTx, txRD$, resetTx, loadAssetTxs, assetTxs$ } = createTransactionService(client$)
+const { fees$, reloadFees, stakeFee$ } = createFeesService(client$)
 
 /**
  * Exports all functions and observables needed at UI level (provided by `BitcoinContext`)
@@ -15,6 +17,7 @@ export {
   reloadBalances,
   assetWB$,
   fees$,
+  stakeFee$,
   pushTx,
   reloadFees,
   txRD$,

--- a/src/renderer/services/bitcoin/fees.ts
+++ b/src/renderer/services/bitcoin/fees.ts
@@ -49,8 +49,7 @@ const fees$: FeesLD = Rx.combineLatest([oClient$, reloadFees$]).pipe(
  */
 const fastTxFee$: FeeLD = FP.pipe(
   fees$,
-  liveData.map((fees) => baseAmount(fees.fast.feeTotal, BTC_DECIMAL)),
-  shareReplay(1)
+  liveData.map((fees) => baseAmount(fees.fast.feeTotal, BTC_DECIMAL))
 )
 
 /**

--- a/src/renderer/services/bitcoin/fees.ts
+++ b/src/renderer/services/bitcoin/fees.ts
@@ -11,7 +11,7 @@ import { liveData } from '../../helpers/rx/liveData'
 import { triggerStream } from '../../helpers/stateHelper'
 import { FeeLD } from '../chain/types'
 import { Client$ } from './common'
-import { FeesService, FeesLD, FeesRD } from './types'
+import { FeesService, FeesLD } from './types'
 
 // reference to current client$
 const oClient$ = Rx.identity
@@ -23,7 +23,7 @@ const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
  * Observable to load transaction fees
  * If a client is not available, it returns an `initial` state
  */
-const loadFees$ = (client: BitcoinClient, memo?: string): Rx.Observable<FeesRD> =>
+const loadFees$ = (client: BitcoinClient, memo?: string): FeesLD =>
   Rx.from(client.calcFees(memo)).pipe(
     map(RD.success),
     catchError((error) => Rx.of(RD.failure(error))),

--- a/src/renderer/services/bitcoin/fees.ts
+++ b/src/renderer/services/bitcoin/fees.ts
@@ -1,0 +1,76 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { Client as BitcoinClient } from '@thorchain/asgardex-bitcoin'
+import { baseAmount } from '@thorchain/asgardex-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
+import { catchError, map, mergeMap, shareReplay, startWith } from 'rxjs/operators'
+
+import { BTC_DECIMAL } from '../../helpers/assetHelper'
+import { liveData } from '../../helpers/rx/liveData'
+import { triggerStream } from '../../helpers/stateHelper'
+import { FeeLD } from '../chain/types'
+import { Client$ } from './common'
+import { FeesService, FeesLD, FeesRD } from './types'
+
+// reference to current client$
+const oClient$ = Rx.identity
+
+// `TriggerStream` to reload `fees`
+const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
+
+/**
+ * Observable to load transaction fees
+ * If a client is not available, it returns an `initial` state
+ */
+const loadFees$ = (client: BitcoinClient, memo?: string): Rx.Observable<FeesRD> =>
+  Rx.from(client.calcFees(memo)).pipe(
+    map(RD.success),
+    catchError((error) => Rx.of(RD.failure(error))),
+    startWith(RD.pending)
+  )
+
+/**
+ * Transaction fees
+ * If a client is not available, it returns `None`
+ */
+const fees$: FeesLD = Rx.combineLatest([oClient$, reloadFees$]).pipe(
+  mergeMap(([oClient, _]) =>
+    FP.pipe(
+      oClient,
+      O.fold(() => Rx.of(RD.initial), loadFees$)
+    )
+  ),
+  shareReplay(1)
+)
+
+/**
+ * Fee for fast tx
+ */
+const fastTxFee$: FeeLD = FP.pipe(
+  fees$,
+  liveData.map((fees) => baseAmount(fees.fast.feeTotal, BTC_DECIMAL)),
+  shareReplay(1)
+)
+
+/**
+ * Fee for fast tx
+ */
+const stakeFee$: FeeLD = fastTxFee$.pipe(Rx.identity)
+
+/**
+ * The only thing we export from this module is this factory
+ * and it's called by `./context.ts` only once
+ * ^ That's needed to "inject" same reference of `client$` used by other modules into this module
+ */
+export const createFeesService = (client$: Client$): FeesService => {
+  // set client FIRST!!!
+  // Needed by other streams in this module
+  oClient$(client$)
+
+  return {
+    fees$,
+    stakeFee$,
+    reloadFees
+  }
+}

--- a/src/renderer/services/bitcoin/types.ts
+++ b/src/renderer/services/bitcoin/types.ts
@@ -5,6 +5,7 @@ import { BaseAmount } from '@thorchain/asgardex-util'
 import * as Rx from 'rxjs'
 
 import { LiveData } from '../../helpers/rx/liveData'
+import { FeeLD } from '../chain/types'
 import { ClientState } from '../types'
 import { ApiError, AssetTxsPageLD } from '../wallet/types'
 
@@ -26,9 +27,13 @@ export type SendTxParams = {
 export type TransactionService = {
   txRD$: LiveData<ApiError, string>
   pushTx: (p: SendTxParams) => Rx.Subscription
-  fees$: FeesLD
-  reloadFees: () => void
   resetTx: () => void
   assetTxs$: AssetTxsPageLD
   loadAssetTxs: () => void
+}
+
+export type FeesService = {
+  fees$: FeesLD
+  stakeFee$: FeeLD
+  reloadFees: () => void
 }

--- a/src/renderer/services/chain/context.ts
+++ b/src/renderer/services/chain/context.ts
@@ -1,0 +1,6 @@
+import { reloadFees, stakeFee$ } from './fees'
+
+/**
+ * Exports all functions and observables needed at UI level (provided by `ChainContext`)
+ */
+export { reloadFees, stakeFee$ }

--- a/src/renderer/services/chain/fees.ts
+++ b/src/renderer/services/chain/fees.ts
@@ -33,7 +33,7 @@ const reloadFeesByChain = (chain: Chain) => {
 }
 
 export const reloadFees$: Rx.Observable<O.Option<LoadFeesHandler>> = selectedPoolChain$.pipe(
-  RxOp.map(O.map((chain) => reloadFeesByChain(chain)))
+  RxOp.map(O.map(reloadFeesByChain))
 )
 
 const stakeFeeByChain$ = (chain: Chain): FeeLD => {
@@ -56,10 +56,7 @@ export const stakeFee$: FeeLD = selectedPoolChain$.pipe(
   RxOp.switchMap((oChain) =>
     FP.pipe(
       oChain,
-      O.fold(
-        () => Rx.of(RD.initial),
-        (chain) => stakeFeeByChain$(chain)
-      )
+      O.fold(() => Rx.of(RD.initial), stakeFeeByChain$)
     )
   )
 )

--- a/src/renderer/services/chain/fees.ts
+++ b/src/renderer/services/chain/fees.ts
@@ -1,0 +1,65 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { Chain } from '@thorchain/asgardex-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import * as BNB from '../binance/service'
+import * as BTC from '../bitcoin/context'
+import { selectedPoolChain$ } from '../midgard/common'
+import { LoadFeesHandler, FeeLD } from './types'
+
+export const reloadFees = () => {
+  BNB.reloadFees()
+  BTC.reloadFees()
+}
+
+const reloadFeesByChain = (chain: Chain) => {
+  switch (chain) {
+    case 'BNB':
+      return BNB.reloadFees
+    case 'BTC':
+      return BTC.reloadFees
+    case 'ETH':
+      // reload ETH balances - not available yet
+      return () => {}
+    case 'THOR':
+      // reload THOR fees - not available yet
+      return () => {}
+    default:
+      return () => {}
+  }
+}
+
+export const reloadFees$: Rx.Observable<O.Option<LoadFeesHandler>> = selectedPoolChain$.pipe(
+  RxOp.map(O.map((chain) => reloadFeesByChain(chain)))
+)
+
+const stakeFeeByChain$ = (chain: Chain): FeeLD => {
+  switch (chain) {
+    case 'BNB':
+      return BNB.stakeFee$
+    case 'BTC':
+      return BTC.stakeFee$
+    case 'ETH':
+      return Rx.of(RD.failure(new Error('Stake fee for ETH has not been implemented')))
+    case 'THOR':
+      return Rx.of(RD.failure(new Error('Stake fee for THOR has not been implemented')))
+    default:
+      return Rx.of(RD.failure(new Error(`Getting stake fees for ${chain} is not supported`)))
+  }
+}
+
+// export const stakeFee$: Rx.Observable<O.Option<AssetWithAmount>> = selectedChain$.pipe(
+export const stakeFee$: FeeLD = selectedPoolChain$.pipe(
+  RxOp.switchMap((oChain) =>
+    FP.pipe(
+      oChain,
+      O.fold(
+        () => Rx.of(RD.initial),
+        (chain) => stakeFeeByChain$(chain)
+      )
+    )
+  )
+)

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -1,0 +1,7 @@
+import { BaseAmount } from '@thorchain/asgardex-util'
+
+import { LiveData } from '../../helpers/rx/liveData'
+
+export type LoadFeesHandler = () => void
+
+export type FeeLD = LiveData<Error, BaseAmount>

--- a/src/renderer/services/midgard/common.ts
+++ b/src/renderer/services/midgard/common.ts
@@ -1,14 +1,22 @@
-import { Asset } from '@thorchain/asgardex-util'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
-import { distinctUntilChanged } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+import * as RxOp from 'rxjs/operators'
 
 import { eqOAsset } from '../../helpers/fp/eq'
 import { observableState } from '../../helpers/stateHelper'
+import { SelectedPoolAsset, SelectedPoolChain } from './types'
 
 /** Selected pool asset */
-const { get$: getSelectedPoolAsset$, set: setSelectedPoolAsset } = observableState<O.Option<Asset>>(O.none)
+const { get$: getSelectedPoolAsset$, set: setSelectedPoolAsset } = observableState<SelectedPoolAsset>(O.none)
 
 // "dirty check" to trigger "real" changes of an asset only
-const selectedPoolAsset$ = getSelectedPoolAsset$.pipe(distinctUntilChanged(eqOAsset.equals))
+const selectedPoolAsset$: Observable<SelectedPoolAsset> = getSelectedPoolAsset$.pipe(
+  RxOp.distinctUntilChanged(eqOAsset.equals)
+)
 
-export { selectedPoolAsset$, setSelectedPoolAsset }
+const selectedPoolChain$: Observable<SelectedPoolChain> = selectedPoolAsset$.pipe(
+  RxOp.map(FP.flow(O.map(({ chain }) => chain)))
+)
+
+export { selectedPoolAsset$, setSelectedPoolAsset, selectedPoolChain$ }

--- a/src/renderer/services/midgard/common.ts
+++ b/src/renderer/services/midgard/common.ts
@@ -1,4 +1,3 @@
-import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -15,8 +14,6 @@ const selectedPoolAsset$: Observable<SelectedPoolAsset> = getSelectedPoolAsset$.
   RxOp.distinctUntilChanged(eqOAsset.equals)
 )
 
-const selectedPoolChain$: Observable<SelectedPoolChain> = selectedPoolAsset$.pipe(
-  RxOp.map(FP.flow(O.map(({ chain }) => chain)))
-)
+const selectedPoolChain$: Observable<SelectedPoolChain> = selectedPoolAsset$.pipe(RxOp.map(O.map(({ chain }) => chain)))
 
 export { selectedPoolAsset$, setSelectedPoolAsset, selectedPoolChain$ }

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Asset, Chain } from '@thorchain/asgardex-util'
 import BigNumber from 'bignumber.js'
-import { Option } from 'fp-ts/lib/Option'
+import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
 import { LiveData } from '../../helpers/rx/liveData'
@@ -44,12 +44,15 @@ export type PoolsState = {
   assetDetails: AssetDetails
   poolAssets: PoolStringAssets
   poolDetails: PoolDetails
-  pricePools: Option<PricePools>
+  pricePools: O.Option<PricePools>
 }
 export type PoolsStateRD = RD.RemoteData<Error, PoolsState>
 export type PoolsStateLD = LiveData<Error, PoolsState>
 
-export type SelectedPricePoolAsset = Option<PricePoolAsset>
+export type SelectedPoolAsset = O.Option<Asset>
+export type SelectedPoolChain = O.Option<Chain>
+
+export type SelectedPricePoolAsset = O.Option<PricePoolAsset>
 
 export type SelectedPricePool = PricePool
 
@@ -71,7 +74,7 @@ export type PoolsService = {
   setSelectedPricePoolAsset: (asset: PricePoolAsset) => void
   selectedPricePoolAsset$: Rx.Observable<SelectedPricePoolAsset>
   selectedPricePool$: Rx.Observable<SelectedPricePool>
-  selectedPricePoolAssetSymbol$: Rx.Observable<Option<string>>
+  selectedPricePoolAssetSymbol$: Rx.Observable<O.Option<string>>
   reloadPools: () => void
   poolAddresses$: ThorchainEndpointsLD
   runeAsset$: Rx.Observable<Asset>


### PR DESCRIPTION
- [x] `ChainContext` + `services`
- [x] `selectedPoolChain$` (to provide state of selected `chain` depending on `selectedPoolAsset$`)
- [x] Get `stake` fees for multi-chain (currently `BNC` + `BTC`)
- [x] `Eq` instances: `eqChain`, `eqOChain` (incl. tests)
- [x] Remove uneeded `children` prop from all `<Provider>`s

Closes #534 