### PR TITLE
Load / show fees for cross-chain deposits

### DIFF
--- a/src/renderer/components/stake/add/AddStake.helper.ts
+++ b/src/renderer/components/stake/add/AddStake.helper.ts
@@ -1,4 +1,11 @@
-import { baseAmount, BaseAmount, PoolData } from '@thorchain/asgardex-util'
+import {
+  Asset,
+  baseAmount,
+  BaseAmount,
+  baseToAsset,
+  formatAssetAmountCurrency,
+  PoolData
+} from '@thorchain/asgardex-util'
 
 import { THORCHAIN_DECIMAL } from '../../../helpers/assetHelper'
 
@@ -55,3 +62,10 @@ export const getAssetAmountToStake = (
     runeAmount.amount().times(poolAssetBalance.amount().dividedBy(poolRuneBalance.amount())),
     THORCHAIN_DECIMAL
   )
+
+export const formatFee = (fee: BaseAmount, asset: Asset) =>
+  formatAssetAmountCurrency({
+    amount: baseToAsset(fee),
+    asset,
+    trimZeros: true
+  })

--- a/src/renderer/components/stake/add/AddStake.stories.tsx
+++ b/src/renderer/components/stake/add/AddStake.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { storiesOf } from '@storybook/react'
 import { bn, assetAmount, assetToBase, AssetRune67C, AssetBNB, baseAmount, AssetBTC } from '@thorchain/asgardex-util'
+import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_MAINNET } from '../../../../shared/mock/assets'
 import { TRANSFER_FEES } from '../../../../shared/mock/fees'
