### PR TITLE
UI on Liquidity Screen #909

### DIFF
--- a/src/renderer/components/deposit/Deposit.styles.tsx
+++ b/src/renderer/components/deposit/Deposit.styles.tsx
@@ -7,7 +7,7 @@ import { Tabs as TabsBase } from '../tabs/Tabs'
 import { Button } from '../uielements/button'
 
 export const Container = styled('div')`
-  min-height: 100%;
+  flex: 1;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -36,7 +36,7 @@ export const ShareContentWrapper = styled.div`
   min-height: 300px;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: baseline;
   ${media.xl`
       min-height: 100%;
   `};

--- a/src/renderer/components/deposit/Deposit.tsx
+++ b/src/renderer/components/deposit/Deposit.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { Asset, AssetRuneNative } from '@xchainjs/xchain-util'
+import { Grid } from 'antd'
 import { useIntl } from 'react-intl'
 
 import { PoolShareRD } from '../../services/midgard/types'
@@ -21,7 +22,7 @@ export type Props = {
   asset: Asset
   asymPoolShare: PoolShareRD
   symPoolShare: PoolShareRD
-  ShareContent: React.ComponentType<{ asset: Asset; poolShare: PoolShareRD }>
+  ShareContent: React.ComponentType<{ asset: Asset; poolShare: PoolShareRD; smallWidth?: boolean }>
   AsymDepositContent: React.ComponentType<{ asset: Asset }>
   SymDepositContent: React.ComponentType<{ asset: Asset }>
   WidthdrawContent: React.ComponentType<{ asset: Asset; poolShare: PoolShareRD }>
@@ -34,6 +35,8 @@ export const Deposit: React.FC<Props> = (props) => {
 
   const walletIsImported = useMemo(() => hasImportedKeystore(keystoreState), [keystoreState])
   const walletIsLocked = useMemo(() => isLocked(keystoreState), [keystoreState])
+
+  const isDesktopView = Grid.useBreakpoint()?.md ?? false
 
   const tabs = useMemo(
     (): Tab[] => [
@@ -68,7 +71,7 @@ export const Deposit: React.FC<Props> = (props) => {
             </Styled.DepositContentCol>
             <Styled.ShareContentCol xs={24} xl={9}>
               <Styled.ShareContentWrapper>
-                <ShareContent asset={asset} poolShare={symPoolShare} />
+                <ShareContent smallWidth={!isDesktopView} asset={asset} poolShare={symPoolShare} />
               </Styled.ShareContentWrapper>
             </Styled.ShareContentCol>
           </>

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -578,9 +578,11 @@ export const SymDeposit: React.FC<Props> = (props) => {
 
   return (
     <Styled.Container>
-      <Styled.BalanceErrorRow>
-        <Col xs={24}>{showBalanceError && renderBalanceError}</Col>
-      </Styled.BalanceErrorRow>
+      {showBalanceError && (
+        <Styled.BalanceErrorRow>
+          <Col xs={24}>{showBalanceError && renderBalanceError}</Col>
+        </Styled.BalanceErrorRow>
+      )}
       <Styled.CardsRow gutter={{ lg: 32 }}>
         <Col xs={24} xl={12}>
           <Styled.AssetCard

--- a/src/renderer/components/uielements/poolShare/PoolShare.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.tsx
@@ -13,7 +13,6 @@ import { Col } from 'antd'
 import BigNumber from 'bignumber.js'
 import { useIntl } from 'react-intl'
 
-import { useElementWidth } from '../../../hooks/useContainerWidth'
 import * as Styled from './PoolShare.style'
 import { PoolShareCard } from './PoolShareCard'
 
@@ -28,6 +27,7 @@ type Props = {
   assetDepositPrice: BaseAmount
   poolShare: BigNumber
   depositUnits: BaseAmount
+  smallWidth?: boolean
 }
 
 export const PoolShare: React.FC<Props> = (props): JSX.Element => {
@@ -41,7 +41,8 @@ export const PoolShare: React.FC<Props> = (props): JSX.Element => {
     assetDepositShare,
     assetDepositPrice,
     poolShare,
-    depositUnits
+    depositUnits,
+    smallWidth
   } = props
 
   const intl = useIntl()
@@ -52,10 +53,6 @@ export const PoolShare: React.FC<Props> = (props): JSX.Element => {
   ])
 
   const ref: RefObject<HTMLDivElement> = useRef(null)
-
-  const wrapperWidth = useElementWidth(ref)
-
-  const smallWidth = wrapperWidth <= 576 // sm
 
   const renderRedemptionCol = useCallback(
     (amount: BaseAmount, price: BaseAmount, asset: Asset) => (

--- a/src/renderer/views/deposit/share/ShareView.tsx
+++ b/src/renderer/views/deposit/share/ShareView.tsx
@@ -17,9 +17,9 @@ import { PoolDetailRD, PoolDetail, PoolShareRD, PoolShare } from '../../../servi
 import { toPoolData } from '../../../services/midgard/utils'
 import * as Styled from './ShareView.styles'
 
-type Props = { asset: Asset; poolShare: PoolShareRD }
+type Props = { asset: Asset; poolShare: PoolShareRD; smallWidth?: boolean }
 
-export const ShareView: React.FC<Props> = ({ asset, poolShare: poolShareRD }) => {
+export const ShareView: React.FC<Props> = ({ asset, poolShare: poolShareRD, smallWidth }) => {
   const { service: midgardService } = useMidgardContext()
   const {
     pools: { poolDetail$, selectedPricePoolAsset$, selectedPricePool$ }
@@ -45,6 +45,7 @@ export const ShareView: React.FC<Props> = ({ asset, poolShare: poolShareRD }) =>
 
       return (
         <PoolShareUI
+          smallWidth={smallWidth}
           sourceAsset={AssetRuneNative}
           targetAsset={asset}
           poolShare={poolShare}
@@ -58,7 +59,7 @@ export const ShareView: React.FC<Props> = ({ asset, poolShare: poolShareRD }) =>
         />
       )
     },
-    [asset, oPriceAsset, pricePoolData]
+    [asset, oPriceAsset, pricePoolData, smallWidth]
   )
 
   const renderNoShare = useMemo(


### PR DESCRIPTION
- fixed `min-height` for `Deposit.styles:Container` element
- moved checking for `smallWidth` to the higher level (`Deposit.tsx` component) 

closes #909 