### PR TITLE
[Swap] Improve handling of fees, max amount, reloding fees etc.

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -144,7 +144,7 @@ export const Swap = ({
   const sourceChainAsset = useMemo(() => getChainAsset(sourceAssetProp.chain), [sourceAssetProp])
 
   // User balance for source chain asset
-  const sourceChainAssetBalance: BaseAmount = useMemo(
+  const sourceChainAssetAmount: BaseAmount = useMemo(
     () =>
       FP.pipe(
         getWalletBalanceByAsset(walletBalances, O.some(sourceChainAsset)),
@@ -265,16 +265,16 @@ export const Swap = ({
       RD.toOption(chainFeesRD),
       O.fold(
         // Ingnore fees and use balance of source chain asset for max.
-        () => sourceChainAssetBalance,
+        () => sourceChainAssetAmount,
         ({ source: sourceFee }) => {
-          let max = sourceChainAssetBalance.amount().minus(sourceFee.amount())
+          let max = sourceChainAssetAmount.amount().minus(sourceFee.amount())
           max = max.isGreaterThan(0) ? max : ZERO_BN
-          return baseAmount(max, sourceChainAssetBalance.decimal)
+          return baseAmount(max, sourceChainAssetAmount.decimal)
         }
       )
     )
     return eqAsset.equals(sourceChainAsset, sourceAssetProp) ? maxChainAssetAmount : sourceAssetAmount
-  }, [sourceAssetAmount, chainFeesRD, sourceAssetProp, sourceChainAsset, sourceChainAssetBalance])
+  }, [sourceAssetAmount, chainFeesRD, sourceAssetProp, sourceChainAsset, sourceChainAssetAmount])
 
   const setAmountToSwap = useCallback(
     (targetAmount: BaseAmount) => {
@@ -543,18 +543,18 @@ export const Swap = ({
     )
   }, [closePasswordModal, oSwapParams, subscribeSwapState, swap$])
 
-  const sourceChainBalanceError: boolean = useMemo(
+  const sourceChainError: boolean = useMemo(
     () =>
       FP.pipe(
         chainFeesRD,
         RD.getOrElse(() => ({ source: ZERO_BASE_AMOUNT, target: ZERO_BASE_AMOUNT })),
-        ({ source }) => sourceChainAssetBalance.amount().minus(source.amount()).isNegative()
+        ({ source }) => sourceChainAssetAmount.amount().minus(source.amount()).isNegative()
       ),
-    [chainFeesRD, sourceChainAssetBalance]
+    [chainFeesRD, sourceChainAssetAmount]
   )
 
   const sourceChainErrorLabel: JSX.Element = useMemo(() => {
-    if (!sourceChainBalanceError) {
+    if (!sourceChainError) {
       return <></>
     }
 
@@ -581,7 +581,7 @@ export const Swap = ({
       )),
       O.getOrElse(() => <></>)
     )
-  }, [sourceChainBalanceError, chainFeesRD, intl, sourceAssetProp, sourceAssetAmount, sourceChainAsset])
+  }, [sourceChainError, chainFeesRD, intl, sourceAssetProp, sourceAssetAmount, sourceChainAsset])
 
   const targetChainFeeAmountInTargetAsset: BaseAmount = useMemo(() => {
     const fees = FP.pipe(
@@ -716,7 +716,7 @@ export const Swap = ({
               onChange={setAmountToSwap}
               onBlur={reloadFeesHandler}
               amount={amountToSwap}
-              hasError={sourceChainBalanceError || targetChainFeeError}
+              hasError={sourceChainError || targetChainFeeError}
             />
             {FP.pipe(
               sourceAsset,

--- a/src/renderer/components/uielements/assets/assetInput/AssetInput.tsx
+++ b/src/renderer/components/uielements/assets/assetInput/AssetInput.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useCallback } from 'react'
 
 import { assetAmount, assetToBase, BaseAmount, baseToAsset } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import * as FP from 'fp-ts/lib/function'
 
 import { FixmeType } from '../../../../types/asgardex'
 import { InputBigNumber } from '../../input'
@@ -15,6 +16,7 @@ type Props = {
   label: string
   inputProps?: AssetInputProps
   onChange: (value: BaseAmount) => void
+  onBlur?: FP.Lazy<void>
   className?: string
 }
 
@@ -27,7 +29,17 @@ type Props = {
  * Decimal of `InputBigNumber` depends on `decimal` of given `amount`.
  */
 export const AssetInput: React.FC<Props> = (props): JSX.Element => {
-  const { title, amount, status, label, inputProps = {}, className = '', onChange, ...otherProps } = props
+  const {
+    title,
+    amount,
+    status,
+    label,
+    inputProps = {},
+    className = '',
+    onChange,
+    onBlur: onBlurHandler = FP.constVoid,
+    ...otherProps
+  } = props
 
   const inputRef = useRef<FixmeType>()
 
@@ -53,6 +65,7 @@ export const AssetInput: React.FC<Props> = (props): JSX.Element => {
         <InputBigNumber
           value={baseToAsset(amount).amount()}
           onChange={onChangeHandler}
+          onBlur={onBlurHandler}
           size={'large'}
           {...inputProps}
           decimal={amount.decimal}

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.style.ts
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.style.ts
@@ -22,6 +22,7 @@ export const AssetSelectMenuWrapper = styled.div<{ minWidth?: number }>`
 `
 
 export const DropdownIcon = styled(CaretDownOutlined)`
+  cursor: ${({ disabled = false }) => (disabled ? 'not-allowed' : 'pointer')};
   transition: transform 0.2s ease-in-out;
   ${({ open }) => (open ? 'transform: rotate(180deg);' : 'transform: rotate(0);')}
   font-size: 18px;
@@ -29,6 +30,7 @@ export const DropdownIcon = styled(CaretDownOutlined)`
   svg {
     font-size: 22px;
     color: ${palette('primary', 0)};
+    opacity: ${({ disabled = false }) => (disabled ? 0.5 : 1)};
   }
 `
 
@@ -38,13 +40,13 @@ export const DropdownIconHolder = styled.div`
 `
 
 export const AssetDropdownButton = styled.button`
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   ${({ disabled }) => css`
     display: flex;
     flex-direction: row;
     align-items: center;
     background: transparent;
     border: none;
-    cursor: pointer;
     padding: 0;
     &:focus {
       outline: none;

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.tsx
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react'
 
 import { delay, Asset, assetToString } from '@xchainjs/xchain-util'
 import { Dropdown } from 'antd'
+import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../../../shared/api/types'
@@ -19,14 +20,15 @@ import { AssetSelectData } from './AssetSelectData'
 
 type DropdownCarretProps = {
   open: boolean
-  onClick?: () => void
+  onClick?: FP.Lazy<void>
+  disabled?: boolean
 }
 
 const DropdownCarret: React.FC<DropdownCarretProps> = (props: DropdownCarretProps): JSX.Element => {
-  const { open, onClick = () => {} } = props
+  const { open, onClick = FP.constVoid, disabled = false } = props
   return (
     <DropdownIconHolder>
-      <DropdownIcon open={open} onClick={onClick} />
+      <DropdownIcon open={open} onClick={onClick} disabled={disabled} />
     </DropdownIconHolder>
   )
 }
@@ -41,6 +43,7 @@ type Props = {
   className?: string
   minWidth?: number
   showAssetName?: boolean
+  disabled?: boolean
   network: Network
 }
 
@@ -56,6 +59,7 @@ export const AssetSelect: React.FC<Props> = (props): JSX.Element => {
     className,
     minWidth,
     showAssetName,
+    disabled = false,
     network
   } = props
 
@@ -106,10 +110,10 @@ export const AssetSelect: React.FC<Props> = (props): JSX.Element => {
   }, [assets, intl, asset, closeMenu, handleChangeAsset, priceIndex, searchDisable, withSearch, minWidth, network])
 
   const renderDropDownButton = () => {
-    const disabled = assets.length === 0
+    const hideButton = assets.length === 0
     return (
-      <AssetDropdownButton disabled={disabled} onClick={handleDropdownButtonClicked}>
-        {!disabled ? <DropdownCarret open={openDropdown} /> : null}
+      <AssetDropdownButton disabled={hideButton || disabled} onClick={handleDropdownButtonClicked}>
+        {!hideButton ? <DropdownCarret open={openDropdown} disabled={disabled} /> : null}
       </AssetDropdownButton>
     )
   }


### PR DESCRIPTION
- [x] Reload fees: 
    - After changing slider
    - After changing input value
    - After switching assets
- [x] Store previous source/target - needed to reload fees while changing   
- [x] New helper: `sourceAssetAmount`, `sourceChainAsset`, `sourceChainAssetAmount`, `maxAmountToSwap`
- [x] "Reset" values after switching target / source assets
- [x] Add `pendingSwitchAssets` state to avoid race conditions of balances + fees while switching assets (see #1037)
- [x] Provide default `maxAmountToSwap` for not logged in users to play around with swap
- [x] Add `onBlurHandler` to `AssetInput`

All other changes just movements of existing code in `Swap`