### PR TITLE
enable refresh at the bonds view #841

### DIFF
--- a/src/renderer/contexts/ThorchainContext.tsx
+++ b/src/renderer/contexts/ThorchainContext.tsx
@@ -14,6 +14,7 @@ import {
   subscribeTx,
   interact$,
   getNodeInfo$,
+  reloadNodesInfo,
   explorerUrl$
 } from '../services/thorchain'
 
@@ -32,6 +33,7 @@ export type ThorchainContextValue = {
   interact$: typeof interact$
   getNodeInfo$: typeof getNodeInfo$
   explorerUrl$: typeof explorerUrl$
+  reloadNodesInfo: typeof reloadNodesInfo
 }
 
 const initialContext: ThorchainContextValue = {
@@ -48,7 +50,8 @@ const initialContext: ThorchainContextValue = {
   fees$,
   interact$,
   getNodeInfo$,
-  explorerUrl$
+  explorerUrl$,
+  reloadNodesInfo
 }
 
 const ThorchainContext = createContext<ThorchainContextValue | null>(null)

--- a/src/renderer/services/thorchain/index.ts
+++ b/src/renderer/services/thorchain/index.ts
@@ -4,7 +4,7 @@ import { reloadBalances, balances$ } from './balances'
 import { client$, address$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ } from './common'
 import { createFeesService } from './fees'
 import { createInteractService$ } from './interact'
-import { getNodeInfo$ } from './thorNode'
+import { getNodeInfo$, reloadNodesInfo } from './thorNode'
 import { createDepositService, createTransactionService } from './transaction'
 
 const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$ } = createTransactionService(client$)
@@ -31,5 +31,6 @@ export {
   getExplorerAddressUrl$,
   sendDepositTx,
   interact$,
-  getNodeInfo$
+  getNodeInfo$,
+  reloadNodesInfo
 }

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -7,6 +7,7 @@ import { Switch, Route, Redirect } from 'react-router-dom'
 
 import { RefreshButton } from '../../components/uielements/button/'
 import { AssetsNav } from '../../components/wallet/assets'
+import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import { RedirectRouteState } from '../../routes/types'
 import * as walletRoutes from '../../routes/wallet'
@@ -28,6 +29,7 @@ import { UpgradeView } from './UpgradeView'
 
 export const WalletView: React.FC = (): JSX.Element => {
   const { keystoreService, reloadBalances } = useWalletContext()
+  const { reloadNodesInfo } = useThorchainContext()
 
   // Important note:
   // DON'T set `INITIAL_KEYSTORE_STATE` as default value
@@ -76,7 +78,7 @@ export const WalletView: React.FC = (): JSX.Element => {
             <DepositsView />
           </Route>
           <Route path={walletRoutes.bonds.template} exact>
-            {reloadButton(reloadBalances)}
+            {reloadButton(reloadNodesInfo)}
             <AssetsNav />
             <BondsView />
           </Route>
@@ -95,7 +97,7 @@ export const WalletView: React.FC = (): JSX.Element => {
         </Switch>
       </>
     ),
-    [reloadBalances, reloadButton]
+    [reloadBalances, reloadButton, reloadNodesInfo]
   )
 
   const renderWalletRoute = useCallback(


### PR DESCRIPTION
- added trigger stream at the `thorNode` service
- fixed new requests to start with `RD.pending`
- passed reload callback to the `WalletView`

closes #841 