### PR TITLE
Add `PrivateModal` component

### DIFF
--- a/src/renderer/components/modal/password/PasswordModal.stories.tsx
+++ b/src/renderer/components/modal/password/PasswordModal.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import { Story, Meta } from '@storybook/react'
+import * as Rx from 'rxjs'
+
+import { ValidatePasswordHandler } from '../../../services/wallet/types'
+import { PasswordModal } from './PasswordModal'
+
+const onClose = () => console.log('onClose')
+const onSuccess = () => console.log('onCSuccess')
+const validatePasswordInitial$: ValidatePasswordHandler = (_) => Rx.of(RD.initial)
+const validatePasswordPending$: ValidatePasswordHandler = (_) => Rx.of(RD.pending)
+const validatePasswordFailure$: ValidatePasswordHandler = (_) => Rx.of(RD.failure(Error('invalid password')))
+const validatePasswordSuccess$: ValidatePasswordHandler = (_) => Rx.of(RD.success(undefined))
+
+export const StoryInitial: Story = () => (
+  <PasswordModal onClose={onClose} onSuccess={onSuccess} validatePassword$={validatePasswordInitial$} />
+)
+StoryInitial.storyName = 'initial'
+
+export const StorySuccess: Story = () => (
+  <PasswordModal onClose={onClose} onSuccess={onSuccess} validatePassword$={validatePasswordSuccess$} />
+)
+StorySuccess.storyName = 'success'
+
+export const StoryValidating: Story = () => (
+  <PasswordModal onClose={onClose} onSuccess={onSuccess} validatePassword$={validatePasswordPending$} />
+)
+StoryValidating.storyName = 'validating'
+
+export const StoryInvalid: Story = () => (
+  <PasswordModal onClose={onClose} onSuccess={onSuccess} validatePassword$={validatePasswordFailure$} />
+)
+
+StoryInvalid.storyName = 'invalid'
+
+const meta: Meta = {
+  component: PasswordModal,
+  title: 'Components/Password Modal',
+  decorators: [
+    (S: Story) => (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '300px'
+        }}>
+        <S />
+      </div>
+    )
+  ]
+}
+
+export default meta

--- a/src/renderer/components/modal/password/PasswordModal.tsx
+++ b/src/renderer/components/modal/password/PasswordModal.tsx
@@ -5,27 +5,28 @@ import * as FP from 'fp-ts/function'
 import { useObservableState } from 'observable-hooks'
 
 import { PrivateModal } from '../../../components/modal/private'
-import { useWalletContext } from '../../../contexts/WalletContext'
+import { ValidatePasswordLD } from '../../../services/wallet/types'
 
 /**
- * @Note
- * This is not a 'usual' view
- * Just a modal 'connected' to the all appropriate services
+ * Wrapper around `PrivateModal` to validate password using `validatePassword$` stream
  */
 
