### PR TITLE
[SWAP] fix transaction data information #688

### DIFF
--- a/src/renderer/components/modal/swap/SwapModal.stories.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.stories.tsx
@@ -27,7 +27,6 @@ export const StorySuccess: Story = () => (
     swapResultByBasePriceAsset={price}
     swapTargetAsset={AssetBNB}
     txStatus={txStatus}
-    visible
     maxSec={1}
   />
 )
@@ -42,7 +41,6 @@ export const StoryCompleted: Story = () => (
     swapResultByBasePriceAsset={price}
     swapTargetAsset={AssetBNB}
     txStatus={txStatus}
-    visible
     maxSec={1}
   />
 )

--- a/src/renderer/components/modal/swap/SwapModal.stories.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.stories.tsx
@@ -36,10 +36,10 @@ storiesOf('Components/Swap Modal', module).add('default', () => {
       <SwapModal
         calcResult={calcResult}
         isCompleted={false}
-        swapSource={ASSETS_MAINNET.RUNE}
-        priceFrom={assetToBase(assetAmount(5))}
-        priceTo={assetToBase(assetAmount(5))}
-        swapTarget={ASSETS_MAINNET.BNB}
+        swapSourceAsset={ASSETS_MAINNET.RUNE}
+        amountToSwapInSelectedPriceAsset={assetToBase(assetAmount(5))}
+        swapResultByBasePriceAsset={assetToBase(assetAmount(5))}
+        swapTargetAsset={ASSETS_MAINNET.BNB}
         txStatus={txStatus}
         visible
         maxSec={1}

--- a/src/renderer/components/modal/swap/SwapModal.stories.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.stories.tsx
@@ -1,49 +1,68 @@
 import React from 'react'
 
-import { storiesOf } from '@storybook/react'
-import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
-import BigNumber from 'bignumber.js'
+import { Story, Meta } from '@storybook/react'
+import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, bn } from '@xchainjs/xchain-util'
 
-import { ASSETS_MAINNET } from '../../../../shared/mock/assets'
 import { TxStatus, TxTypes } from '../../../types/asgardex'
 import { SwapModal } from './SwapModal'
-import { CalcResult } from './SwapModal.types'
 
-storiesOf('Components/Swap Modal', module).add('default', () => {
-  const txStatus: TxStatus = {
-    modal: true,
-    value: 25,
-    status: true,
-    type: TxTypes.SWAP,
-    startTime: Date.now(),
-    hash: 'FCA7F45C74278F819757DC00AB5289E1192F9EA31A6C31B0B300CFCDC7C70B64'
-  }
-  const calcResult: CalcResult = {
-    Px: new BigNumber(1),
-    slip: new BigNumber(0.01645550108862126),
-    outputAmount: assetAmount(1),
-    outputPrice: new BigNumber(556327544945582288316300000000),
-    fee: assetAmount(1)
-  }
+const txStatus: TxStatus = {
+  modal: true,
+  value: 25,
+  status: true,
+  type: TxTypes.SWAP,
+  startTime: Date.now(),
+  hash: 'FCA7F45C74278F819757DC00AB5289E1192F9EA31A6C31B0B300CFCDC7C70B64'
+}
+const slip = bn(0.01645550108862126)
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        width: '300px'
-      }}>
-      <SwapModal
-        calcResult={calcResult}
-        isCompleted={false}
-        swapSourceAsset={ASSETS_MAINNET.RUNE}
-        amountToSwapInSelectedPriceAsset={assetToBase(assetAmount(5))}
-        swapResultByBasePriceAsset={assetToBase(assetAmount(5))}
-        swapTargetAsset={ASSETS_MAINNET.BNB}
-        txStatus={txStatus}
-        visible
-        maxSec={1}
-      />
-    </div>
-  )
-})
+const price = assetToBase(assetAmount(5))
+
+export const StorySuccess: Story = () => (
+  <SwapModal
+    slip={slip}
+    isCompleted={false}
+    swapSourceAsset={AssetRuneNative}
+    amountToSwapInSelectedPriceAsset={price}
+    swapResultByBasePriceAsset={price}
+    swapTargetAsset={AssetBNB}
+    txStatus={txStatus}
+    visible
+    maxSec={1}
+  />
+)
+StorySuccess.storyName = 'success'
+
+export const StoryCompleted: Story = () => (
+  <SwapModal
+    slip={slip}
+    isCompleted={true}
+    swapSourceAsset={AssetRuneNative}
+    amountToSwapInSelectedPriceAsset={price}
+    swapResultByBasePriceAsset={price}
+    swapTargetAsset={AssetBNB}
+    txStatus={txStatus}
+    visible
+    maxSec={1}
+  />
+)
+StoryCompleted.storyName = 'completed'
+
+const meta: Meta = {
+  component: SwapModal,
+  title: 'Components/SwapModal',
+  decorators: [
+    (S: Story) => (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '300px'
+        }}>
+        <S />
+      </div>
+    )
+  ]
+}
+
+export default meta

