### PR TITLE
Introduce `useSubscriptionState`

### DIFF
--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -305,6 +305,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
 
   return (
     <>
+      <div>amountToSend: {amountToSend.amount().toString()}</div>
       <Row>
         <Styled.Col span={24}>
           <AccountSelector

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -305,7 +305,6 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
 
   return (
     <>
-      <div>amountToSend: {amountToSend.amount().toString()}</div>
       <Row>
         <Styled.Col span={24}>
           <AccountSelector

--- a/src/renderer/hooks/useSubscriptionState.ts
+++ b/src/renderer/hooks/useSubscriptionState.ts
@@ -30,15 +30,6 @@ export const useSubscriptionState = <T>(initialState: T) => {
     subRef.current = O.none
   }, [subRef])
 
-  // Store subscription by unsubscribing previous subscription
-  const setSub = useCallback(
-    (subscription) => {
-      unsubscribeSub()
-      subRef.current = O.some(subscription)
-    },
-    [unsubscribeSub]
-  )
-
   // Reset subscription and state
   const reset = useCallback(() => {
     unsubscribeSub()
@@ -47,8 +38,9 @@ export const useSubscriptionState = <T>(initialState: T) => {
 
   // Subscribe to an Observable
   const subscribe = (stream$: Rx.Observable<T>) => {
+    unsubscribeSub()
     const subscription = stream$.subscribe(setState)
-    setSub(subscription)
+    subRef.current = O.some(subscription)
   }
 
   /** Clean up */
@@ -58,5 +50,5 @@ export const useSubscriptionState = <T>(initialState: T) => {
     }
   }, [unsubscribeSub])
 
-  return { state, setState, subscribe, reset }
+  return { state, subscribe, reset }
 }

--- a/src/renderer/hooks/useSubscriptionState.ts
+++ b/src/renderer/hooks/useSubscriptionState.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
+
+/**
+ * Custom hook
+ * to subscribe to an Observable
+ * and to put its values into a state
+ *
+ * Why not just using `observableState of `observable-state`?
+ * Just because `observableState` does ont work in `useCallback.
+ *
+ * In other cases, always use `observableState`
+ */
+export const useSubscriptionState = <T>(initialState: T) => {
+  // State stream values
+  const [state, setState] = useState<T>(initialState)
+
+  // Ref. to subscription
+  const subRef = useRef<O.Option<Rx.Subscription>>(O.none)
+
+  // Unsubscribe subscription (if there any)
+  const unsubscribeSub = useCallback(() => {
+    FP.pipe(
+      subRef.current,
+      O.map((sub) => sub.unsubscribe())
+    )
+    subRef.current = O.none
+  }, [subRef])
+
+  // Store subscription by unsubscribing previous subscription
+  const setSub = useCallback(
+    (subscription) => {
+      unsubscribeSub()
+      subRef.current = O.some(subscription)
+    },
+    [unsubscribeSub]
+  )
+
+  // Reset subscription and state
+  const reset = useCallback(() => {
+    unsubscribeSub()
+    setState(initialState)
+  }, [unsubscribeSub, initialState])
+
+  // Subscribe to an Observable
+  const subscribe = (stream$: Rx.Observable<T>) => {
+    const subscription = stream$.subscribe(setState)
+    setSub(subscription)
+  }
+
+  /** Clean up */
+  useEffect(() => {
+    return () => {
+      unsubscribeSub()
+    }
+  }, [unsubscribeSub])
+
+  return { state, setState, subscribe, reset }
+}

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -33,8 +33,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
   const {
     balancesState$,
     getExplorerTxUrl$,
-    keystoreService: { validatePassword$ },
-    reloadBalances
+    keystoreService: { validatePassword$ }
   } = useWalletContext()
 
   const { balances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
@@ -65,7 +64,6 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             <SendViewBNB
               asset={asset}
               balances={balances}
-              reloadBalances={reloadBalances}
               getExplorerTxUrl={getExplorerTxUrl}
               validatePassword$={validatePassword$}
               network={network}
@@ -76,7 +74,6 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             <SendViewBTC
               asset={asset}
               balances={balances}
-              reloadBalances={reloadBalances}
               getExplorerTxUrl={getExplorerTxUrl}
               validatePassword$={validatePassword$}
               network={network}
@@ -87,7 +84,6 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             <SendViewETH
               asset={asset}
               balances={balances}
-              reloadBalances={reloadBalances}
               getExplorerTxUrl={getExplorerTxUrl}
               validatePassword$={validatePassword$}
               network={network}
@@ -98,7 +94,6 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             <SendViewTHOR
               asset={asset}
               balances={balances}
-              reloadBalances={reloadBalances}
               getExplorerTxUrl={getExplorerTxUrl}
               validatePassword$={validatePassword$}
               network={network}
@@ -117,7 +112,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           )
       }
     },
