### PR TITLE
Spelling #904

### DIFF
--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -2,7 +2,7 @@ import { SwapMessages } from '../types'
 
 const swap: SwapMessages = {
   'swap.state.pending': 'Swapping',
-  'swap.state.success': 'Successfull swap',
+  'swap.state.success': 'Successful swap',
   'swap.state.error': 'Swap error',
   'swap.input': 'Input',
   'swap.balance': 'Balance',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -64,7 +64,7 @@ const wallet: WalletMessages = {
   'wallet.password.repeat': 'Repeat password',
   'wallet.password.mismatch': 'Password mismatch',
   'wallet.upgrade.pending': 'Upgrading',
-  'wallet.upgrade.success': 'Successfull upgrade',
+  'wallet.upgrade.success': 'Successful upgrade',
   'wallet.upgrade.error': 'Upgrade error',
   'wallet.upgrade.error.loadPoolAddress': '{pool} pool address could not be loaded',
   'wallet.upgrade.feeError': 'Upgrade fee {fee} is not covered by your balance {balance}',


### PR DESCRIPTION
- fixed typo for "successfull"
no "successfull" anymore at the translations
![image](https://user-images.githubusercontent.com/67793194/107934438-19e04000-6f91-11eb-885b-63c6a8d22cf3.png)


closes #904 