### PR TITLE
Deposit: Update fee handling using `estimateCall`

### DIFF
--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -680,6 +680,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
 
   const reloadFeesCheck = useCallback(() => {
     if (!isEthChain(asset.chain)) {
+      prevAsset.current = O.some(asset)
       reloadFeesHandler()
     } else {
       FP.pipe(

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -678,6 +678,25 @@ export const SymDeposit: React.FC<Props> = (props) => {
     )
   }, [asset, isApprovedERC20Token$, needApprovement, oPoolRouter, subscribeIsApprovedState])
 
+  const reloadFeesCheck = useCallback(() => {
+    if (!isEthChain(asset.chain)) {
+      reloadFeesHandler()
+    } else {
+      FP.pipe(
+        oPoolRouter,
+        O.map((router) => {
+          // ETH requires router to be set
+          if (router) {
+            prevAsset.current = O.some(asset)
+            reloadFeesHandler()
+            return true
+          }
+          return false
+        })
+      )
+    }
+  }, [asset, oPoolRouter, reloadFeesHandler])
+
   useEffect(() => {
     if (prevPoolRouter.current !== oPoolRouter) {
       prevPoolRouter.current = oPoolRouter
@@ -690,18 +709,17 @@ export const SymDeposit: React.FC<Props> = (props) => {
     }
 
     if (!eqOAsset.equals(prevAsset.current, O.some(asset))) {
-      if (asset.chain === 'ETH') {
-        const router = FP.pipe(oPoolRouter, O.toUndefined)
-        if (router) {
-          prevAsset.current = O.some(asset)
-          reloadFeesHandler()
-        }
-      } else {
-        prevAsset.current = O.some(asset)
-        reloadFeesHandler()
-      }
+      reloadFeesCheck()
     }
-  }, [asset, checkApprovedStatus, oPoolRouter, reloadFeesHandler, resetApproveState, resetIsApprovedState])
+  }, [
+    asset,
+    checkApprovedStatus,
+    oPoolRouter,
+    reloadFeesCheck,
+    reloadFeesHandler,
+    resetApproveState,
+    resetIsApprovedState
+  ])
 
   return (
     <Styled.Container>

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -147,9 +147,10 @@ export const SymDeposit: React.FC<Props> = (props) => {
       amount: assetAmountToDeposit,
       memos: oMemo,
       recipient: oPoolAddress,
+      router: oPoolRouter,
       type: 'sym'
     }),
-    [asset, assetAmountToDeposit, oMemo, oPoolAddress]
+    [asset, assetAmountToDeposit, oMemo, oPoolRouter, oPoolAddress]
   )
 
   const [depositFeesRD] = useObservableState<DepositFeesRD>(() => chainFees$(depositFeesParams), RD.initial)

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -17,7 +17,8 @@ import {
   eqChain,
   eqOChain,
   eqPoolShares,
-  eqPoolShare
+  eqPoolShare,
+  eqONullableString
 } from './eq'
 
 describe('helpers/fp/eq', () => {
@@ -150,6 +151,20 @@ describe('helpers/fp/eq', () => {
       }
       expect(eqBalance.equals(a, b)).toBeFalsy()
       expect(eqBalance.equals(a, c)).toBeFalsy()
+    })
+  })
+
+  describe('eqONullableString', () => {
+    it('is equal', () => {
+      expect(eqONullableString.equals(O.some('MEMO'), O.some('MEMO'))).toBeTruthy()
+    })
+    it('is not equal', () => {
+      expect(eqONullableString.equals(O.none, O.some('MEMO'))).toBeFalsy()
+      expect(eqONullableString.equals(O.some('MEMO'), O.none)).toBeFalsy()
+      expect(eqONullableString.equals(O.some('MEMO'), undefined)).toBeFalsy()
+      expect(eqONullableString.equals(undefined, O.some('MEMO'))).toBeFalsy()
+      expect(eqONullableString.equals(undefined, O.none)).toBeFalsy()
+      expect(eqONullableString.equals(O.none, undefined)).toBeFalsy()
     })
   })
 

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -1,5 +1,14 @@
 import { Balance } from '@xchainjs/xchain-client'