-    [balances, getExplorerTxUrl, network, reloadBalances, validatePassword$, intl]
+    [balances, getExplorerTxUrl, network, validatePassword$, intl]
   )
 
   return FP.pipe(

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Client as BinanceClient } from '@xchainjs/xchain-binance'
@@ -7,7 +7,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-import * as Rx from 'rxjs'
+import { useHistory } from 'react-router-dom'
 
 import { Network } from '../../../../shared/api/types'
 import { Send } from '../../../components/wallet/txs/send/'
@@ -17,6 +17,7 @@ import { useChainContext } from '../../../contexts/ChainContext'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { liveData } from '../../../helpers/rx/liveData'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { AddressValidation } from '../../../services/binance/types'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { FeeRD, SendTxParams, SendTxState } from '../../../services/chain/types'
@@ -28,75 +29,32 @@ import * as Helper from './SendView.helper'
 type Props = {
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
-  reloadBalances: FP.Lazy<void>
   getExplorerTxUrl: O.Option<GetExplorerTxUrl>
   validatePassword$: ValidatePasswordHandler
   network: Network
 }
 
 export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
-  const {
-    asset,
-    balances: oBalances,
-    reloadBalances,
-    getExplorerTxUrl: oGetExplorerTxUrl = O.none,
-    validatePassword$,
-    network
-  } = props
+  const { asset, balances: oBalances, getExplorerTxUrl: oGetExplorerTxUrl = O.none, validatePassword$, network } = props
 
   const intl = useIntl()
+  const history = useHistory()
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 
-  // TODO (@asgdx-team)
-  // Extract boilerplate for manual Rx.Subscription
-  // see https://github.com/thorchain/asgardex-electron/issues/898
-
-  // (Possible) subscription of transfer tx
-  const [sendTxSub, _setSendTxSub] = useState<O.Option<Rx.Subscription>>(O.none)
-
-  // unsubscribe transfer$ subscription
-  const unsubscribeSendTxSub = useCallback(() => {
-    FP.pipe(
-      sendTxSub,
-      O.map((sub) => sub.unsubscribe())
-    )
-  }, [sendTxSub])
-
-  const setSendTxSub = useCallback(
-    (state) => {
-      unsubscribeSendTxSub()
-      _setSendTxSub(state)
-    },
-    [unsubscribeSendTxSub]
-  )
-
-  useEffect(() => {
-    // Unsubscribe of (possible) previous subscription of `send$`
-    return () => {
-      unsubscribeSendTxSub()
-    }
-  }, [unsubscribeSendTxSub])
-
-  // State of send tx
-  const [sendTxState, setSendTxState] = useState<SendTxState>(INITIAL_SEND_STATE)
-
-  const resetTxState = useCallback(() => {
-    setSendTxState(INITIAL_SEND_STATE)
-    setSendTxSub(O.none)
-  }, [setSendTxSub])
-
-  // --- END TODO
+  const {
+    state: sendTxState,
+    reset: resetSendTxState,
+    subscribe: subscribeSendTxState
+  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
 
   const onSend = useCallback(
     (params: SendTxParams) => {
-      const subscription = transfer$(params).subscribe(setSendTxState)
-      // store subscription
-      return setSendTxSub(O.some(subscription))
+      subscribeSendTxState(transfer$(params))
     },
-    [setSendTxSub, transfer$]
+    [subscribeSendTxState, transfer$]
   )
 
   const { fees$, client$, reloadFees } = useBinanceContext()
@@ -158,9 +116,9 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
   )
 
   const finishActionHandler = useCallback(() => {
-    reloadBalances()
-    resetTxState()
-  }, [reloadBalances, resetTxState])
+    resetSendTxState()
+    history.goBack()
+  }, [history, resetSendTxState])
 
   return FP.pipe(
     sequenceTOption(oWalletBalance, oGetExplorerTxUrl),
@@ -173,7 +131,7 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
             txRD={sendTxState.status}
             viewTxHandler={viewTxHandler}
             finishActionHandler={finishActionHandler}
-            errorActionHandler={resetTxState}
+            errorActionHandler={finishActionHandler}
             sendForm={sendForm(walletBalance)}
           />
         )