@@ -18,7 +19,7 @@ const poolData = {
 const assets = [AssetBNB, AssetBTC, ASSETS_MAINNET.TOMO]
 const fees: StakeFeesRD = RD.success({
   base: assetToBase(TRANSFER_FEES.single),
-  pool: assetToBase(TRANSFER_FEES.single)
+  cross: O.none
 })
 const reloadFeesHandler = () => console.log('reload fees')
 
@@ -58,7 +59,7 @@ export const AddAsymCrossStakeStory = () => {
       reloadFees={reloadFeesHandler}
       fees={RD.success({
         base: assetToBase(TRANSFER_FEES.single),
-        pool: baseAmount(12300)
+        cross: O.some(baseAmount(12300))
       })}
       poolData={poolData}
       priceAsset={AssetRune67C}

--- a/src/renderer/components/stake/add/AddStake.stories.tsx
+++ b/src/renderer/components/stake/add/AddStake.stories.tsx
@@ -3,10 +3,10 @@ import React from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { storiesOf } from '@storybook/react'
 import { bn, assetAmount, assetToBase, AssetRune67C, AssetBNB, baseAmount, AssetBTC } from '@thorchain/asgardex-util'
-import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_MAINNET } from '../../../../shared/mock/assets'
 import { TRANSFER_FEES } from '../../../../shared/mock/fees'
+import { StakeFeesRD } from '../../../services/chain/types'
 import { AddStake } from './AddStake'
 
 const assetBalance = assetToBase(assetAmount(200))
@@ -16,9 +16,11 @@ const poolData = {
   runeBalance: baseAmount('2000')
 }
 const assets = [AssetBNB, AssetBTC, ASSETS_MAINNET.TOMO]
-const chainAsset = O.some(AssetBNB)
-const fee = RD.success(assetToBase(TRANSFER_FEES.single))
-const reloadFeeHandler = () => console.log('reload fee')
+const fees: StakeFeesRD = RD.success({
+  base: assetToBase(TRANSFER_FEES.single),
+  pool: assetToBase(TRANSFER_FEES.single)
+})
+const reloadFeesHandler = () => console.log('reload fees')
 
 export const AddAsymStakeStory = () => {
   return (
@@ -32,15 +34,39 @@ export const AddAsymStakeStory = () => {
       runeBalance={runeBalance}
       onStake={console.log}
       onChangeAsset={console.log}
-      reloadFee={reloadFeeHandler}
-      chainAsset={chainAsset}
-      fee={fee}
+      reloadFees={reloadFeesHandler}
+      fees={fees}
       poolData={poolData}
       priceAsset={AssetRune67C}
       assets={assets}
     />
   )
 }
+
+export const AddAsymCrossStakeStory = () => {
+  return (
+    <AddStake
+      type="asym"
+      asset={AssetBTC}
+      runeAsset={AssetRune67C}
+      assetPrice={bn(2)}
+      runePrice={bn(1)}
+      assetBalance={assetBalance}
+      runeBalance={runeBalance}
+      onStake={console.log}
+      onChangeAsset={console.log}
+      reloadFees={reloadFeesHandler}
+      fees={RD.success({
+        base: assetToBase(TRANSFER_FEES.single),
+        pool: baseAmount(12300)
+      })}
+      poolData={poolData}
+      priceAsset={AssetRune67C}
+      assets={assets}
+    />
+  )
+}
+
 export const AddSymStakeStory = () => {
   return (
     <AddStake
@@ -53,9 +79,8 @@ export const AddSymStakeStory = () => {
       runeBalance={runeBalance}
       onStake={console.log}
       onChangeAsset={console.log}
-      chainAsset={chainAsset}
-      fee={fee}
-      reloadFee={reloadFeeHandler}
+      fees={fees}
+      reloadFees={reloadFeesHandler}
       poolData={poolData}
       priceAsset={AssetRune67C}
       assets={assets}
@@ -63,4 +88,7 @@ export const AddSymStakeStory = () => {
   )
 }
 
-storiesOf('Components/Stake/AddStake', module).add('sym', AddSymStakeStory).add('asym', AddAsymStakeStory)
+storiesOf('Components/Stake/AddStake', module)
+  .add('sym', AddSymStakeStory)
+  .add('asym', AddAsymStakeStory)
+  .add('asym - cross-chain', AddAsymCrossStakeStory)

--- a/src/renderer/components/stake/add/AddStake.style.ts
+++ b/src/renderer/components/stake/add/AddStake.style.ts
@@ -1,6 +1,7 @@
 import { Col, Row } from 'antd'
 import styled from 'styled-components'
 
+import { media } from '../../../helpers/styleHelper'
 import { AssetCard as BaseAssetCard } from '../../uielements/assets/assetCard'
 import { Button as UIButton } from '../../uielements/button'
 import { Label as UILabel } from '../../uielements/label'
@@ -34,11 +35,21 @@ export const AssetCard = styled(BaseAssetCard)`
 export const DragWrapper = styled('div')`
   padding: 20px;
 `
+export const FeeRow = styled(Row).attrs({
+  align: 'middle'
+})`
+  padding-bottom: 20px;
+
+  ${media.xl`
+  padding-bottom: 0px;
+`}
+`
 
 export const FeeLabel = styled(UILabel).attrs({
   size: 'normal'
 })`
   padding: 0;
+  min-width: 150px; /* needed for loader */
 `
 export const ReloadFeeButton = styled(UIButton).attrs({
   typevalue: 'outline'

--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -24,8 +24,6 @@ export const BASE_CHAIN: Chain = 'BNB'
 
 /**
  * Asset of "base" chain RUNE is currently running on
- * BNB for now, but it will be changed to `NativeRUNE` in the near future
- * TODO(@veado): Change it if we go live with `NativeRUNE`
  */
 export const BASE_CHAIN_ASSET: Asset = getChainAsset(BASE_CHAIN)
 

--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -8,14 +8,30 @@ import {
   AssetETH,
   Asset,
   assetToString,
-  baseAmount
+  baseAmount,
+  Chain
 } from '@thorchain/asgardex-util'
 
+import { getChainAsset } from './helpers/chainHelper'
 import { PricePoolCurrencyWeights, PricePoolAssets } from './views/pools/Pools.types'
 
-// BUSD testnet
+/**
+ * "Base" chain RUNE is currently running
+ * BNC for now, but it will be changed to `THOR` in the near future
+ * TODO(@veado): Change it if we go live with `NativeRUNE`
+ */
+export const BASE_CHAIN: Chain = 'BNB'
+
+/**
+ * Asset of "base" chain RUNE is currently running on
+ * BNB for now, but it will be changed to `NativeRUNE` in the near future
+ * TODO(@veado): Change it if we go live with `NativeRUNE`
+ */
+export const BASE_CHAIN_ASSET: Asset = getChainAsset(BASE_CHAIN)
+
+// BUSD testnet (neded for pricing)
 export const AssetBUSDBAF: Asset = { chain: 'BNB', symbol: 'BUSD-BAF', ticker: 'BUSD' }
-// BUSD mainnet
+// BUSD mainnet (neded for pricing)
 export const AssetBUSDBD1: Asset = { chain: 'BNB', symbol: 'BUSD-BD1', ticker: 'BUSD' }
 
 export const PRICE_ASSETS: PricePoolAssets = [

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -1,17 +1,15 @@
 import React, { createContext, useContext } from 'react'
 
-import { stakeFee$, reloadFees, chainAsset$ } from '../services/chain/context'
+import { stakeFees$, reloadFees } from '../services/chain/context'
 
 type ChainContextValue = {
-  stakeFee$: typeof stakeFee$
+  stakeFees$: typeof stakeFees$
   reloadFees: typeof reloadFees
-  chainAsset$: typeof chainAsset$
 }
 
 const initialContext: ChainContextValue = {
-  stakeFee$,
-  reloadFees,
-  chainAsset$
+  stakeFees$,
+  reloadFees
 }
 const ChainContext = createContext<ChainContextValue | null>(null)
 

--- a/src/renderer/helpers/chainHelper.ts
+++ b/src/renderer/helpers/chainHelper.ts
@@ -1,0 +1,14 @@
+import { Asset, AssetBNB, AssetBTC, AssetETH, AssetRuneNative, Chain } from '@thorchain/asgardex-util'
+
+export const getChainAsset = (chain: Chain): Asset => {
+  switch (chain) {
+    case 'BNB':
+      return AssetBNB
+    case 'BTC':
+      return AssetBTC
+    case 'ETH':
+      return AssetETH
+    case 'THOR':
+      return AssetRuneNative
+  }
+}

--- a/src/renderer/helpers/fpHelpers.test.ts
+++ b/src/renderer/helpers/fpHelpers.test.ts
@@ -6,11 +6,6 @@ import { sequenceTOptionFromArray, sequenceTRDFromArray } from './fpHelpers'
 
 describe('helpers/envHelper/', () => {
   describe('sequenceTOptionFromArray', () => {
-    it('returns none for an empty list', () => {
-      const result = FP.pipe([], sequenceTOptionFromArray)
-      expect(result).toBeNone()
-    })
-
     it('returns none for a list with none inside', () => {
       const result = FP.pipe([O.none, O.some(1)], sequenceTOptionFromArray)
       expect(result).toBeNone()
@@ -23,30 +18,24 @@ describe('helpers/envHelper/', () => {
   })
 
   describe('sequenceTRDFromArray', () => {
-    const onEmpty = () => 'empty'
-    it('returns `failure` for an empty list', () => {
-      const result = FP.pipe([], sequenceTRDFromArray<string, string>(onEmpty))
-      expect(result).toEqual(RD.failure('empty'))
-    })
-
     it('returns `failure` for a RD list with failures inside', () => {
-      const result = FP.pipe([RD.failure('another error'), RD.success(1)], sequenceTRDFromArray(onEmpty))
+      const result = FP.pipe([RD.failure('another error'), RD.success(1)], sequenceTRDFromArray)
       expect(result).toEqual(RD.failure('another error'))
     })
 
     it('returns `pending` for a RD list with `pending` inside', () => {
-      const result = FP.pipe([RD.success(1), RD.pending], sequenceTRDFromArray(onEmpty))
+      const result = FP.pipe([RD.success(1), RD.pending], sequenceTRDFromArray)
       expect(result).toEqual(RD.pending)
     })
 
     it('returns `pending` for a RD list with `pending` inside', () => {
       const progress = { loaded: 100, total: O.none }
-      const result = FP.pipe([RD.success(1), RD.progress(progress)], sequenceTRDFromArray(onEmpty))
+      const result = FP.pipe([RD.success(1), RD.progress(progress)], sequenceTRDFromArray)
       expect(result).toEqual(RD.progress(progress))
     })
 
     it('Lifts all `success` values', () => {
-      const result = FP.pipe([RD.success(1), RD.success(2)], sequenceTRDFromArray(onEmpty))
+      const result = FP.pipe([RD.success(1), RD.success(2)], sequenceTRDFromArray)
       expect(result).toEqual(RD.success([1, 2]))
     })
   })

--- a/src/renderer/helpers/fpHelpers.ts
+++ b/src/renderer/helpers/fpHelpers.ts
@@ -1,6 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Lazy } from 'fp-ts/function'
 import { sequenceT } from 'fp-ts/lib/Apply'
+import { array } from 'fp-ts/lib/Array'
 import * as O from 'fp-ts/lib/Option'
 
 /**
@@ -8,23 +9,10 @@ import * as O from 'fp-ts/lib/Option'
  */
 
 export const sequenceTOption = sequenceT(O.option)
-export const sequenceTOptionFromArray = <A>([first, ...rest]: O.Option<A>[]): O.Option<A[]> => {
-  if (!first) {
-    return O.none
-  }
+export const sequenceTOptionFromArray = array.sequence(O.option)
 
-  return sequenceTOption(first, ...rest)
-}
 export const sequenceTRD = sequenceT(RD.remoteData)
-export const sequenceTRDFromArray = <E, A>(onEmpty: () => E) => ([first, ...rest]: RD.RemoteData<
-  E,
-  A
->[]): RD.RemoteData<E, A[]> => {
-  if (!first) {
-    return RD.failure(onEmpty())
-  }
-  return sequenceTRD(first, ...rest)
-}
+export const sequenceTRDFromArray = array.sequence(RD.remoteData)
 
 /**
  * Creation

--- a/src/renderer/helpers/funcHelper.ts
+++ b/src/renderer/helpers/funcHelper.ts
@@ -1,0 +1,2 @@
+export type EmptyFunc = () => void
+export const emptyFunc = () => {}

--- a/src/renderer/services/chain/asset.ts
+++ b/src/renderer/services/chain/asset.ts
@@ -1,5 +1,4 @@
-import { Asset, AssetBNB, AssetBTC, AssetETH, Chain } from '@thorchain/asgardex-util'
-import * as FP from 'fp-ts/lib/function'
+import { Chain } from '@thorchain/asgardex-util'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -33,24 +32,4 @@ const reloadFeesByChain = (chain: Chain) => {
 
 export const reloadFees$: Rx.Observable<O.Option<LoadFeesHandler>> = selectedPoolChain$.pipe(
   RxOp.map(O.map(reloadFeesByChain))
-)
-
-const getChainAsset = (chain: Chain): O.Option<Asset> => {
-  switch (chain) {
-    case 'BNB':
-      return O.some(AssetBNB)
-    case 'BTC':
-      return O.some(AssetBTC)
-    case 'ETH':
-      return O.some(AssetETH)
-    case 'THOR':
-      // not defined
-      return O.none
-    default:
-      return O.none
-  }
-}
-
-export const chainAsset$: Rx.Observable<O.Option<Asset>> = selectedPoolChain$.pipe(
-  RxOp.map((oChain) => FP.pipe(oChain, O.chain(getChainAsset)))
 )

--- a/src/renderer/services/chain/context.ts
+++ b/src/renderer/services/chain/context.ts
@@ -1,7 +1,6 @@
-import { chainAsset$ } from './asset'
-import { reloadFees, stakeFee$ } from './fees'
+import { reloadFees, stakeFees$ } from './fees'
 
 /**
  * Exports all functions and observables needed at UI level (provided by `ChainContext`)
  */
-export { reloadFees, stakeFee$, chainAsset$ }
+export { reloadFees, stakeFees$ }

--- a/src/renderer/services/chain/fees.ts
+++ b/src/renderer/services/chain/fees.ts
@@ -43,7 +43,7 @@ Rx.combineLatest([selectedPoolChain$, reloadFees$])
           oChain,
           O.map((chain) => {
             reloadFeesByChain(chain)
-            // reload base chain if it's different to selected chain (needed for fees to transfer RUNE assets on base chain)
+            // reload base-chain if it's different to selected pool-chain (needed for fees to transfer RUNE assets on base chain)
             if (!eqChain.equals(chain, BASE_CHAIN)) reloadFeesByChain(BASE_CHAIN)
             return true
           })

--- a/src/renderer/services/chain/fees.ts
+++ b/src/renderer/services/chain/fees.ts
@@ -7,6 +7,8 @@ import * as RxOp from 'rxjs/operators'
 
 import { BASE_CHAIN } from '../../const'
 import { eqChain } from '../../helpers/fp/eq'
+import { sequenceTRDFromArray } from '../../helpers/fpHelpers'
+import { liveData } from '../../helpers/rx/liveData'
 import { triggerStream } from '../../helpers/stateHelper'
 import * as BNB from '../binance/service'
 import * as BTC from '../bitcoin/context'
@@ -37,17 +39,15 @@ const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
 // reload fees
 Rx.combineLatest([selectedPoolChain$, reloadFees$])
   .pipe(
-    RxOp.switchMap(([oChain]) =>
-      Rx.of(
-        FP.pipe(
-          oChain,
-          O.map((chain) => {
-            reloadFeesByChain(chain)
-            // reload base-chain if it's different to selected pool-chain (needed for fees to transfer RUNE assets on base chain)
-            if (!eqChain.equals(chain, BASE_CHAIN)) reloadFeesByChain(BASE_CHAIN)
-            return true
-          })
-        )
+    RxOp.tap(([oChain, _]) =>
+      FP.pipe(
+        oChain,
+        O.map((chain) => {
+          reloadFeesByChain(chain)
+          // reload base-chain if it's different to selected pool-chain (needed for fees to transfer RUNE assets on base chain)
+          if (!eqChain.equals(chain, BASE_CHAIN)) reloadFeesByChain(BASE_CHAIN)
+          return true
+        })
       )
     )
   )
@@ -70,20 +70,21 @@ const stakeFees$: StakeFeesLD = selectedPoolAsset$.pipe(
   RxOp.switchMap((oPoolAsset) =>
     FP.pipe(
       oPoolAsset,
-      O.fold(
-        () => Rx.of(RD.initial),
-        (poolAsset) =>
-          FP.pipe(
-            Rx.combineLatest([stakeFeeByChain$(BASE_CHAIN), stakeFeeByChain$(poolAsset.chain)]),
-            RxOp.map((fees) => RD.combine(...fees)),
-            RxOp.map(
-              RD.map(([base, pool]) => ({
-                base,
-                pool
-              }))
-            )
-          )
-      )
+      O.map((poolAsset) =>
+        FP.pipe(
+          Rx.combineLatest(
+            eqChain.equals(BASE_CHAIN, poolAsset.chain)
+              ? [stakeFeeByChain$(BASE_CHAIN)]
+              : [stakeFeeByChain$(BASE_CHAIN), stakeFeeByChain$(poolAsset.chain)]
+          ),
+          RxOp.map(sequenceTRDFromArray),
+          liveData.map(([base, cross]) => ({
+            base,
+            cross: O.fromNullable(cross)
+          }))
+        )
+      ),
+      O.getOrElse((): StakeFeesLD => Rx.of(RD.initial))
     )
   )
 )

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -11,8 +11,11 @@ export type FeeLD = LiveData<Error, BaseAmount>
 /**
  * Stake fees
  *
+ * For cross-chain deposits we do need one or two fees:
+ *
+ * pool: Fee for selected "pool-chain", which might be different to "base-chain"
+ * AND / OR
  * base: Fee for "base-chain" pool (base chain is the chain where RUNE is running)
- * cross: Fee for "cross-chain" pool
  */
 export type StakeFees = { base: BaseAmount; pool: BaseAmount }
 export type StakeFeesRD = RD.RemoteData<Error, StakeFees>

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -1,5 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { BaseAmount } from '@thorchain/asgardex-util'
+import * as O from 'fp-ts/lib/Option'
 
 import { LiveData } from '../../helpers/rx/liveData'
 
@@ -11,12 +12,11 @@ export type FeeLD = LiveData<Error, BaseAmount>
 /**
  * Stake fees
  *
- * For cross-chain deposits we do need one or two fees:
+ * For deposits we do need one or two fees:
  *
- * pool: Fee for selected "pool-chain", which might be different to "base-chain"
- * AND / OR
  * base: Fee for "base-chain" pool (base chain is the chain where RUNE is running)
+ * cross: Fee for a cross "pool-chain" (for cross-chain deposits only - it will be `none` in other case)
  */
-export type StakeFees = { base: BaseAmount; pool: BaseAmount }
+export type StakeFees = { base: BaseAmount; cross: O.Option<BaseAmount> }
 export type StakeFeesRD = RD.RemoteData<Error, StakeFees>
 export type StakeFeesLD = LiveData<Error, StakeFees>

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -7,3 +7,13 @@ export type LoadFeesHandler = () => void
 
 export type FeeRD = RD.RemoteData<Error, BaseAmount>
 export type FeeLD = LiveData<Error, BaseAmount>
+
+/**
+ * Stake fees
+ *
+ * base: Fee for "base-chain" pool (base chain is the chain where RUNE is running)
+ * cross: Fee for "cross-chain" pool
+ */
+export type StakeFees = { base: BaseAmount; pool: BaseAmount }
+export type StakeFeesRD = RD.RemoteData<Error, StakeFees>
+export type StakeFeesLD = LiveData<Error, StakeFees>

--- a/src/renderer/services/midgard/service.ts
+++ b/src/renderer/services/midgard/service.ts
@@ -154,6 +154,7 @@ export const service = {
   thorchainLastblockState$,
   reloadThorchainLastblock,
   setSelectedPoolAsset,
+  selectedPoolAsset$,
   apiEndpoint$: byzantine$,
   reloadApiEndpoint: reloadByzantine,
   pools: createPoolsService(byzantine$, getMidgardDefaultApi, selectedPoolAsset$),

--- a/src/renderer/views/stake/add/AddStakeView.tsx
+++ b/src/renderer/views/stake/add/AddStakeView.tsx
@@ -14,6 +14,7 @@ import { useChainContext } from '../../../contexts/ChainContext'
 import { useMidgardContext } from '../../../contexts/MidgardContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
 import { sequenceTRD } from '../../../helpers/fpHelpers'
+import { emptyFunc } from '../../../helpers/funcHelper'
 import * as stakeRoutes from '../../../routes/stake'
 import { PoolDetailRD } from '../../../services/midgard/types'
 import { getPoolDetail, toPoolData } from '../../../services/midgard/utils'
@@ -89,31 +90,29 @@ export const AddStakeView: React.FC<Props> = ({ asset, runeAsset, type = 'asym' 
     RD.map((state) => bnOrZero(state.price).multipliedBy(runPrice))
   )
 
-  const { stakeFee$, chainAsset$, reloadFees } = useChainContext()
-  const stakeFeeRD = useObservableState(stakeFee$, RD.initial)
-  const oChainAsset = useObservableState(chainAsset$, O.none)
+  const { stakeFees$, reloadFees } = useChainContext()
+  const stakeFees = useObservableState(stakeFees$, RD.initial)
 
   const renderDisabledAddStake = useCallback(
     () => (
       <AddStake
         type={type}
-        onChangeAsset={() => {}}
+        onChangeAsset={emptyFunc}
         asset={asset}
         runeAsset={runeAsset}
         assetPrice={ZERO_BN}
         runePrice={ZERO_BN}
         assetBalance={ZERO_BASE_AMOUNT}
         runeBalance={ZERO_BASE_AMOUNT}
-        onStake={() => {}}
-        fee={RD.initial}
-        reloadFee={() => {}}
-        chainAsset={O.none}
+        onStake={emptyFunc}
+        fees={stakeFees}
+        reloadFees={emptyFunc}
         priceAsset={selectedPricePoolAsset}
         disabled={true}
         poolData={{ runeBalance: ZERO_BASE_AMOUNT, assetBalance: ZERO_BASE_AMOUNT }}
       />
     ),
-    [asset, runeAsset, selectedPricePoolAsset, type]
+    [asset, runeAsset, selectedPricePoolAsset, stakeFees, type]
   )
 
   return FP.pipe(
@@ -135,9 +134,8 @@ export const AddStakeView: React.FC<Props> = ({ asset, runeAsset, type = 'asym' 
             assetBalance={assetBalance}
             runeBalance={runeBalance}
             onStake={console.log}
-            fee={stakeFeeRD}
-            reloadFee={reloadFees}
-            chainAsset={oChainAsset}
+            fees={stakeFees}
+            reloadFees={reloadFees}
             priceAsset={selectedPricePoolAsset}
             assets={poolAssets}
           />


### PR DESCRIPTION
- [x] Add const `BASE_CHAIN` + `BASE_CHAIN_ASSET` - base chain == chain RUNE is running on (currently BNC)
- [x] Load / show `pool` and/or `base` fees (base == fees for base-chain /  pool == fees for cross-chain)
- [x] `emptyFunc` for lazy devs
- [x] Fix `sequenceT...` helpers (review suggestion)

Close ##552