### PR TITLE
Resolve: Liquidity / Swap - too many requests for loading BTC fees

### DIFF
--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -10,7 +10,6 @@ import {
   getWithdrawMemo$,
   withdrawFee$,
   reloadWithdrawFee,
-  reloadDepositFeesEffect$,
   retrieveLedgerAddress,
   removeLedgerAddress,
   removeAllLedgerAddress,
@@ -33,7 +32,6 @@ type ChainContextValue = {
   reloadDepositFees: typeof reloadDepositFees
   withdrawFee$: typeof withdrawFee$
   reloadWithdrawFees: typeof reloadWithdrawFee
-  reloadDepositFeesEffect$: typeof reloadDepositFeesEffect$
   symDepositTxMemo$: typeof symDepositTxMemo$
   asymDepositTxMemo$: typeof asymDepositTxMemo$
   getWithdrawMemo$: typeof getWithdrawMemo$
@@ -59,7 +57,6 @@ const initialContext: ChainContextValue = {
   reloadDepositFees,
   withdrawFee$,
   reloadWithdrawFees: reloadWithdrawFee,
-  reloadDepositFeesEffect$,
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,

--- a/src/renderer/services/chain/index.ts
+++ b/src/renderer/services/chain/index.ts
@@ -1,15 +1,7 @@
 import { addressByChain$, assetAddress$ } from './address'
 import { clientByChain$ } from './client'
 import { getExplorerUrlByAsset$, getExplorerAddressByChain$ } from './explorerUrl'
-import {
-  reloadDepositFees,
-  depositFees$,
-  withdrawFee$,
-  reloadWithdrawFee,
-  reloadDepositFeesEffect$,
-  reloadSwapFees,
-  swapFees$
-} from './fees'
+import { reloadDepositFees, depositFees$, withdrawFee$, reloadWithdrawFee, reloadSwapFees, swapFees$ } from './fees'
 import { retrieveLedgerAddress, removeLedgerAddress, removeAllLedgerAddress } from './ledger'
 import { asymDepositTxMemo$, symDepositTxMemo$, getWithdrawMemo$ } from './memo'
 import { swap$, asymDeposit$, symDeposit$, upgradeBnbRune$, withdraw$ } from './transaction'
@@ -24,7 +16,6 @@ export {
   depositFees$,
   withdrawFee$,
   reloadWithdrawFee,
-  reloadDepositFeesEffect$,
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -5,7 +5,7 @@ import { Asset, assetToString, BaseAmount, bn } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
-import { useObservableState, useSubscription } from 'observable-hooks'
+import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router'
 import * as RxOp from 'rxjs/operators'
@@ -51,12 +51,8 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     asymDeposit$,
     reloadDepositFees,
     asymDepositTxMemo$,
-    reloadDepositFeesEffect$,
     getExplorerUrlByAsset$
   } = useChainContext()
-
-  // subscribe to
-  useSubscription(reloadDepositFeesEffect$)
 
   const [depositFees] = useObservableState(() => depositFees$('asym'), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -5,7 +5,7 @@ import { Asset, AssetRuneNative, assetToString, BaseAmount, bn } from '@xchainjs
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
-import { useObservableState, useSubscription } from 'observable-hooks'
+import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router'
 import * as RxOp from 'rxjs/operators'
@@ -46,17 +46,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
     }
   } = useMidgardContext()
 
-  const {
-    depositFees$,
-    symDeposit$,
-    reloadDepositFees,
-    symDepositTxMemo$,
-    reloadDepositFeesEffect$,
-    getExplorerUrlByAsset$
-  } = useChainContext()
-
-  // subscribe to
-  useSubscription(reloadDepositFeesEffect$)
+  const { depositFees$, symDeposit$, reloadDepositFees, symDepositTxMemo$, getExplorerUrlByAsset$ } = useChainContext()
 
   const [depositFees] = useObservableState(() => depositFees$('sym'), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)


### PR DESCRIPTION
- removed useless manual subscriptions at the Add deposit views
- fixed wrong caching stream results at the bitcoin fees services

closes #864 