--- a/src/renderer/views/wallet/send/SendViewBTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewBTC.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Client as BitcoinClient } from '@xchainjs/xchain-bitcoin'
@@ -7,7 +7,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-import * as Rx from 'rxjs'
+import { useHistory } from 'react-router-dom'
 
 import { Network } from '../../../../shared/api/types'
 import { Send } from '../../../components/wallet/txs/send/'
@@ -16,9 +16,10 @@ import { useBitcoinContext } from '../../../contexts/BitcoinContext'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { AddressValidation } from '../../../services/bitcoin/types'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
-import { SendTxState, SendTxParams } from '../../../services/chain/types'
+import { SendTxParams, SendTxState } from '../../../services/chain/types'
 import { GetExplorerTxUrl, WalletBalances } from '../../../services/clients'
 import { NonEmptyWalletBalances, ValidatePasswordHandler } from '../../../services/wallet/types'
 import { WalletBalance } from '../../../types/wallet'
@@ -27,75 +28,32 @@ import * as Helper from './SendView.helper'
 type Props = {
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
-  reloadBalances: FP.Lazy<void>
   getExplorerTxUrl: O.Option<GetExplorerTxUrl>
   validatePassword$: ValidatePasswordHandler
   network: Network
 }
 
 export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
-  const {
-    asset,
-    balances: oBalances,
-    reloadBalances,
-    getExplorerTxUrl: oGetExplorerTxUrl = O.none,
-    validatePassword$,
-    network
-  } = props
+  const { asset, balances: oBalances, getExplorerTxUrl: oGetExplorerTxUrl = O.none, validatePassword$, network } = props
 
   const intl = useIntl()
+  const history = useHistory()
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 
-  // TODO (@asgdx-team)
-  // Extract boilerplate for manual Rx.Subscription
-  // see https://github.com/thorchain/asgardex-electron/issues/898
-
-  // (Possible) subscription of transfer tx
-  const [sendTxSub, _setSendTxSub] = useState<O.Option<Rx.Subscription>>(O.none)
-
-  // unsubscribe transfer$ subscription
-  const unsubscribeSendTxSub = useCallback(() => {
-    FP.pipe(
-      sendTxSub,
-      O.map((sub) => sub.unsubscribe())
-    )
-  }, [sendTxSub])
-
-  const setSendTxSub = useCallback(
-    (state) => {
-      unsubscribeSendTxSub()
-      _setSendTxSub(state)
-    },
-    [unsubscribeSendTxSub]
-  )
-
-  useEffect(() => {
-    // Unsubscribe of (possible) previous subscription of `send$`
-    return () => {
-      unsubscribeSendTxSub()
-    }
-  }, [unsubscribeSendTxSub])
-
-  // State of send tx
-  const [sendTxState, setSendTxState] = useState<SendTxState>(INITIAL_SEND_STATE)
-
-  const resetTxState = useCallback(() => {
-    setSendTxState(INITIAL_SEND_STATE)
-    setSendTxSub(O.none)
-  }, [setSendTxSub])
-
-  // --- END TODO
+  const {
+    state: sendTxState,
+    reset: resetSendTxState,
+    subscribe: subscribeSendTxState
+  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
 
   const onSend = useCallback(
     (params: SendTxParams) => {
-      const subscription = transfer$(params).subscribe(setSendTxState)
-      // store subscription
-      return setSendTxSub(O.some(subscription))
+      subscribeSendTxState(transfer$(params))
     },
-    [setSendTxSub, transfer$]
+    [subscribeSendTxState, transfer$]
   )
 
   const { fees$, client$, reloadFees } = useBitcoinContext()
@@ -144,9 +102,9 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
   )
 
   const finishActionHandler = useCallback(() => {
-    reloadBalances()
-    resetTxState()
-  }, [reloadBalances, resetTxState])
+    resetSendTxState()
+    history.goBack()
+  }, [history, resetSendTxState])
 
   return FP.pipe(
     sequenceTOption(oGetExplorerTxUrl, oWalletBalance),
@@ -160,7 +118,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
               txRD={sendTxState.status}
               viewTxHandler={viewTxHandler}
               finishActionHandler={finishActionHandler}
-              errorActionHandler={resetTxState}
+              errorActionHandler={resetSendTxState}
               sendForm={sendForm(walletBalance)}
             />
           </>

--- a/src/renderer/views/wallet/send/SendViewTHOR.tsx
+++ b/src/renderer/views/wallet/send/SendViewTHOR.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Client as ThorchainClient } from '@xchainjs/xchain-thorchain'
@@ -7,7 +7,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-import * as Rx from 'rxjs'
+import { useHistory } from 'react-router-dom'
 
 import { Network } from '../../../../shared/api/types'
 import { Send, SendFormTHOR } from '../../../components/wallet/txs/send/'
