### PR TITLE
Build releases on `release` and `hotfix` branches only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Electron build
 on:
   push:
     branches:
-      - master
+      # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
+      - 'release/**'
+      - 'hotfix/**'
 
 jobs:
   build:
@@ -16,8 +18,6 @@ jobs:
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v2
-        with:
-          ref: master
 
       - name: Install missing dependencies on Linux
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev

--- a/BRANCHING_WORKFLOW.md
+++ b/BRANCHING_WORKFLOW.md
@@ -6,9 +6,9 @@ For development ASGARDEX we follow [OneFlow approach](https://www.endoflineblog.
 
 - Based on [OneFlow (Variation – develop + master)](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#variation-develop-master)
 - `develop` branch for development
-- `release/{version}` branches are created from `develop`. It will be finalized by creating a new tag (semver based). (Possible) changes are merged back into `develop`.
-- `hotfix/{version}` branches are created from `develop`. It will be finalized by creating a new tag (semver based). Changes are merged back into `develop`.
-- `master` includes always latest stable production build by fast-forwarding to tag of latest release or latest hotfix.
+- `master` includes always latest stable production build by fast-forwarding to tags of latest release or latest hotfix.
+- `release/{version}` branches are created from `develop`. It will be finalized by creating a new tag (semver based). (Possible) changes are merged back into `develop`. `master` will be fast-forwarded to this tag.
+- `hotfix/{version}` branches are created from `master` or from latest tag. It will be finalized by creating a new tag (semver based). Changes are merged back into `develop`. `master` will be fast-forwarded to this tag.
 - Naming conventions for branches (`release/{version}` or `hotfix/{version}`) are important! These are needed to trigger actions for Electron builds (defined in `.github/workflows/build.yml`).
 
 ## Development

--- a/BRANCHING_WORKFLOW.md
+++ b/BRANCHING_WORKFLOW.md
@@ -1,6 +1,15 @@
 # Git branching workflow
 
-For development ASGARDEX we follow [OneFlow approach](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#finishing-a-release-branch), which based on [GitFlow considered harmful](https://www.endoflineblog.com/gitflow-considered-harmful) article by [Adam Ruka](https://www.endoflineblog.com).
+For development ASGARDEX we follow [OneFlow approach](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow), which based on [GitFlow considered harmful](https://www.endoflineblog.com/gitflow-considered-harmful) article by [Adam Ruka](https://www.endoflineblog.com).
+
+## TL;DR
+
+- Based on [OneFlow (Variation – develop + master)](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#variation-develop-master)
+- `develop` branch for development
+- `release/{version}` branches are created from `develop`. It will be finalized by creating a new tag (semver based). (Possible) changes are merged back into `develop`.
+- `hotfix/{version}` branches are created from `develop`. It will be finalized by creating a new tag (semver based). Changes are merged back into `develop`.
+- `master` includes always latest stable production build by fast-forwarding to tag of latest release or latest hotfix.
+- Naming conventions for branches (`release/{version}` or `hotfix/{version}`) are important! These are needed to trigger actions for Electron builds (defined in `.github/workflows/build.yml`).
 
 ## Development
 
@@ -82,7 +91,7 @@ git push
 
 ### Create `hotfix` branch
 
-Checkout master, which always based on latest tag.
+To create a hotfix branch (name it `hotfix/{version}`, checkout master (which always based on latest tag).
 
 Example:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # How to release
 
 1. Dev bumps `version` in `package.json`.
-2. Dev drafts a new release as desribed [here](https://help.github.com/articles/creating-releases/) and edits the release draft to populate it with changes. The "Tag version" should be the `version` in `package.json`, but prefixed with v.
+2. Dev drafts a new release as desribed [here](https://help.github.com/articles/creating-releases/) and edits the release draft to populate it with changes. The "Tag version" should be the `version` in `package.json`, but prefixed with `v.`. Target branch should be `release/xyz` or `hotfix/xyz` (**never** target to `develop` nor `master`)
 
    - E.g if the version is `1.0.0`, then the GitHub tag should be `v1.0.0`
 


### PR DESCRIPTION
- [x] Target `release/` and `hotfix` branches for Electron builds only
- [x] Add TL;DR for branching workflow to` BRANCHING_WORKFLOW.md`
- [x] Add note about `target` branch to `RELEASE.md`