-import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn, Chain } from '@xchainjs/xchain-util'
+import {
+  AssetBNB,
+  AssetBTC,
+  AssetETH,
+  AssetRuneERC20,
+  AssetRuneNative,
+  baseAmount,
+  bn,
+  Chain
+} from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
@@ -180,6 +189,27 @@ describe('helpers/fp/eq', () => {
         asset: AssetBNB
       }
       expect(eqBalance.equals(a, a)).toBeTruthy()
+    })
+    it('is not equal', () => {
+      const a: SymDepositFeesParams = {
+        memos: O.none,
+        recipient: O.none,
+        type: 'sym',
+        amount: baseAmount('1'),
+        asset: AssetETH
+      }
+      // b = same as a, but another amount
+      const b: SymDepositFeesParams = {
+        ...a,
+        asset: AssetRuneERC20
+      }
+      // c = same as a, but another asset
+      const c: SymDepositFeesParams = {
+        ...a,
+        asset: AssetRuneNative
+      }
+      expect(eqBalance.equals(a, b)).toBeFalsy()
+      expect(eqBalance.equals(a, c)).toBeFalsy()
     })
     it('is not equal', () => {
       const a: SymDepositFeesParams = {

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -157,6 +157,8 @@ describe('helpers/fp/eq', () => {
   describe('eqONullableString', () => {
     it('is equal', () => {
       expect(eqONullableString.equals(O.some('MEMO'), O.some('MEMO'))).toBeTruthy()
+      expect(eqONullableString.equals(O.none, O.none)).toBeTruthy()
+      expect(eqONullableString.equals(undefined, undefined)).toBeTruthy()
     })
     it('is not equal', () => {
       expect(eqONullableString.equals(O.none, O.some('MEMO'))).toBeFalsy()

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -10,6 +10,7 @@ import { DepositFeesParams } from '../../services/chain/types'
 import { PoolShare } from '../../services/midgard/types'
 import { ApiError } from '../../services/wallet/types'
 import { WalletBalance } from '../../types/wallet'
+import { isEthChain } from '../chainHelper'
 
 export const eqOString = O.getEq(Eq.eqString)
 
@@ -50,12 +51,15 @@ export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
 }
 
 export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
-  equals: (x, y) =>
+  equals: (x, y) => {
     // Check if entered chain was changed
-    eqAsset.equals(x.asset, y.asset) &&
-    // Check if entered amount was changed
-    eqBaseAmount.equals(x.amount, y.amount) &&
-    eqONullableString.equals(x.router, y.router)
+    return (
+      eqChain.equals(x.asset.chain, y.asset.chain) &&
+      (!isEthChain(x.asset.chain) || eqAsset.equals(x.asset, y.asset)) &&
+      eqBaseAmount.equals(x.amount, y.amount) &&
+      eqONullableString.equals(x.router, y.router)
+    )
+  }
 }
 
 export const eqErrorId = Eq.eqString

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -53,6 +53,9 @@ export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
 export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
   equals: (x, y) => {
     // Check if entered chain was changed
+    // Check if entered amount was changed
+    // Check if router was changed
+    // For ETH chain, need to check if asset was changed (ETH assets have different fees)
     return (
       eqChain.equals(x.asset.chain, y.asset.chain) &&
       (!isEthChain(x.asset.chain) || eqAsset.equals(x.asset, y.asset)) &&

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -52,7 +52,7 @@ export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
 export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
   equals: (x, y) =>
     // Check if entered chain was changed
-    eqChain.equals(x.asset.chain, y.asset.chain) &&
+    eqAsset.equals(x.asset, y.asset) &&
     // Check if entered amount was changed
     eqBaseAmount.equals(x.amount, y.amount) &&
     eqONullableString.equals(x.router, y.router)

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -40,12 +40,22 @@ export const eqBalance: Eq.Eq<Balance> = {
   equals: (x, y) => eqAsset.equals(x.asset, y.asset) && eqBaseAmount.equals(x.amount, y.amount)
 }
 
+export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
+  equals: (x, y) => {
+    if (x && y) {
+      return eqOString.equals(x, y)
+    }
+    return x === y
+  }
+}
+
 export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
   equals: (x, y) =>
     // Check if entered chain was changed
     eqChain.equals(x.asset.chain, y.asset.chain) &&
     // Check if entered amount was changed
-    eqBaseAmount.equals(x.amount, y.amount)
+    eqBaseAmount.equals(x.amount, y.amount) &&
+    eqONullableString.equals(x.router, y.router)
 }
 
 export const eqErrorId = Eq.eqString

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -1,5 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
+import { ETHAddress } from '@xchainjs/xchain-ethereum'
 import {
   Asset,
   AssetRuneNative,
@@ -14,11 +15,14 @@ import {
   PolkadotChain,
   THORChain
 } from '@xchainjs/xchain-util'
+import { ethers } from 'ethers'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
+import { getEthChecksumAddress } from '../../../helpers/addressHelper'
+import { getEthTokenAddress, isEthAsset } from '../../../helpers/assetHelper'
 import { eqDepositFeesParams } from '../../../helpers/fp/eq'
 import { sequenceSOption, sequenceTRDFromArray } from '../../../helpers/fpHelpers'
 import { liveData } from '../../../helpers/rx/liveData'
@@ -26,6 +30,7 @@ import { observableState } from '../../../helpers/stateHelper'
 import * as BNB from '../../binance'
 import * as BTC from '../../bitcoin'
 import * as BCH from '../../bitcoincash'
+import { ethRouterABI } from '../../const'
 import * as ETH from '../../ethereum'
 import * as LTC from '../../litecoin'
 import { selectedPoolChain$ } from '../../midgard/common'
@@ -62,17 +67,28 @@ const { get$: reloadDepositFees$, set: reloadDepositFees } = observableState<Dep
 type DepositByChainParams = {
   asset: Asset
   recipient?: O.Option<Address>
+  router?: O.Option<Address>
   amount?: O.Option<BaseAmount>
   memo?: O.Option<Memo>
 }
 
 const depositFeeByChain$ = ({
-  asset: { chain },
+  asset,
   recipient = O.none,
   amount = O.none,
-  memo = O.none
+  memo = O.none,
+  router = O.none
 }: DepositByChainParams): FeeLD => {
-  switch (chain) {
+  console.log(
+    JSON.stringify({
+      asset,
+      recipient,
+      amount,
+      memo,
+      router
+    })
+  )
+  switch (asset.chain) {
     case BNBChain:
       return BNB.fees$().pipe(liveData.map(({ fast }) => fast))
     case BTCChain: {
@@ -92,11 +108,31 @@ const depositFeeByChain$ = ({
     }
     case ETHChain: {
       return FP.pipe(
-        sequenceSOption({ recipient, amount, memo }),
+        sequenceSOption({ recipient, router, amount, memo }),
         O.fold(
           () => Rx.of(RD.initial),
-          ({ recipient, amount, memo }) =>
-            ETH.fees$({ recipient, amount, memo }).pipe(liveData.map((fees) => fees.fast))
+          ({ recipient, router, amount, memo }) =>
+            ETH.callFees$(
+              router,
+              ethRouterABI,
+              'deposit',
+              isEthAsset(asset)
+                ? [
+                    FP.pipe(getEthChecksumAddress(recipient), O.toUndefined),
+                    ETHAddress,
+                    0,
+                    memo,
+                    {
+                      value: amount.amount().toFixed()
+                    }
+                  ]
+                : [
+                    ethers.utils.getAddress(recipient.toLowerCase()),
+                    FP.pipe(getEthTokenAddress(asset), O.toUndefined),
+                    amount.amount().toFixed(),
+                    memo
+                  ]
+            ).pipe(liveData.map((fees) => fees.fast))
         )
       )
     }
@@ -154,7 +190,8 @@ const depositFees$ = (initialParams: DepositFeesParams): DepositFeesLD =>
                   amount: O.some(params.amount),
                   memo: params.memo,
                   asset: params.asset,
-                  recipient: params.recipient
+                  recipient: params.recipient,
+                  router: params.router
                 })
               ]
             : // for sym deposits, two txs at thorchain an asset chain needed == 2 fees,
@@ -166,7 +203,8 @@ const depositFees$ = (initialParams: DepositFeesParams): DepositFeesLD =>
                     O.map(({ asset }) => asset)
                   ),
                   asset: params.asset,
-                  recipient: params.recipient
+                  recipient: params.recipient,
+                  router: params.router
                 }),
                 depositFeeByChain$({
                   asset: AssetRuneNative,

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -15,7 +15,6 @@ import {
   PolkadotChain,
   THORChain
 } from '@xchainjs/xchain-util'
-import { ethers } from 'ethers'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
@@ -79,15 +78,6 @@ const depositFeeByChain$ = ({
   memo = O.none,
   router = O.none
 }: DepositByChainParams): FeeLD => {
-  console.log(
-    JSON.stringify({
-      asset,
-      recipient,
-      amount,
-      memo,
-      router
-    })
-  )
   switch (asset.chain) {
     case BNBChain:
       return BNB.fees$().pipe(liveData.map(({ fast }) => fast))
@@ -127,7 +117,7 @@ const depositFeeByChain$ = ({
                     }
                   ]
                 : [
-                    ethers.utils.getAddress(recipient.toLowerCase()),
+                    FP.pipe(getEthChecksumAddress(recipient), O.toUndefined),
                     FP.pipe(getEthTokenAddress(asset), O.toUndefined),
                     amount.amount().toFixed(),
                     memo

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -51,6 +51,7 @@ export type AsymDepositFeesParams = {
   readonly amount: BaseAmount
   readonly memo: O.Option<Memo>
   readonly recipient?: O.Option<Address>
+  readonly router?: O.Option<Address>
   readonly type: 'asym'
 }
 
@@ -59,6 +60,7 @@ export type SymDepositFeesParams = {
   readonly amount: BaseAmount
   readonly memos: O.Option<SymDepositMemo>
   readonly recipient?: O.Option<Address>
+  readonly router?: O.Option<Address>
   readonly type: 'sym'
 }
 


### PR DESCRIPTION
close #1069 

Here is how we handle deposit fees.
- watch router, asset change.
- reload fees once asset changed (for ETH, we need to check router)
- update deposit fee params equal-check (the fees will be different for ETH and ERC20)
- calc ETH/ERC20 deposit fee using `router.deposit` (use estimateCall of xchain-etheruem)