--- a/src/renderer/components/modal/swap/SwapModal.style.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.style.tsx
@@ -57,31 +57,27 @@ export const CoinDataContainer = styled.div`
   }
 `
 
-export const SwapInfoWrapper = styled(Row)`
-  display: flex;
-  flex-direction: column;
-  padding: 20px 0;
+export const SwapInfoWrapper = styled(Row).attrs({
+  justify: 'center'
+})`
+  padding-bottom: 20px;
 `
 
-export const HashWrapper = styled.div`
-  display: flex;
-  align-items: center;
+export const TrendContainer = styled(Row).attrs({
+  justify: 'center'
+})`
+  padding-top: 20px;
+  width: 100%;
 `
 
-export const BtnCopyWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+export const HashWrapper = styled(Row).attrs({
+  justify: 'center'
+})``
 
-  border: 1px solid ${palette('gradient', 0)};
-  border-radius: 6px;
-  padding: 1px 4px;
-  margin-right: 6px;
-  margin-bottom: 16px;
-  color: ${palette('gradient', 0)};
-  cursor: pointer;
-`
+export const BtnCopyWrapper = styled(Row).attrs({
+  justify: 'center',
+  align: 'middle'
+})``
 
 export const ViewButton = styled(UIButton)`
   width: 300px;

