### PR TITLE
Unlock wallet: Re-direct to previous view #523

### DIFF
--- a/src/renderer/components/wallet/add/AddWallet.tsx
+++ b/src/renderer/components/wallet/add/AddWallet.tsx
@@ -14,7 +14,7 @@ export const AddWallet: React.FC<Props> = ({ isLocked = false }) => {
   const intl = useIntl()
   const history = useHistory()
   const onButtonClick = useCallback(() => {
-    history.push(walletRoutes.base.path())
+    history.push(walletRoutes.base.path(history.location.pathname))
   }, [history])
 
   const intlLabelId = isLocked ? 'wallet.unlock.instruction' : 'wallet.connect.instruction'

--- a/src/renderer/components/wallet/unlock/UnlockForm.tsx
+++ b/src/renderer/components/wallet/unlock/UnlockForm.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect, useMemo } from 'react'
 
 import { Modal } from 'antd'
 import Form, { Rule } from 'antd/lib/form'
+import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
 import { none, Option, some } from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
@@ -9,6 +10,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 
 import { IS_PRODUCTION } from '../../../../shared/const'
 import { envOrDefault } from '../../../helpers/envHelper'
+import { getUrlSearchParam } from '../../../helpers/url.helper'
 import * as appRoutes from '../../../routes/app'
 import { RedirectRouteState } from '../../../routes/types'
 import * as walletRoutes from '../../../routes/wallet'
@@ -63,8 +65,11 @@ export const UnlockForm: React.FC<Props> = (props): JSX.Element => {
   // Re-direct to previous view after unlocking the wallet
   useEffect(() => {
     if (!isLocked(keystore) && !!validPassword) {
-      const from = location.state?.from?.pathname ?? walletRoutes.assets.template
-      history.push(from)
+      FP.pipe(
+        getUrlSearchParam(location.search, walletRoutes.REDIRECT_PARAMETER_NAME),
+        O.alt(() => O.some(location.state?.from?.pathname ?? walletRoutes.assets.template)),
+        O.map(history.push)
+      )
     }
   }, [keystore, validPassword, location, history])
 

--- a/src/renderer/helpers/url.helper.test.ts
+++ b/src/renderer/helpers/url.helper.test.ts
@@ -1,0 +1,20 @@
+import * as O from 'fp-ts/Option'
+
+import { getUrlSearchParam } from './url.helper'
+
+describe('helpers/url.helpers', () => {
+  describe('getUrlSearchParam', () => {
+    it('should return O.none', () => {
+      expect(getUrlSearchParam('', '')).toEqual(O.none)
+      expect(getUrlSearchParam('', 'param')).toEqual(O.none)
+      expect(getUrlSearchParam('http://valid.url?anotherValue', 'param')).toEqual(O.none)
+    })
+
+    it('should return O.some value', () => {
+      expect(getUrlSearchParam('?param=value', 'param')).toEqual(O.some('value'))
+      expect(getUrlSearchParam('http://valid.url?param=value', 'param')).toEqual(O.some('value'))
+      expect(getUrlSearchParam('http://valid.url?&another&param=value', 'param')).toEqual(O.some('value'))
+      expect(getUrlSearchParam('http://valid.url?&another&param=value', 'another')).toEqual(O.some(''))
+    })
+  })
+})

--- a/src/renderer/helpers/url.helper.ts
+++ b/src/renderer/helpers/url.helper.ts
@@ -1,0 +1,18 @@
+import * as O from 'fp-ts/Option'
+
+export const getUrlSearchParam = (queryString: string, paramName: string): O.Option<string> => {
+  const base = queryString.startsWith('http') ? '' : 'https://base'
+  const url = new URL(`${base}${queryString}`)
+
+  const searchStartIndex = url.href.indexOf('?')
+
+  if (searchStartIndex < 0) {
+    return O.none
+  }
+
+  const searchQuery = url.href.slice(searchStartIndex)
+
+  const searchParams = new URLSearchParams(searchQuery)
+
+  return O.fromNullable(searchParams.get(paramName))
+}

--- a/src/renderer/helpers/url.helper.ts
+++ b/src/renderer/helpers/url.helper.ts
@@ -1,11 +1,16 @@
 import * as O from 'fp-ts/Option'
 
+/**
+ * queryString might be a full valid address or just a search query
+ */
 export const getUrlSearchParam = (queryString: string, paramName: string): O.Option<string> => {
+  // Need to have fully valid address for URL constructor
   const base = queryString.startsWith('http') ? '' : 'https://base'
   const url = new URL(`${base}${queryString}`)
 
   const searchStartIndex = url.href.indexOf('?')
 
+  // if there is no `?` symbol => there is no search query at the address
   if (searchStartIndex < 0) {
     return O.none
   }

--- a/src/renderer/routes/wallet/wallet.ts
+++ b/src/renderer/routes/wallet/wallet.ts
@@ -1,10 +1,12 @@
 import { Route } from '../types'
 import * as createRoutes from './create'
 
-export const base: Route<void> = {
+type RedirectUrl = string
+
+export const base: Route<RedirectUrl | void> = {
   template: '/wallet',
-  path() {
-    return this.template
+  path(redirectUrl) {
+    return redirectUrl ? `${this.template}?redirectUrl=${redirectUrl}` : this.template
   }
 }
 
@@ -22,10 +24,12 @@ export const imports: Route<void> = {
   }
 }
 
-export const locked: Route<void> = {
+export const REDIRECT_PARAMETER_NAME = 'redirectUrl'
+
+export const locked: Route<RedirectUrl | void> = {
   template: `${base.template}/locked`,
-  path() {
-    return this.template
+  path(redirectUrl) {
+    return redirectUrl ? `${this.template}?${REDIRECT_PARAMETER_NAME}=${redirectUrl}` : this.template
   }
 }
 

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -108,6 +108,7 @@ export const WalletView: React.FC = (): JSX.Element => {
           <Redirect
             to={{
               pathname: walletRoutes.locked.path(),
+              search: location.search,
               state: { from: location } as RedirectRouteState
             }}
           />


### PR DESCRIPTION
search query was chosen as a way of passing information between redirected pages for the reason it's not gonna be lost in case of page reload instead of history's state. also this is more explicit and commonly used way to restore data / page's state

closes #523