### PR TITLE
[Swap] Fix Asset icon in Drag Slider

### DIFF
--- a/src/renderer/components/uielements/assets/assetIcon/AssetIcon.style.ts
+++ b/src/renderer/components/uielements/assets/assetIcon/AssetIcon.style.ts
@@ -23,6 +23,7 @@ export const sizes: Sizes = {
 
 export const IconWrapper = styled.div<IconProps>`
   width: ${({ size }) => `${sizes[size]}px`};
+  min-width: ${({ size }) => `${sizes[size]}px`};
   height: ${({ size }) => `${sizes[size]}px`};
   position: relative;
 `

--- a/src/renderer/components/uielements/drag/Drag.style.tsx
+++ b/src/renderer/components/uielements/drag/Drag.style.tsx
@@ -111,7 +111,7 @@ export const TitleLabel = styled(Label).attrs({
 })`
   width: 200px;
   font-size: 12px;
-  margin: 0 ${ICON_SIZE}; /* icon size */
+  margin: 0 0 0 ${ICON_SIZE}; /* icon size */
   text-transform: uppercase;
   color: ${palette('text', 2)};
 `


### PR DESCRIPTION
Fix #848 

![1](https://user-images.githubusercontent.com/39806640/107032415-7f009c80-67ff-11eb-96d2-432adcbb1946.png)

- `Drag to swap` to the center
![2](https://user-images.githubusercontent.com/39806640/107068533-796d7b80-682c-11eb-80dc-33e22c9acfe5.png)