--- a/src/renderer/components/modal/swap/SwapModal.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 
 import { Asset, BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
@@ -21,7 +21,6 @@ type Props = {
   isCompleted?: boolean
   amountToSwapInSelectedPriceAsset?: BaseAmount
   swapResultByBasePriceAsset?: BaseAmount
-  visible?: boolean
   onClose?: () => void
   onChangeTxTimer?: () => void
   onEndTxTimer?: () => void
@@ -40,7 +39,6 @@ export const SwapModal: React.FC<Props> = (props): JSX.Element => {
     swapSourceAsset,
     swapTargetAsset,
     txStatus,
-    visible = false,
     onClose = () => {},
     onChangeTxTimer = () => {},
     onClickFinish = () => {},
@@ -48,21 +46,20 @@ export const SwapModal: React.FC<Props> = (props): JSX.Element => {
     onViewTxClick = () => {},
     maxSec = Number.MAX_SAFE_INTEGER
   } = props
-  const [openSwapModal, setOpenSwapModal] = useState<boolean>(visible)
+
   const intl = useIntl()
 
   const swapTitleKey = isCompleted ? 'swap.state.success' : 'swap.swapping'
   const { status, value, startTime, hash } = txStatus
 
   const onCloseModal = useCallback(() => {
-    setOpenSwapModal(!openSwapModal)
-    if (onClose) onClose()
-  }, [openSwapModal, onClose])
+    onClose()
+  }, [onClose])
 
   return (
     <Styled.SwapModalWrapper
       title={intl.formatMessage({ id: swapTitleKey })}
-      visible={openSwapModal}
+      visible
       footer={null}
       onCancel={onCloseModal}>
       <Styled.SwapModalContent>

--- a/src/renderer/components/modal/swap/SwapModal.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { Asset, BaseAmount, baseAmount } from '@xchainjs/xchain-util'
+import BigNumber from 'bignumber.js'
 import { useIntl } from 'react-intl'
 
 import { TxStatus } from '../../../types/asgardex'
@@ -10,11 +11,10 @@ import { StepBar } from '../../uielements/stepBar'
 import { Trend } from '../../uielements/trend'
 import { TxTimer } from '../../uielements/txTimer'
 import * as Styled from './SwapModal.style'
-import { CalcResult } from './SwapModal.types'
 
 type Props = {
   basePriceAsset?: PricePoolAsset
-  calcResult: CalcResult
+  slip: BigNumber
   swapSourceAsset: Asset
   swapTargetAsset: Asset
   txStatus: TxStatus
@@ -33,7 +33,7 @@ type Props = {
 export const SwapModal: React.FC<Props> = (props): JSX.Element => {
   const {
     basePriceAsset,
-    calcResult,
+    slip,
     isCompleted = false,
     amountToSwapInSelectedPriceAsset = baseAmount(0),
     swapResultByBasePriceAsset = baseAmount(0),
@@ -51,8 +51,7 @@ export const SwapModal: React.FC<Props> = (props): JSX.Element => {
   const [openSwapModal, setOpenSwapModal] = useState<boolean>(visible)
   const intl = useIntl()
 
-  const swapTitleKey = isCompleted ? 'swap.state.success' : 'swap.state.pending'
-  const { slip: slipAmount } = calcResult
+  const swapTitleKey = isCompleted ? 'swap.state.success' : 'swap.swapping'
   const { status, value, startTime, hash } = txStatus
 
   const onCloseModal = useCallback(() => {
@@ -91,9 +90,11 @@ export const SwapModal: React.FC<Props> = (props): JSX.Element => {
               <AssetData priceBaseAsset={basePriceAsset} asset={swapTargetAsset} price={swapResultByBasePriceAsset} />
             </Styled.CoinDataContainer>
           </Styled.CoinDataWrapper>
+          <Styled.TrendContainer>
+            <Trend amount={slip} />
+          </Styled.TrendContainer>
         </Styled.SwapModalContentRow>
         <Styled.SwapInfoWrapper>
-          <Trend amount={slipAmount} />
           {hash && (
             <Styled.HashWrapper>
               <Styled.BtnCopyWrapper>

--- a/src/renderer/components/modal/swap/SwapModal.tsx
+++ b/src/renderer/components/modal/swap/SwapModal.tsx
@@ -13,14 +13,14 @@ import * as Styled from './SwapModal.style'
 import { CalcResult } from './SwapModal.types'
 
 type Props = {
-  baseAsset?: PricePoolAsset
+  basePriceAsset?: PricePoolAsset
   calcResult: CalcResult
-  swapSource: Asset
-  swapTarget: Asset
+  swapSourceAsset: Asset
+  swapTargetAsset: Asset
   txStatus: TxStatus
   isCompleted?: boolean
-  priceFrom?: BaseAmount
-  priceTo?: BaseAmount
+  amountToSwapInSelectedPriceAsset?: BaseAmount
+  swapResultByBasePriceAsset?: BaseAmount
   visible?: boolean
   onClose?: () => void
   onChangeTxTimer?: () => void
@@ -32,13 +32,13 @@ type Props = {
 
 export const SwapModal: React.FC<Props> = (props): JSX.Element => {
   const {
-    baseAsset,
+    basePriceAsset,
     calcResult,
     isCompleted = false,
-    priceFrom = baseAmount(0),
-    priceTo = baseAmount(0),
-    swapSource,
-    swapTarget,
+    amountToSwapInSelectedPriceAsset = baseAmount(0),
+    swapResultByBasePriceAsset = baseAmount(0),
+    swapSourceAsset,
+    swapTargetAsset,
     txStatus,
     visible = false,
     onClose = () => {},
@@ -83,8 +83,12 @@ export const SwapModal: React.FC<Props> = (props): JSX.Element => {
           <Styled.CoinDataWrapper>
             <StepBar size={50} />
             <Styled.CoinDataContainer>
-              <AssetData priceBaseAsset={baseAsset} asset={swapSource} price={priceFrom} />
-              <AssetData priceBaseAsset={baseAsset} asset={swapTarget} price={priceTo} />
+              <AssetData
+                priceBaseAsset={basePriceAsset}
+                asset={swapSourceAsset}
+                price={amountToSwapInSelectedPriceAsset}
+              />
+              <AssetData priceBaseAsset={basePriceAsset} asset={swapTargetAsset} price={swapResultByBasePriceAsset} />
             </Styled.CoinDataContainer>
           </Styled.CoinDataWrapper>
         </Styled.SwapModalContentRow>

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -39,7 +39,6 @@ import { TxStatus, TxTypes } from '../../types/asgardex'
 import { PricePool } from '../../views/pools/Pools.types'
 import { CurrencyInfo } from '../currency'
 import { SwapModal } from '../modal/swap'
-import { CalcResult } from '../modal/swap/SwapModal.types'
 import { AssetSelect } from '../uielements/assets/assetSelect'
 import { Fee, Fees } from '../uielements/fees'
 import { Modal } from '../uielements/modal'
@@ -73,7 +72,7 @@ export const Swap = ({
   poolDetails = [],
   walletBalances = O.none,
   txWithState = RD.initial,
-  goToTransaction,
+  goToTransaction = (_) => {},
   resetTx,
   activePricePool,
   PasswordConfirmation,
@@ -281,7 +280,7 @@ export const Swap = ({
       FP.pipe(
         txWithState,
         RD.fold(
-          () => null,
+          () => <></>,
           () => <Spin />,
           (error) => (
             <Modal
@@ -294,9 +293,9 @@ export const Swap = ({
               {error.message}
             </Modal>
           ),
-          (r) =>
+          ({ state, txHash }) =>
             FP.pipe(
-              r.state,
+              state,
               O.map(
                 (): TxStatus => ({
                   modal: true,
@@ -338,7 +337,7 @@ export const Swap = ({
                   <SwapModal
                     key={'swap modal result'}
                     basePriceAsset={activePricePool.asset}
-                    calcResult={{ slip: swapData.slip } as CalcResult}
+                    slip={swapData.slip}
                     swapSourceAsset={sourceAssetWP.asset}
                     swapTargetAsset={targetAssetWP.asset}
                     amountToSwapInSelectedPriceAsset={amountToSwapInSelectedPriceAsset}
@@ -346,14 +345,13 @@ export const Swap = ({
                     onClose={resetTx}
                     onClickFinish={resetTx}
                     isCompleted={!txStatus.status}
-                    visible
                     onViewTxClick={(e) => {
                       e.preventDefault()
-                      goToTransaction && goToTransaction(r.txHash)
+                      goToTransaction(txHash)
                     }}
                     txStatus={{
                       ...txStatus,
-                      hash: r.txHash
+                      hash: txHash
                     }}
                   />
                 )

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -316,43 +316,48 @@ export const Swap = ({
                   })
               ),
               O.chain((txStatus) => sequenceTOption(oSourceAssetWP, oTargetAssetWP, O.some(txStatus))),
-              O.map(([sourceAssetWP, targetAssetWP, txStatus]) => (
-                <SwapModal
-                  key={'swap modal result'}
-                  baseAsset={activePricePool.asset}
-                  calcResult={{ slip: swapData.slip } as CalcResult}
-                  swapSource={sourceAssetWP.asset}
-                  swapTarget={targetAssetWP.asset}
-                  priceFrom={
-                    poolData[assetToString(sourceAssetWP.asset)] &&
-                    getValueOfAsset1InAsset2(
-                      assetToBase(assetAmount(1)),
-                      poolData[assetToString(sourceAssetWP.asset)],
-                      activePricePool.poolData
-                    )
-                  }
-                  priceTo={
-                    poolData[assetToString(targetAssetWP.asset)] &&
-                    getValueOfAsset1InAsset2(
-                      assetToBase(assetAmount(1)),
-                      poolData[assetToString(targetAssetWP.asset)],
-                      activePricePool.poolData
-                    )
-                  }
-                  onClose={resetTx}
-                  onClickFinish={resetTx}
-                  isCompleted={!txStatus.status}
-                  visible
-                  onViewTxClick={(e) => {
-                    e.preventDefault()
-                    goToTransaction && goToTransaction(r.txHash)
-                  }}
-                  txStatus={{
-                    ...txStatus,
-                    hash: r.txHash
-                  }}
-                />
-              )),
+              O.map(([sourceAssetWP, targetAssetWP, txStatus]) => {
+                const swapResultByBasePriceAsset =
+                  poolData[assetToString(targetAssetWP.asset)] &&
+                  // Convert swapResult to the selected price asset values
+                  getValueOfAsset1InAsset2(
+                    assetToBase(assetAmount(swapData.swapResult)),
+                    poolData[assetToString(targetAssetWP.asset)],
+                    activePricePool.poolData
+                  )
+
+                const amountToSwapInSelectedPriceAsset =
+                  poolData[assetToString(sourceAssetWP.asset)] &&
+                  getValueOfAsset1InAsset2(
+                    assetToBase(assetAmount(changeAmount)),
+                    poolData[assetToString(sourceAssetWP.asset)],
+                    activePricePool.poolData
+                  )
+
+                return (
+                  <SwapModal
+                    key={'swap modal result'}
+                    basePriceAsset={activePricePool.asset}
+                    calcResult={{ slip: swapData.slip } as CalcResult}
+                    swapSourceAsset={sourceAssetWP.asset}
+                    swapTargetAsset={targetAssetWP.asset}
+                    amountToSwapInSelectedPriceAsset={amountToSwapInSelectedPriceAsset}
+                    swapResultByBasePriceAsset={swapResultByBasePriceAsset}
+                    onClose={resetTx}
+                    onClickFinish={resetTx}
+                    isCompleted={!txStatus.status}
+                    visible
+                    onViewTxClick={(e) => {
+                      e.preventDefault()
+                      goToTransaction && goToTransaction(r.txHash)
+                    }}
+                    txStatus={{
+                      ...txStatus,
+                      hash: r.txHash
+                    }}
+                  />
+                )
+              }),
               O.toNullable
             )
         )
@@ -367,7 +372,8 @@ export const Swap = ({
       oTargetAssetWP,
       swapData,
       activePricePool,
-      poolData
+      poolData,
+      changeAmount
     ]
   )
 

--- a/src/renderer/components/uielements/button/Button.style.ts
+++ b/src/renderer/components/uielements/button/Button.style.ts
@@ -219,6 +219,7 @@ export const ButtonWrapper = styled(Button)<Props>`
     font-size: ${(props) => fontSettings[props.sizevalue].size};
     font-weight: ${(props) => props.weight};
     letter-spacing: ${(props) => fontSettings[props.sizevalue].spacing};
+    box-shadow: none; /* overridden */
 
     text-transform: uppercase;
 

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -2,7 +2,6 @@ import { SwapMessages } from '../types'
 
 const swap: SwapMessages = {
   'swap.swapping': 'Tauschen',
-  'swap.state.pending': 'Tauschvorgang läuft',
   'swap.state.success': 'Erfolgreich getauscht',
   'swap.input': 'Eingabe',
   'swap.balance': 'Guthaben',

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -1,9 +1,8 @@
 import { SwapMessages } from '../types'
 
 const swap: SwapMessages = {
-  'swap.swapping': 'You are swapping',
-  'swap.state.pending': 'You are swapping',
-  'swap.state.success': 'You have been swapped successfully',
+  'swap.swapping': 'Swapping',
+  'swap.state.success': 'Successfull swap',
   'swap.input': 'Input',
   'swap.balance': 'Balance',
   'swap.output': 'Output',

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -2,7 +2,6 @@ import { SwapMessages } from '../types'
 
 const swap: SwapMessages = {
   'swap.swapping': 'Обменять',
-  'swap.state.pending': 'Обмен обрабатывается',
   'swap.state.success': 'Обмен совершён',
   'swap.input': 'Отдаете',
   'swap.balance': 'Баланс',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -160,7 +160,6 @@ type SwapMessageKey =
   | 'swap.output'
   | 'swap.drag'
   | 'swap.searchAsset'
-  | 'swap.state.pending'
   | 'swap.state.success'
   | 'swap.swapping'
   | 'swap.errors.amount.balanceShouldCoverChainFee'


### PR DESCRIPTION
closes #688

as we have now simple pricing for source and target assets it's not clear for user what this data is. this pr includes changing simple showing of assets prices to swap results based on selected price asset 

Including few tweaks:
- Remove box shadow from `transparent` button
- Remove `calResult` in favour of `slip`property
- Remove `visible` property
- Update stories for using latest storybook
- Remove `swap.state.pending` from i18n 

