### PR TITLE
[Deposit] Fix fees to depend on memo etc

### DIFF
--- a/src/renderer/components/deposit/add/AsymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/AsymDeposit.stories.tsx
@@ -30,10 +30,13 @@ const defaultProps: AsymDepositProps = {
   chainAssetBalance: O.some(assetToBase(assetAmount(55))),
   onChangeAsset: (a: Asset) => console.log('change asset', a),
   reloadFees: () => console.log('reload fees'),
-  fees: RD.success({
-    thor: O.none,
-    asset: baseAmount(123)
-  }),
+  fees$: () =>
+    Rx.of(
+      RD.success({
+        thor: O.none,
+        asset: baseAmount(123)
+      })
+    ),
   poolData: {
     assetBalance: baseAmount('1000'),
     runeBalance: baseAmount('2000')
@@ -80,10 +83,13 @@ BalanceError.storyName = 'balance error'
 export const FeeError: Story = () => {
   const props: AsymDepositProps = {
     ...defaultProps,
-    fees: RD.success({
-      thor: O.some(baseAmount(2)),
-      asset: baseAmount(123)
-    }),
+    fees$: () =>
+      Rx.of(
+        RD.success({
+          thor: O.some(baseAmount(2)),
+          asset: baseAmount(123)
+        })
+      ),
     assetBalance: O.some(baseAmount(1)),
     chainAssetBalance: O.some(baseAmount(1))
   }

--- a/src/renderer/components/deposit/add/AsymDeposit.tsx
+++ b/src/renderer/components/deposit/add/AsymDeposit.tsx
@@ -21,6 +21,7 @@ import * as RxOp from 'rxjs/operators'
 import { Network } from '../../../../shared/api/types'
 import { ZERO_BASE_AMOUNT, ZERO_BN } from '../../../const'
 import { isChainAsset } from '../../../helpers/assetHelper'
+import { eqBaseAmount } from '../../../helpers/fp/eq'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_ASYM_DEPOSIT_STATE } from '../../../services/chain/const'
@@ -132,7 +133,9 @@ export const AsymDeposit: React.FC<Props> = (props) => {
           return (
             oldParams.asset.chain === newParams.asset.chain &&
             // Check for the first enter to the page when chain or amount was not changed
-            !(O.isNone(oldParams.memo) && O.isSome(newParams.memo))
+            !(O.isNone(oldParams.memo) && O.isSome(newParams.memo)) &&
+            // Check if entered amount was changed
+            eqBaseAmount.equals(oldParams.amount, newParams.amount)
           )
         }),
         RxOp.switchMap(chainFees$)
@@ -148,7 +151,7 @@ export const AsymDeposit: React.FC<Props> = (props) => {
      */
     setDepositFees({
       asset,
-      amount: O.some(assetAmountToDeposit),
+      amount: assetAmountToDeposit,
       memo: oMemo,
       recipient: oPoolAddress,
       type: 'asym'

--- a/src/renderer/components/deposit/add/AsymDeposit.tsx
+++ b/src/renderer/components/deposit/add/AsymDeposit.tsx
@@ -30,7 +30,7 @@ import {
   AsymDepositStateHandler,
   LoadDepositFeesHandler,
   DepositFeesHandler,
-  DepositFeesParams,
+  AsymDepositFeesParams,
   DepositFeesRD
 } from '../../../services/chain/types'
 import { PoolAddress } from '../../../services/midgard/types'
@@ -115,7 +115,7 @@ export const AsymDeposit: React.FC<Props> = (props) => {
 
   const chainFees$ = useMemo(() => fees$, [fees$])
 
-  const [depositFeesRD, setDepositFees] = useObservableState<DepositFeesRD, DepositFeesParams>(
+  const [depositFeesRD, setDepositFees] = useObservableState<DepositFeesRD, AsymDepositFeesParams>(
     (params$) =>
       FP.pipe(
         params$,
@@ -129,7 +129,11 @@ export const AsymDeposit: React.FC<Props> = (props) => {
            * 1 - chain was changed
            * 2 - Amount to deposit was changed. Some chains' fess depends on amount too (e.g. ETH)
            */
-          return oldParams.asset.chain === newParams.asset.chain
+          return (
+            oldParams.asset.chain === newParams.asset.chain &&
+            // Check for the first enter to the page when chain or amount was not changed
+            !(O.isNone(oldParams.memo) && O.isSome(newParams.memo))
+          )
         }),
         RxOp.switchMap(chainFees$)
       ),

--- a/src/renderer/components/deposit/add/SymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.stories.tsx
@@ -32,10 +32,13 @@ const defaultProps: SymDepositProps = {
   chainAssetBalance: O.some(assetToBase(assetAmount(55))),
   onChangeAsset: (a: Asset) => console.log('change asset', a),
   reloadFees: () => console.log('reload fees'),
-  fees: RD.success({
-    thor: O.some(baseAmount(100)),
-    asset: baseAmount(12300)
-  }),
+  fees$: () =>
+    Rx.of(
+      RD.success({
+        thor: O.some(baseAmount(100)),
+        asset: baseAmount(12300)
+      })
+    ),
   poolData: {
     assetBalance: baseAmount('1000'),
     runeBalance: baseAmount('2000')

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState, useEffect } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { PoolData } from '@thorchain/asgardex-util'
@@ -15,7 +15,9 @@ import { Col } from 'antd'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
+import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
+import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../../shared/api/types'
 import { ZERO_BASE_AMOUNT, ZERO_BN } from '../../../const'
@@ -23,10 +25,17 @@ import { isChainAsset } from '../../../helpers/assetHelper'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_SYM_DEPOSIT_STATE } from '../../../services/chain/const'
-import { SymDepositMemo, DepositFeesRD, SymDepositState, SymDepositStateHandler } from '../../../services/chain/types'
+import {
+  SymDepositMemo,
+  SymDepositState,
+  SymDepositStateHandler,
+  LoadDepositFeesHandler,
+  DepositFeesHandler,
+  DepositFeesRD,
+  DepositFeesParams
+} from '../../../services/chain/types'
 import { PoolAddress } from '../../../services/midgard/types'
 import { ValidatePasswordHandler } from '../../../services/wallet/types'
-import { DepositType } from '../../../types/asgardex'
 import { PasswordModal } from '../../modal/password'
 import { TxModal } from '../../modal/tx'
 import { DepositAssets } from '../../modal/tx/extra'
@@ -47,8 +56,8 @@ export type Props = {
   poolAddress: O.Option<PoolAddress>
   memo: O.Option<SymDepositMemo>
   priceAsset?: Asset
-  fees: DepositFeesRD
-  reloadFees: (type: DepositType) => void
+  reloadFees: LoadDepositFeesHandler
+  fees$: DepositFeesHandler
   reloadBalances: FP.Lazy<void>
   viewAssetTx: (txHash: string) => void
   viewRuneTx: (txHash: string) => void
@@ -80,7 +89,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
     priceAsset,
     reloadFees,
     reloadBalances = FP.constVoid,
-    fees,
+    fees$,
     onChangeAsset,
     disabled = false,
     poolData,
@@ -121,14 +130,48 @@ export const SymDeposit: React.FC<Props> = (props) => {
     [oRuneBalance]
   )
 
+  const chainFees$ = useMemo(() => fees$, [fees$])
+
+  const depositFeesParams: DepositFeesParams = useMemo(
+    () => ({
+      asset,
+      amount: O.some(assetAmountToDeposit),
+      memo: FP.pipe(
+        oMemo,
+        O.map(({ asset }) => asset)
+      ),
+      recipient: oPoolAddress,
+      type: 'sym'
+    }),
+    [asset, assetAmountToDeposit, oMemo, oPoolAddress]
+  )
+
+  const [depositFeesRD, setDepositFees] = useObservableState<DepositFeesRD, DepositFeesParams>(
+    (params$) =>
+      FP.pipe(
+        params$,
+        RxOp.debounceTime(500),
+        RxOp.distinctUntilChanged((oldParams, newParams) => {
+          return oldParams.asset.chain === newParams.asset.chain
+        }),
+        // RxOp.tap((params) => console.log('params - ', params)),
+        RxOp.switchMap(chainFees$)
+      ),
+    RD.initial
+  )
+
+  useEffect(() => {
+    setDepositFees(depositFeesParams)
+  }, [setDepositFees, depositFeesParams])
+
   const oThorchainFee: O.Option<BaseAmount> = useMemo(
     () =>
       FP.pipe(
-        fees,
-        RD.toOption,
-        O.chain(({ thor }) => thor)
+        depositFeesRD,
+        RD.map(({ thor }) => thor),
+        FP.flow(RD.toOption, O.flatten)
       ),
-    [fees]
+    [depositFeesRD]
   )
 
   const maxRuneAmountToDeposit = useMemo((): BaseAmount => {
@@ -150,11 +193,11 @@ export const SymDeposit: React.FC<Props> = (props) => {
   const oAssetChainFee: O.Option<BaseAmount> = useMemo(
     () =>
       FP.pipe(
-        fees,
-        RD.toOption,
-        O.map(({ asset }) => asset)
+        depositFeesRD,
+        RD.map(({ asset }) => asset),
+        RD.toOption
       ),
-    [fees]
+    [depositFeesRD]
   )
 
   const maxAssetAmountToDeposit = useMemo((): BaseAmount => {
@@ -366,8 +409,6 @@ export const SymDeposit: React.FC<Props> = (props) => {
     )
   }, [oChainAssetBalance, oAssetChainFee, renderFeeError, asset])
 
-  const reloadFeesHandler = useCallback(() => reloadFees('sym'), [reloadFees])
-
   const txModalExtraContent = useMemo(() => {
     const stepDescriptions = [
       intl.formatMessage({ id: 'common.tx.healthCheck' }),
@@ -526,22 +567,24 @@ export const SymDeposit: React.FC<Props> = (props) => {
     isBalanceError,
     isThorchainFeeError
   ])
-
   const uiFeesRD: UIFeesRD = useMemo(
     () =>
       FP.pipe(
-        fees,
-        RD.map(({ asset: assetFeeAmount, thor: oThorFeeAmount }) => {
-          const fees = [{ asset, amount: assetFeeAmount }]
-
-          return FP.pipe(
-            oThorFeeAmount,
-            O.map((thorFeeAmount) => [...fees, { asset: AssetRuneNative, amount: thorFeeAmount }]),
-            O.getOrElse(() => fees)
+        depositFeesRD,
+        RD.map(({ asset: assetFeeAmount, thor }) =>
+          FP.pipe(
+            thor,
+            O.fold(
+              () => [{ asset, amount: assetFeeAmount }],
+              (thorAmount) => [
+                { asset, amount: assetFeeAmount },
+                { asset: AssetRuneNative, amount: thorAmount }
+              ]
+            )
           )
-        })
+        )
       ),
-    [asset, fees]
+    [depositFeesRD, asset]
   )
 
   return (
@@ -590,7 +633,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
       <Styled.FeesRow gutter={{ lg: 32 }}>
         <Col xs={24} xl={12}>
           <Styled.FeeRow>
-            <Fees fees={uiFeesRD} reloadFees={reloadFeesHandler} />
+            <Fees fees={uiFeesRD} reloadFees={reloadFees} />
           </Styled.FeeRow>
           <Styled.FeeErrorRow>
             <Col>

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -327,6 +327,14 @@ export const SymDeposit: React.FC<Props> = (props) => {
     [maxAssetAmountToDeposit, maxRuneAmountToDeposit]
   )
 
+  const onChangeAssetHandler = useCallback(
+    (asset: Asset) => {
+      onChangeAsset(asset)
+      changePercentHandler(0)
+    },
+    [changePercentHandler, onChangeAsset]
+  )
+
   const [showPasswordModal, setShowPasswordModal] = useState(false)
 
   const confirmDepositHandler = useCallback(() => {
@@ -432,7 +440,8 @@ export const SymDeposit: React.FC<Props> = (props) => {
   const onFinishTxModal = useCallback(() => {
     resetDepositState()
     reloadBalances()
-  }, [reloadBalances, resetDepositState])
+    changePercentHandler(0)
+  }, [reloadBalances, resetDepositState, changePercentHandler])
 
   const renderTxModal = useMemo(() => {
     const { deposit: depositRD, depositTxs: symDepositTxs } = depositState
@@ -597,7 +606,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
             assets={assets}
             percentValue={percentValueToDeposit}
             onChangePercent={changePercentHandler}
-            onChangeAsset={onChangeAsset}
+            onChangeAsset={onChangeAssetHandler}
             priceAsset={priceAsset}
             network={network}
           />

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -22,6 +22,7 @@ import * as RxOp from 'rxjs/operators'
 import { Network } from '../../../../shared/api/types'
 import { ZERO_BASE_AMOUNT, ZERO_BN } from '../../../const'
 import { isChainAsset } from '../../../helpers/assetHelper'
+import { eqBaseAmount } from '../../../helpers/fp/eq'
 import { sequenceTOption } from '../../../helpers/fpHelpers'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_SYM_DEPOSIT_STATE } from '../../../services/chain/const'
@@ -149,10 +150,12 @@ export const SymDeposit: React.FC<Props> = (props) => {
           return (
             oldParams.asset.chain === newParams.asset.chain &&
             // Check for the first enter to the page when chain or amount was not changed
-            !(O.isNone(oldParams.memos) && O.isSome(newParams.memos))
+            !(O.isNone(oldParams.memos) && O.isSome(newParams.memos)) &&
+            // Check if entered amount was changed
+            eqBaseAmount.equals(oldParams.amount, newParams.amount)
           )
         }),
-        RxOp.switchMap(chainFees$)
+        RxOp.switchMap((params) => chainFees$({ ...params, amount: params.amount }))
       ),
     RD.initial
   )
@@ -165,7 +168,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
      */
     setDepositFees({
       asset,
-      amount: O.some(assetAmountToDeposit),
+      amount: assetAmountToDeposit,
       memos: oMemo,
       recipient: oPoolAddress,
       type: 'sym'

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -3,6 +3,7 @@ import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn, Chain } from '@xch
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
+import { SymDepositFeesParams } from '../../services/chain/types'
 import { PoolShare } from '../../services/midgard/types'
 import { ApiError, ErrorId } from '../../services/wallet/types'
 import {
@@ -144,6 +145,40 @@ describe('helpers/fp/eq', () => {
       }
       // c = same as a, but another asset
       const c: Balance = {
+        ...a,
+        asset: AssetRuneNative
+      }
+      expect(eqBalance.equals(a, b)).toBeFalsy()
+      expect(eqBalance.equals(a, c)).toBeFalsy()
+    })
+  })
+
+  describe('eqDepositFeesParams', () => {
+    it('is equal', () => {
+      const a: SymDepositFeesParams = {
+        memos: O.none,
+        recipient: O.none,
+        type: 'sym',
+        amount: baseAmount('1'),
+        asset: AssetBNB
+      }
+      expect(eqBalance.equals(a, a)).toBeTruthy()
+    })
+    it('is not equal', () => {
+      const a: SymDepositFeesParams = {
+        memos: O.none,
+        recipient: O.none,
+        type: 'sym',
+        amount: baseAmount('1'),
+        asset: AssetBNB
+      }
+      // b = same as a, but another amount
+      const b: SymDepositFeesParams = {
+        ...a,
+        amount: baseAmount('2')
+      }
+      // c = same as a, but another asset
+      const c: SymDepositFeesParams = {
         ...a,
         asset: AssetRuneNative
       }

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -6,6 +6,7 @@ import * as A from 'fp-ts/lib/Array'
 import * as Eq from 'fp-ts/lib/Eq'
 import * as O from 'fp-ts/lib/Option'
 
+import { DepositFeesParams } from '../../services/chain/types'
 import { PoolShare } from '../../services/midgard/types'
 import { ApiError } from '../../services/wallet/types'
 import { WalletBalance } from '../../types/wallet'
@@ -36,6 +37,14 @@ export const eqOptionBaseAmount = O.getEq(eqBaseAmount)
 
 export const eqBalance: Eq.Eq<Balance> = {
   equals: (x, y) => eqAsset.equals(x.asset, y.asset) && eqBaseAmount.equals(x.amount, y.amount)
+}
+
+export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
+  equals: (x, y) =>
+    // Check if entered chain was changed
+    eqChain.equals(x.asset.chain, y.asset.chain) &&
+    // Check if entered amount was changed
+    eqBaseAmount.equals(x.amount, y.amount)
 }
 
 export const eqErrorId = Eq.eqString

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -145,7 +145,7 @@ const depositFees$ = (params: DepositFeesParams): DepositFeesLD =>
             ? // for asym deposits, one tx needed at asset chain only == one fee)
               [
                 depositFeeByChain$({
-                  amount: params.amount,
+                  amount: O.some(params.amount),
                   memo: params.memo,
                   asset: params.asset,
                   recipient: params.recipient
@@ -154,7 +154,7 @@ const depositFees$ = (params: DepositFeesParams): DepositFeesLD =>
             : // for sym deposits, two txs at thorchain an asset chain needed == 2 fees,
               [
                 depositFeeByChain$({
-                  amount: params.amount,
+                  amount: O.some(params.amount),
                   memo: FP.pipe(
                     params.memos,
                     O.map(({ asset }) => asset)

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -19,7 +19,7 @@ import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { eqBaseAmount, eqChain } from '../../../helpers/fp/eq'
+import { eqDepositFeesParams } from '../../../helpers/fp/eq'
 import { sequenceSOption, sequenceTRDFromArray } from '../../../helpers/fpHelpers'
 import { liveData } from '../../../helpers/rx/liveData'
 import { observableState } from '../../../helpers/stateHelper'
@@ -140,12 +140,7 @@ const depositFees$ = (initialParams: DepositFeesParams): DepositFeesLD =>
          * 1 - chain was changed
          * 2 - Amount to deposit was changed. Some chains' fess depends on amount too (e.g. ETH)
          */
-        return (
-          // Check if entered chain was changed
-          eqChain.equals(prev.asset.chain, next.asset.chain) &&
-          // Check if entered amount was changed
-          eqBaseAmount.equals(prev.amount, next.amount)
-        )
+        return eqDepositFeesParams.equals(prev, next)
       }
       return false
     }),

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -32,13 +32,6 @@ import { selectedPoolChain$ } from '../../midgard/common'
 import * as THOR from '../../thorchain'
 import { FeeLD, LoadFeesHandler, DepositFeesParams, DepositFeesLD, Memo } from '../types'
 
-export const reloadFees = () => {
-  BNB.reloadFees()
-  BTC.reloadFees()
-  THOR.reloadFees()
-  BCH.reloadFees()
-}
-
 const reloadFeesByChain = (chain: Chain) => {
   switch (chain) {
     case BNBChain:

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -7,7 +7,7 @@ import * as Rx from 'rxjs'
 
 import { Network } from '../../../shared/api/types'
 import { LiveData } from '../../helpers/rx/liveData'
-import { DepositType, TxTypes } from '../../types/asgardex'
+import { TxTypes } from '../../types/asgardex'
 import { ApiError, TxHashRD } from '../wallet/types'
 
 export type Chain$ = Rx.Observable<O.Option<Chain>>
@@ -47,13 +47,23 @@ export type DepositFeesRD = RD.RemoteData<Error, DepositFees>
 export type DepositFeesLD = LiveData<Error, DepositFees>
 export type SymDepositAmounts = { rune: BaseAmount; asset: BaseAmount }
 
-export type DepositFeesParams = {
+export type AsymDepositFeesParams = {
   readonly asset: Asset
   readonly amount?: O.Option<BaseAmount>
   readonly memo: O.Option<Memo>
   readonly recipient?: O.Option<Address>
-  readonly type: DepositType
+  readonly type: 'asym'
 }
+
+export type SymDepositFeesParams = {
+  readonly asset: Asset
+  readonly amount?: O.Option<BaseAmount>
+  readonly memos: O.Option<SymDepositMemo>
+  readonly recipient?: O.Option<Address>
+  readonly type: 'sym'
+}
+
+export type DepositFeesParams = AsymDepositFeesParams | SymDepositFeesParams
 
 export type DepositFeesHandler = (p: DepositFeesParams) => DepositFeesLD
 

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -1,7 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Address, FeeOptionKey, Fees, Tx } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, Chain } from '@xchainjs/xchain-util'
-import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
@@ -67,7 +66,7 @@ export type DepositFeesParams = AsymDepositFeesParams | SymDepositFeesParams
 
 export type DepositFeesHandler = (p: DepositFeesParams) => DepositFeesLD
 
-export type LoadDepositFeesHandler = FP.Lazy<void>
+export type LoadDepositFeesHandler = (p: DepositFeesParams) => void
 
 export type SendDepositTxParams = { chain: Chain; asset: Asset; poolAddress: string; amount: BaseAmount; memo: Memo }
 

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -49,7 +49,7 @@ export type SymDepositAmounts = { rune: BaseAmount; asset: BaseAmount }
 
 export type AsymDepositFeesParams = {
   readonly asset: Asset
-  readonly amount?: O.Option<BaseAmount>
+  readonly amount: BaseAmount
   readonly memo: O.Option<Memo>
   readonly recipient?: O.Option<Address>
   readonly type: 'asym'
@@ -57,7 +57,7 @@ export type AsymDepositFeesParams = {
 
 export type SymDepositFeesParams = {
   readonly asset: Asset
-  readonly amount?: O.Option<BaseAmount>
+  readonly amount: BaseAmount
   readonly memos: O.Option<SymDepositMemo>
   readonly recipient?: O.Option<Address>
   readonly type: 'sym'

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -1,12 +1,13 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Address, FeeOptionKey, Fees, Tx } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, Chain } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
 import { Network } from '../../../shared/api/types'
 import { LiveData } from '../../helpers/rx/liveData'
-import { TxTypes } from '../../types/asgardex'
+import { DepositType, TxTypes } from '../../types/asgardex'
 import { ApiError, TxHashRD } from '../wallet/types'
 
 export type Chain$ = Rx.Observable<O.Option<Chain>>
@@ -44,6 +45,19 @@ export type SymDepositMemoRx = Rx.Observable<O.Option<SymDepositMemo>>
 export type DepositFees = { thor: O.Option<BaseAmount>; asset: BaseAmount }
 export type DepositFeesRD = RD.RemoteData<Error, DepositFees>
 export type DepositFeesLD = LiveData<Error, DepositFees>
+export type SymDepositAmounts = { rune: BaseAmount; asset: BaseAmount }
+
+export type DepositFeesParams = {
+  readonly asset: Asset
+  readonly amount?: O.Option<BaseAmount>
+  readonly memo: O.Option<Memo>
+  readonly recipient?: O.Option<Address>
+  readonly type: DepositType
+}
+
+export type DepositFeesHandler = (p: DepositFeesParams) => DepositFeesLD
+
+export type LoadDepositFeesHandler = FP.Lazy<void>
 
 export type SendDepositTxParams = { chain: Chain; asset: Asset; poolAddress: string; amount: BaseAmount; memo: Memo }
 
@@ -87,7 +101,7 @@ export type SwapFeeParams = {
   readonly recipient: O.Option<Address>
   readonly asset: Asset
   readonly amount: BaseAmount
-  readonly memo?: string
+  readonly memo?: Memo
 }
 
 export type SwapFeesParams = {
@@ -147,7 +161,7 @@ export type SymDepositState$ = Rx.Observable<SymDepositState>
 export type SymDepositParams = {
   readonly poolAddress: O.Option<string>
   readonly asset: Asset
-  readonly amounts: { rune: BaseAmount; asset: BaseAmount }
+  readonly amounts: SymDepositAmounts
   readonly memos: SymDepositMemo
 }
 

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -60,7 +60,6 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     getExplorerUrlByAsset$
   } = useChainContext()
 
-  // const [depositFees] = useObservableState(() => depositFees$({ type: 'asym' }), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
   const {
@@ -140,8 +139,6 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
           assetPrice={ZERO_BN}
           assetBalance={O.none}
           chainAssetBalance={O.none}
-          // eslint-disable-next-line
-          // @ts-ignore
           fees$={depositFees$}
           reloadFees={FP.constVoid}
           priceAsset={selectedPricePoolAsset}
@@ -188,8 +185,6 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
               chainAssetBalance={chainAssetBalance}
               poolAddress={oPoolAddress}
               memo={memo}
-              // eslint-disable-next-line
-              // @ts-ignore
               fees$={depositFees$}
               reloadFees={reloadDepositFees}
               priceAsset={selectedPricePoolAsset}

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -60,7 +60,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     getExplorerUrlByAsset$
   } = useChainContext()
 
-  const [depositFees] = useObservableState(() => depositFees$('asym'), RD.initial)
+  const [depositFees] = useObservableState(() => depositFees$({ type: 'asym' }), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
   const {

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -60,7 +60,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     getExplorerUrlByAsset$
   } = useChainContext()
 
-  const [depositFees] = useObservableState(() => depositFees$({ type: 'asym' }), RD.initial)
+  // const [depositFees] = useObservableState(() => depositFees$({ type: 'asym' }), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
   const {
@@ -140,7 +140,9 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
           assetPrice={ZERO_BN}
           assetBalance={O.none}
           chainAssetBalance={O.none}
-          fees={depositFees}
+          // eslint-disable-next-line
+          // @ts-ignore
+          fees$={depositFees$}
           reloadFees={FP.constVoid}
           priceAsset={selectedPricePoolAsset}
           disabled={true}
@@ -157,7 +159,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
       validatePassword$,
       viewAssetTx,
       asset,
-      depositFees,
+      depositFees$,
       selectedPricePoolAsset,
       reloadBalances,
       asymDeposit$,
@@ -186,7 +188,9 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
               chainAssetBalance={chainAssetBalance}
               poolAddress={oPoolAddress}
               memo={memo}
-              fees={depositFees}
+              // eslint-disable-next-line
+              // @ts-ignore
+              fees$={depositFees$}
               reloadFees={reloadDepositFees}
               priceAsset={selectedPricePoolAsset}
               reloadBalances={reloadBalances}

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -54,7 +54,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
 
   const { depositFees$, symDeposit$, reloadDepositFees, symDepositTxMemo$, getExplorerUrlByAsset$ } = useChainContext()
 
-  const [depositFees] = useObservableState(() => depositFees$('sym'), RD.initial)
+  const [depositFees] = useObservableState(() => depositFees$({ type: 'sym' }), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
   const {

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -54,7 +54,6 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
 
   const { depositFees$, symDeposit$, reloadDepositFees, symDepositTxMemo$, getExplorerUrlByAsset$ } = useChainContext()
 
-  const [depositFees] = useObservableState(() => depositFees$({ type: 'sym' }), RD.initial)
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
   const {
@@ -160,7 +159,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
           assetBalance={O.none}
           runeBalance={O.none}
           chainAssetBalance={O.none}
-          fees={depositFees}
+          fees$={depositFees$}
           reloadFees={FP.constVoid}
           priceAsset={selectedPricePoolAsset}
           disabled={true}
@@ -178,7 +177,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
       viewRuneTx,
       viewAssetTx,
       asset,
-      depositFees,
+      depositFees$,
       selectedPricePoolAsset,
       reloadBalances,
       symDeposit$,
@@ -210,7 +209,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
               chainAssetBalance={chainAssetBalance}
               poolAddress={oPoolAddress}
               memo={depositTxMemo}
-              fees={depositFees}
+              fees$={depositFees$}
               reloadFees={reloadDepositFees}
               priceAsset={selectedPricePoolAsset}
               reloadBalances={reloadBalances}


### PR DESCRIPTION
- fees/deposit.ts
--  `depositFees$` - refactored to receive parameters needed to calculate fees
-- `depositFeeByChain$` - refactored to receive parameters needed to calculate fees; refactored to get memo purely from parameters; added support for `ETH` fees

- ~`AsymDeposit.tsx` and `SymDeposit.tsx` upgraded to re-request in case chain or amount to deposit was changed. to avoid creation of multiple requests [`setDepositFees`](https://github.com/thorchain/asgardex-electron/pull/1033/files#diff-13b694da7eb491527fdeb8d2323767d9d0cbd39fcb4af79e1669b6b5c701cb3bR119) of `useObservableState`. simple usage of `useObservableState(() => dataStream$)` will have no any effect in case if deposit params were changed during component's lifecycle as [`useObservableState` will call the epic-like `init` function only once](https://github.com/crimx/observable-hooks/blob/master/packages/observable-hooks/src/use-observable-state.ts#L33) so for updating data for re-requesting fees [`useEffect` was used](https://github.com/thorchain/asgardex-electron/pull/1033/files#diff-13b694da7eb491527fdeb8d2323767d9d0cbd39fcb4af79e1669b6b5c701cb3bR146-R159)~
- added resetting amount to deposit in case changing asset and after finishing tx
- removed callback for reloading all fees. it was unused so this is safe remove
closes #1027 