@@ -16,6 +16,7 @@ import { useThorchainContext } from '../../../contexts/ThorchainContext'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { liveData } from '../../../helpers/rx/liveData'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { FeeRD, SendTxParams, SendTxState } from '../../../services/chain/types'
 import { GetExplorerTxUrl, WalletBalances } from '../../../services/clients'
@@ -27,75 +28,31 @@ import * as Helper from './SendView.helper'
 type Props = {
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
-  reloadBalances: FP.Lazy<void>
   getExplorerTxUrl: O.Option<GetExplorerTxUrl>
   validatePassword$: ValidatePasswordHandler
   network: Network
 }
 
 export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
-  const {
-    asset,
-    balances: oBalances,
-    reloadBalances,
-    getExplorerTxUrl: oGetExplorerTxUrl = O.none,
-    validatePassword$,
-    network
-  } = props
+  const { asset, balances: oBalances, getExplorerTxUrl: oGetExplorerTxUrl = O.none, validatePassword$, network } = props
 
   const intl = useIntl()
+  const history = useHistory()
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
-
-  // TODO (@asgdx-team)
-  // Extract boilerplate for manual Rx.Subscription
-  // see https://github.com/thorchain/asgardex-electron/issues/898
-
-  // (Possible) subscription of transfer tx
-  const [sendTxSub, _setSendTxSub] = useState<O.Option<Rx.Subscription>>(O.none)
-
-  // unsubscribe transfer$ subscription
-  const unsubscribeSendTxSub = useCallback(() => {
-    FP.pipe(
-      sendTxSub,
-      O.map((sub) => sub.unsubscribe())
-    )
-  }, [sendTxSub])
-
-  const setSendTxSub = useCallback(
-    (state) => {
-      unsubscribeSendTxSub()
-      _setSendTxSub(state)
-    },
-    [unsubscribeSendTxSub]
-  )
-
-  useEffect(() => {
-    // Unsubscribe of (possible) previous subscription of `send$`
-    return () => {
-      unsubscribeSendTxSub()
-    }
-  }, [unsubscribeSendTxSub])
-
-  // State of send tx
-  const [sendTxState, setSendTxState] = useState<SendTxState>(INITIAL_SEND_STATE)
-
-  const resetTxState = useCallback(() => {
-    setSendTxState(INITIAL_SEND_STATE)
-    setSendTxSub(O.none)
-  }, [setSendTxSub])
-
-  // --- END TODO
+  const {
+    state: sendTxState,
+    reset: resetSendTxState,
+    subscribe: subscribeSendTxState
+  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
 
   const onSend = useCallback(
     (params: SendTxParams) => {
-      const subscription = transfer$(params).subscribe(setSendTxState)
-      // store subscription
-      return setSendTxSub(O.some(subscription))
+      subscribeSendTxState(transfer$(params))
     },
-    [setSendTxSub, transfer$]
+    [subscribeSendTxState, transfer$]
   )
 
   const { fees$, client$, reloadFees } = useThorchainContext()
@@ -152,11 +109,10 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
     ),
     [oBalances, isLoading, onSend, addressValidation, feeRD, reloadFees, validatePassword$, sendTxStatusMsg, network]
   )
-
   const finishActionHandler = useCallback(() => {
-    reloadBalances()
-    resetTxState()
-  }, [reloadBalances, resetTxState])
+    resetSendTxState()
+    history.goBack()
+  }, [history, resetSendTxState])
 
   return FP.pipe(
     sequenceTOption(oGetExplorerTxUrl, oWalletBalance),
@@ -170,7 +126,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
               txRD={sendTxState.status}
               viewTxHandler={viewTxHandler}
               finishActionHandler={finishActionHandler}
-              errorActionHandler={resetTxState}
+              errorActionHandler={finishActionHandler}
               sendForm={sendForm(walletBalance)}
             />
           </>


### PR DESCRIPTION
based on first approach created by @thatStrangeGuyThorchain in #903

PR includes following changes:
- [x] Introduce `useSubscriptionState`
- [x] Remove `loadBalances` from SendViewXYZViews
- [x] Fix target of `Back` button to go back to asset details view (instead
of going back to form)

Closes #898