-export const ConfirmPasswordView: React.FC<{
-  onSuccess: () => void
-  onClose: () => void
-}> = ({ onSuccess, onClose }) => {
+export type Props = {
+  onSuccess: FP.Lazy<void>
+  onClose: FP.Lazy<void>
+  validatePassword$: (_: string) => ValidatePasswordLD
+}
+
+export const PasswordModal: React.FC<Props> = ({ onSuccess, onClose, validatePassword$ }) => {
   const [passwordToValidate, setPasswordToValidate] = useState('')
 
-  const { keystoreService } = useWalletContext()
-  const passwordValidationResult$ = useMemo(() => keystoreService.validatePassword$(passwordToValidate), [
-    passwordToValidate,
-    keystoreService
-  ])
+  const [passwordValidationRD] = useObservableState(() => validatePassword$(passwordToValidate), RD.initial)
 
-  const passwordValidationResult = useObservableState(passwordValidationResult$, RD.initial)
+  // const { keystoreService } = useWalletContext()
+  // const passwordValidationResult$: ValidatePasswordLD = useMemo(
+  //   () => keystoreService.validatePassword$(passwordToValidate),
+  //   [passwordToValidate, keystoreService]
+  // )
 
   const closePrivateModal = useCallback(() => {
     onClose()
@@ -40,7 +41,7 @@ export const ConfirmPasswordView: React.FC<{
   const confirmProps = useMemo(() => {
     const props = { onCancel: closePrivateModal, visible: true }
     return FP.pipe(
-      passwordValidationResult,
+      passwordValidationRD,
       RD.fold(
         () => ({
           ...props,
@@ -64,7 +65,7 @@ export const ConfirmPasswordView: React.FC<{
         })
       )
     )
-  }, [passwordValidationResult, setPasswordToValidate, closePrivateModal, onPasswordValidationSucceed])
+  }, [passwordValidationRD, setPasswordToValidate, closePrivateModal, onPasswordValidationSucceed])
 
   return <PrivateModal {...confirmProps} />
 }

--- a/src/renderer/components/modal/password/index.ts
+++ b/src/renderer/components/modal/password/index.ts
@@ -1,0 +1,1 @@
+export { PasswordModal } from './PasswordModal'

--- a/src/renderer/components/modal/private/PrivateModal.stories.tsx
+++ b/src/renderer/components/modal/private/PrivateModal.stories.tsx
@@ -1,43 +1,33 @@
 import React from 'react'
 
-import { storiesOf } from '@storybook/react'
+import { Story, Meta } from '@storybook/react'
 
 import { PrivateModal } from './PrivateModal'
 
-storiesOf('Components/Private Modal', module)
-  .add('default', () => {
-    return (
+export const StoryDefault: Story = () => <PrivateModal visible invalidPassword validatingPassword={false} />
+StoryDefault.storyName = 'default'
+
+export const StoryInvalid: Story = () => <PrivateModal visible invalidPassword validatingPassword={false} />
+StoryInvalid.storyName = 'invalid'
+
+export const StoryValidating: Story = () => <PrivateModal visible invalidPassword={false} validatingPassword />
+StoryValidating.storyName = 'validating'
+
+const meta: Meta = {
+  component: PrivateModal,
+  title: 'Components/Private Modal',
+  decorators: [
+    (S: Story) => (
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           width: '300px'
         }}>
-        <PrivateModal visible invalidPassword={false} validatingPassword={false} />
+        <S />
       </div>
     )
-  })
-  .add('invalid', () => {
-    return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '300px'
-        }}>
-        <PrivateModal visible invalidPassword validatingPassword={false} />
-      </div>
-    )
-  })
-  .add('validating', () => {
-    return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '300px'
-        }}>
-        <PrivateModal visible invalidPassword={false} validatingPassword />
-      </div>
-    )
-  })
+  ]
+}
+
+export default meta

--- a/src/renderer/components/modal/private/PrivateModal.tsx
+++ b/src/renderer/components/modal/private/PrivateModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { Form } from 'antd'
+import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
 import { Input } from '../../uielements/input'
