### PR TITLE
CHAIN tag for pools

### DIFF
--- a/src/renderer/components/uielements/assets/assetData/AssetData.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.tsx
@@ -55,7 +55,9 @@ export const AssetData: React.FC<Props> = (props): JSX.Element => {
       )}
       {!noTicker && (
         <Col>
-          <Styled.TickerLabel size={size}>{asset.ticker}</Styled.TickerLabel>
+          <Styled.TickerLabel className="ticker" size={size}>
+            {asset.ticker}
+          </Styled.TickerLabel>
           <Styled.TickerLabel className="small" size={size}>
             {asset.chain}
           </Styled.TickerLabel>

--- a/src/renderer/components/uielements/assets/assetData/AssetData.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.tsx
@@ -26,6 +26,7 @@ export type Props = {
   // `className` is needed by `styled components`
   className?: string
   network: Network
+  noIcon?: boolean
 }
 
 export const AssetData: React.FC<Props> = (props): JSX.Element => {
@@ -37,7 +38,8 @@ export const AssetData: React.FC<Props> = (props): JSX.Element => {
     priceAsset,
     size = 'small',
     className,
-    network
+    network,
+    noIcon
   } = props
 
   const priceLabel = priceAsset
@@ -46,9 +48,11 @@ export const AssetData: React.FC<Props> = (props): JSX.Element => {
 
   return (
     <Styled.Wrapper className={className}>
-      <Col>
-        <Styled.AssetIcon asset={asset} size={size} network={network} />
-      </Col>
+      {!noIcon && (
+        <Col>
+          <Styled.AssetIcon asset={asset} size={size} network={network} />
+        </Col>
+      )}
       {!noTicker && (
         <Col>
           <Styled.TickerLabel size={size}>{asset.ticker}</Styled.TickerLabel>

--- a/src/renderer/views/pools/PoolsOverview.shared.tsx
+++ b/src/renderer/views/pools/PoolsOverview.shared.tsx
@@ -1,7 +1,7 @@
 import { Asset, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import { ColumnType } from 'antd/lib/table'
-import * as FP from 'fp-ts/lib/function'
+import * as FP from 'fp-ts/function'
 
 import { ErrorView } from '../../components/shared/error'
 import { AssetIcon } from '../../components/uielements/assets/assetIcon'
@@ -11,8 +11,8 @@ import { sortByDepth } from '../../helpers/poolHelper'
 import { PoolTableRowData } from './Pools.types'
 import * as Styled from './PoolsOverview.style'
 
-const renderAssetColumn = ({ pool }: PoolTableRowData) => (
-  <Styled.Label align="center">{pool.target.ticker}</Styled.Label>
+const renderAssetColumn = ({ pool, network }: PoolTableRowData) => (
+  <Styled.AssetData noIcon asset={pool.target} network={network} />
 )
 
 const sortAssetColumn = ({ pool: poolA }: PoolTableRowData, { pool: poolB }: PoolTableRowData) =>

--- a/src/renderer/views/pools/PoolsOverview.style.tsx
+++ b/src/renderer/views/pools/PoolsOverview.style.tsx
@@ -2,6 +2,7 @@ import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
+import { AssetData as AssetDataUI } from '../../components/uielements/assets/assetData'
 import { Button as UIButton, ButtonProps as UIButtonProps } from '../../components/uielements/button'
 import { Label as UILabel } from '../../components/uielements/label'
 import { media } from '../../helpers/styleHelper'
@@ -59,4 +60,9 @@ export const BlockLeftLabel = styled(UILabel)`
 
 export const Label = styled(UILabel)`
   font-size: 16px;
+`
+export const AssetData = styled(AssetDataUI)`
+  & .ticker {
+    font-size: 16px;
+  }
 `


### PR DESCRIPTION
- added noIcon prop for AssetData component
- replaced `Styled.Label` with `AssetData` component for `PoolsOverview.shared`

closes #1059 
as a part of #1015 