@@ -12,20 +13,29 @@ type Props = {
   invalidPassword?: boolean
   validatingPassword?: boolean
   onConfirm?: (password: string) => void
-  onOk?: () => void
-  onCancel?: () => void
+  onOk?: FP.Lazy<void>
+  onCancel?: FP.Lazy<void>
   isSuccess?: boolean
 }
 
 export const PrivateModal: React.FC<Props> = (props): JSX.Element => {
-  const { visible, invalidPassword, validatingPassword, onConfirm, onOk, onCancel, isSuccess } = props
+  const {
+    visible,
+    invalidPassword,
+    validatingPassword,
+    onConfirm = FP.constVoid,
+    onOk = FP.constVoid,
+    onCancel = FP.constVoid,
+    isSuccess
+  } = props
+
   const intl = useIntl()
 
   /**
    * Call onOk on success only
    */
   useEffect(() => {
-    if (isSuccess && onOk) {
+    if (isSuccess) {
       onOk()
     }
   }, [isSuccess, onOk])
@@ -40,8 +50,9 @@ export const PrivateModal: React.FC<Props> = (props): JSX.Element => {
   )
 
   const onConfirmCb = useCallback(() => {
-    onConfirm && onConfirm(password)
+    onConfirm(password)
   }, [onConfirm, password])
+
   return (
     <Styled.Modal
       title={intl.formatMessage({ id: 'wallet.password.confirmation' })}

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -34,10 +34,11 @@ import { AssetsWithPrice, AssetWithPrice, TxWithStateRD } from '../../services/b
 import { SwapFeesRD } from '../../services/chain/types'
 import { PoolDetails } from '../../services/midgard/types'
 import { getPoolDetailsHashMap } from '../../services/midgard/utils'
-import { NonEmptyWalletBalances } from '../../services/wallet/types'
+import { NonEmptyWalletBalances, ValidatePasswordHandler } from '../../services/wallet/types'
 import { TxStatus, TxTypes } from '../../types/asgardex'
 import { PricePool } from '../../views/pools/Pools.types'
 import { CurrencyInfo } from '../currency'
+import { PasswordModal } from '../modal/password'
 import { SwapModal } from '../modal/swap'
 import { AssetSelect } from '../uielements/assets/assetSelect'
 import { Fee, Fees } from '../uielements/fees'
@@ -58,7 +59,7 @@ type SwapProps = {
   resetTx?: () => void
   goToTransaction?: (txHash: string) => void
   activePricePool: PricePool
-  PasswordConfirmation: React.FC<{ onSuccess: () => void; onClose: () => void }>
+  validatePassword$: ValidatePasswordHandler
   reloadFees?: () => void
   fees?: SwapFeesRD
   targetWalletAddress?: O.Option<Address>
@@ -75,7 +76,7 @@ export const Swap = ({
   goToTransaction = (_) => {},
   resetTx,
   activePricePool,
-  PasswordConfirmation,
+  validatePassword$,
   reloadFees,
   fees: feesProp = RD.initial,
   targetWalletAddress = O.none
@@ -564,7 +565,11 @@ export const Swap = ({
   return (
     <Styled.Container>
       {showPrivateModal && (
-        <PasswordConfirmation onSuccess={onPasswordValidationSucceed} onClose={() => setShowPrivateModal(false)} />
+        <PasswordModal
+          onSuccess={onPasswordValidationSucceed}
+          onClose={() => setShowPrivateModal(false)}
+          validatePassword$={validatePassword$}
+        />
       )}
       <Styled.PendingContainer>{pendingState}</Styled.PendingContainer>
       <Styled.ContentContainer>

--- a/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
@@ -10,9 +10,8 @@ import * as RxOp from 'rxjs/operators'
 
 import { ZERO_BASE_AMOUNT } from '../../../const'
 import { SendTxParams } from '../../../services/binance/types'
-import { ErrorId, TxLD, TxRD } from '../../../services/wallet/types'
+import { ErrorId, TxLD, TxRD, ValidatePasswordHandler } from '../../../services/wallet/types'
 import { WalletBalance, WalletBalances } from '../../../types/wallet'
-import { PrivateModal } from '../../modal/private'
 import { AssetDetails } from './index'
 
 const bnbBalance: WalletBalance = {
@@ -64,9 +63,8 @@ const poolAddress = O.some('pool address')
 
 const thorAddress = O.some('thor address')
 
-const UpgradeConfirmationModal: React.FC<{ onSuccess: () => void; onClose: () => void }> = ({ onSuccess, onClose }) => (
-  <PrivateModal visible onOk={onClose} onCancel={onClose} onConfirm={onSuccess} />
-)
+const validatePasswordInitial$: ValidatePasswordHandler = (_) => Rx.of(RD.initial)
+const validatePasswordSuccess$: ValidatePasswordHandler = (_) => Rx.of(RD.success(undefined))
 
 export const StoryBNB: BaseStory<never, JSX.Element> = () => (
   <AssetDetails
@@ -75,7 +73,7 @@ export const StoryBNB: BaseStory<never, JSX.Element> = () => (
     asset={O.some(AssetBNB)}
     sendTx={sendUpgradeRuneTx}
     poolAddress={poolAddress}
-    UpgradeConfirmationModal={UpgradeConfirmationModal}
+    validatePassword$={validatePasswordInitial$}
   />
 )
 StoryBNB.storyName = 'BNB'
@@ -88,7 +86,7 @@ export const StoryRuneTxSuccess: BaseStory<never, JSX.Element> = () => (
     sendTx={sendUpgradeRuneTx}
     runeNativeAddress={thorAddress}
     poolAddress={poolAddress}
-    UpgradeConfirmationModal={UpgradeConfirmationModal}
+    validatePassword$={validatePasswordSuccess$}
   />
 )
 StoryRuneTxSuccess.storyName = 'RUNE - tx success'
@@ -101,7 +99,7 @@ export const StoryRuneTxError: BaseStory<never, JSX.Element> = () => (
     sendTx={sendUpgradeRuneTxError}
     runeNativeAddress={thorAddress}
     poolAddress={poolAddress}
-    UpgradeConfirmationModal={UpgradeConfirmationModal}
+    validatePassword$={validatePasswordSuccess$}
   />
 )
 StoryRuneTxError.storyName = 'RUNE - tx error'
@@ -113,7 +111,7 @@ export const StoryRuneNoBalances: BaseStory<never, JSX.Element> = () => (
     asset={O.some(AssetRune67C)}
     sendTx={sendUpgradeRuneTx}
     poolAddress={poolAddress}
-    UpgradeConfirmationModal={UpgradeConfirmationModal}
+    validatePassword$={validatePasswordInitial$}
   />
 )
 StoryRuneNoBalances.storyName = 'RUNE - disabled - no balance'

--- a/src/renderer/components/wallet/assets/AssetDetails.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.tsx
@@ -21,8 +21,15 @@ import { GetExplorerTxUrl, TxsPageRD } from '../../../services/clients'
 import { MAX_ITEMS_PER_PAGE } from '../../../services/const'
 import { PoolAddress } from '../../../services/midgard/types'
 import { EMPTY_LOAD_TXS_HANDLER } from '../../../services/wallet/const'
-import { LoadTxsHandler, NonEmptyWalletBalances, TxLD, TxRD } from '../../../services/wallet/types'
+import {
+  LoadTxsHandler,
+  NonEmptyWalletBalances,
+  TxLD,
+  TxRD,
+  ValidatePasswordHandler
+} from '../../../services/wallet/types'
 import { WalletBalance } from '../../../types/wallet'
+import { PasswordModal } from '../../modal/password'
 import { TxModal } from '../../modal/tx'
 import { AssetInfo } from '../../uielements/assets/assetInfo'
 import { BackLink } from '../../uielements/backLink'
@@ -48,7 +55,7 @@ type Props = {
   runeNativeAddress?: O.Option<Address>
   poolAddress: O.Option<PoolAddress>
   sendTx: (_: SendTxParams) => TxLD
-  UpgradeConfirmationModal: React.FC<{ onSuccess: () => void; onClose: () => void }>
+  validatePassword$: ValidatePasswordHandler
 }
 
 export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
@@ -63,7 +70,7 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
     getExplorerTxUrl: oGetExplorerTxUrl = O.none,
     walletAddress: oWalletAddress = O.none,
     runeNativeAddress: oRuneNativeAddress = O.none,
-    UpgradeConfirmationModal
+    validatePassword$
   } = props
 
   const [currentPage, setCurrentPage] = useState(1)
@@ -245,14 +252,15 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
   const renderConfirmUpgradeModal = useMemo(
     () =>
       showConfirmUpgradeModal ? (
-        <UpgradeConfirmationModal
+        <PasswordModal
           onSuccess={upgradeConfirmationHandler}
           onClose={() => setShowConfirmUpgradeModal(false)}
+          validatePassword$={validatePassword$}
         />
       ) : (
         <></>
       ),
-    [UpgradeConfirmationModal, showConfirmUpgradeModal, upgradeConfirmationHandler]
+    [showConfirmUpgradeModal, upgradeConfirmationHandler, validatePassword$]
   )
 
   return (

--- a/src/renderer/services/wallet/keystore.ts
+++ b/src/renderer/services/wallet/keystore.ts
@@ -8,7 +8,7 @@ import { catchError, map, startWith, switchMap } from 'rxjs/operators'
 import { liveData } from '../../helpers/rx/liveData'
 import { observableState } from '../../helpers/stateHelper'
 import { INITIAL_KEYSTORE_STATE } from './const'
-import { Phrase, KeystoreService, KeystoreState } from './types'
+import { Phrase, KeystoreService, KeystoreState, ValidatePasswordLD } from './types'
 import { hasImportedKeystore } from './util'
 
 const { get$: getKeystoreState$, set: setKeystoreState } = observableState<KeystoreState>(INITIAL_KEYSTORE_STATE)
@@ -66,13 +66,13 @@ window.apiKeystore.exists().then(
   (_) => setKeystoreState(O.none /*not imported*/)
 )
 
-const validatePassword$ = (password: string) =>
+const validatePassword$ = (password: string): ValidatePasswordLD =>
   password
     ? FP.pipe(
         Rx.from(window.apiKeystore.get()),
         switchMap((keystore) => Rx.from(decryptFromKeystore(keystore, password))),
         map(RD.success),
-        liveData.map(() => null),
+        liveData.map(() => undefined),
         catchError((err) => Rx.of(RD.failure(err))),
         startWith(RD.pending)
       )

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -2,6 +2,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Address, TxHash } from '@xchainjs/xchain-client'
 import { Chain } from '@xchainjs/xchain-util'
 import { getMonoid } from 'fp-ts/Array'
+import * as FP from 'fp-ts/lib/function'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
 import { Observable } from 'rxjs'
@@ -25,17 +26,20 @@ export type KeystoreContent = { phrase: Phrase }
  */
 export type KeystoreState = O.Option<O.Option<KeystoreContent>>
 
+export type ValidatePasswordHandler = (password: string) => LiveData<Error, void>
+export type ValidatePasswordLD = LiveData<Error, void>
+
 export type KeystoreService = {
   keystore$: Observable<KeystoreState>
   addKeystore: (phrase: Phrase, password: string) => Promise<void>
   removeKeystore: () => Promise<void>
   unlock: (state: KeystoreState, password: string) => Promise<void>
-  lock: () => void
+  lock: FP.Lazy<void>
   /**
    * Use RemoteData as result of validation
    * No need to store any success data. Only status
    */
-  validatePassword$: (password: string) => LiveData<Error, null>
+  validatePassword$: ValidatePasswordHandler
 }
 
 /**

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -37,7 +37,6 @@ import { SwapFeesLD, SwapFeesRD } from '../../services/chain/types'
 import { PoolAddressRx } from '../../services/midgard/types'
 import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 import { TxTypes } from '../../types/asgardex'
-import { ConfirmPasswordView } from '../wallet/ConfirmPassword'
 import * as Styled from './SwapView.styles'
 
 type Props = {}
@@ -61,7 +60,12 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
     getExplorerUrlByAsset$,
     assetAddress$
   } = useChainContext()
-  const { balancesState$ } = useWalletContext()
+
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
   const poolsState = useObservableState(poolsState$, initial)
 
   const oSource = useMemo(() => O.fromNullable(assetFromString(source.toUpperCase())), [source])
@@ -212,7 +216,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
               return (
                 <Swap
-                  PasswordConfirmation={ConfirmPasswordView}
+                  validatePassword$={validatePassword$}
                   activePricePool={selectedPricePool}
                   txWithState={txWithState}
                   resetTx={resetTx}

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -22,7 +22,6 @@ import { liveData } from '../../helpers/rx/liveData'
 import { AssetDetailsParams } from '../../routes/wallet'
 import { getPoolAddressByChain } from '../../services/midgard/utils'
 import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
-import { ConfirmPasswordView } from '../wallet/ConfirmPassword'
 
 export const AssetDetailsView: React.FC = (): JSX.Element => {
   const { asset, walletAddress } = useParams<AssetDetailsParams>()
@@ -48,7 +47,8 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
     reloadBalances$,
     setSelectedAsset,
     getExplorerTxUrl$,
-    resetTxsPage
+    resetTxsPage,
+    keystoreService: { validatePassword$ }
   } = useWalletContext()
 
   const {
@@ -137,7 +137,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
         runeNativeAddress={oRuneNativeAddress}
         poolAddress={bnbPoolAddress}
         sendTx={sendBnbTx}
-        UpgradeConfirmationModal={ConfirmPasswordView}
+        validatePassword$={validatePassword$}
       />
     </>
   )

--- a/src/renderer/views/wallet/ConfirmPassword/index.ts
+++ b/src/renderer/views/wallet/ConfirmPassword/index.ts
@@ -1,1 +1,0 @@
-export * from './ConfirmPasswordView'


### PR DESCRIPTION
to deprecate `ConfirmPasswordView`.

- [x] Extract `ConfirmPasswordView` → `PasswordModal`, but without dependency of `WalletContext` 
- [x] Add stories `PasswordModal`
- [x] Update stories of `PrivateModal`
- [x] Update `Swap` + `AssetDetails` to use PrivateModel` (instead passing `ConfirmPasswordView`) 
- [x] Introduce types of `ValidatePasswordLD` + `ValidatePasswordHandler`

Closes #699 