### PR TITLE
Improve data handling for `PoolAssetDetail`s

### DIFF
--- a/src/renderer/components/currency/CurrencyInfo.tsx
+++ b/src/renderer/components/currency/CurrencyInfo.tsx
@@ -6,12 +6,12 @@ import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/pipeable'
 
 import { sequenceTOption } from '../../helpers/fpHelpers'
-import { AssetWithPrice } from '../../services/binance/types'
+import { PoolAssetDetail } from '../../services/midgard/types'
 import * as Styled from './CurrencyInfo.styles'
 
 type CurrencyInfoProps = {
-  from?: O.Option<AssetWithPrice>
-  to?: O.Option<AssetWithPrice>
+  from?: O.Option<PoolAssetDetail>
+  to?: O.Option<PoolAssetDetail>
   slip?: BigNumber
 }
 
@@ -30,7 +30,7 @@ export const CurrencyInfo = ({ to = O.none, from = O.none, slip = bn(0) }: Curre
             ={' '}
             {formatAssetAmountCurrency({
               asset: to.asset,
-              amount: assetAmount(from.priceRune.dividedBy(to.priceRune)),
+              amount: assetAmount(from.assetPrice.dividedBy(to.assetPrice)),
               trimZeros: true
             })}
           </div>
@@ -43,7 +43,7 @@ export const CurrencyInfo = ({ to = O.none, from = O.none, slip = bn(0) }: Curre
             ={' '}
             {formatAssetAmountCurrency({
               asset: from.asset,
-              amount: assetAmount(to.priceRune.dividedBy(from.priceRune)),
+              amount: assetAmount(to.assetPrice.dividedBy(from.assetPrice)),
               trimZeros: true
             })}
           </div>

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -17,8 +17,8 @@ import { Swap, SwapProps } from './Swap'
 const defaultProps: SwapProps = {
   keystore: O.none,
   availableAssets: [
-    { asset: AssetBTC, priceRune: bn('56851.67420275761') },
-    { asset: AssetRuneNative, priceRune: ONE_BN }
+    { asset: AssetBTC, assetPrice: bn('56851.67420275761') },
+    { asset: AssetRuneNative, assetPrice: ONE_BN }
   ],
   sourceAsset: AssetRuneNative,
   targetAsset: AssetBTC,

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -35,7 +35,6 @@ import { LiveData } from '../../helpers/rx/liveData'
 import { getWalletBalanceByAsset } from '../../helpers/walletHelper'
 import { useSubscriptionState } from '../../hooks/useSubscriptionState'
 import { swap } from '../../routes/swap'
-import { AssetsWithPrice, AssetWithPrice } from '../../services/binance/types'
 import { INITIAL_SWAP_STATE } from '../../services/chain/const'
 import {
   SwapState,
@@ -48,6 +47,7 @@ import {
   SwapFeesLD
 } from '../../services/chain/types'
 import { ApproveParams, IsApprovedRD } from '../../services/ethereum/types'
+import { PoolAssetDetail, PoolAssetDetails } from '../../services/midgard/types'
 import { PoolDetails } from '../../services/midgard/types'
 import { getPoolDetailsHashMap } from '../../services/midgard/utils'
 import {
@@ -67,13 +67,13 @@ import { ViewTxButton } from '../uielements/button'
 import { Fees, UIFeesRD } from '../uielements/fees'
 import { Slider } from '../uielements/slider'
 import * as Styled from './Swap.styles'
-import { getSwapData, assetWithPriceToAsset, pickAssetWithPrice, convertToBase8 } from './Swap.utils'
+import { getSwapData, poolAssetDetailToAsset, pickPoolAsset, convertToBase8 } from './Swap.utils'
 
 export type ConfirmSwapParams = { asset: Asset; amount: BaseAmount; memo: string }
 
 export type SwapProps = {
   keystore: KeystoreState
-  availableAssets: AssetsWithPrice
+  availableAssets: PoolAssetDetails
   sourceAsset: Asset
   targetAsset: Asset
   sourcePoolAddress: O.Option<string>
@@ -125,18 +125,18 @@ export const Swap = ({
     poolDetails
   ])
 
-  const oSourceAssetWP: O.Option<AssetWithPrice> = useMemo(() => pickAssetWithPrice(availableAssets, sourceAssetProp), [
+  const oSourcePoolAsset: O.Option<PoolAssetDetail> = useMemo(() => pickPoolAsset(availableAssets, sourceAssetProp), [
     availableAssets,
     sourceAssetProp
   ])
 
-  const oTargetAssetWP: O.Option<AssetWithPrice> = useMemo(() => pickAssetWithPrice(availableAssets, targetAssetProp), [
+  const oTargetPoolAsset: O.Option<PoolAssetDetail> = useMemo(() => pickPoolAsset(availableAssets, targetAssetProp), [
     availableAssets,
     targetAssetProp
   ])
 
-  const sourceAsset: O.Option<Asset> = useMemo(() => assetWithPriceToAsset(oSourceAssetWP), [oSourceAssetWP])
-  const targetAsset: O.Option<Asset> = useMemo(() => assetWithPriceToAsset(oTargetAssetWP), [oTargetAssetWP])
+  const sourceAsset: O.Option<Asset> = useMemo(() => poolAssetDetailToAsset(oSourcePoolAsset), [oSourcePoolAsset])
+  const targetAsset: O.Option<Asset> = useMemo(() => poolAssetDetailToAsset(oTargetPoolAsset), [oTargetPoolAsset])
 
   const assetsToSwap: O.Option<{ source: Asset; target: Asset }> = useMemo(
     () => sequenceSOption({ source: sourceAsset, target: targetAsset }),
@@ -452,7 +452,7 @@ export const Swap = ({
 
   const extraTxModalContent = useMemo(() => {
     return FP.pipe(
-      sequenceTOption(oSourceAssetWP, oTargetAssetWP),
+      sequenceTOption(oSourcePoolAsset, oTargetPoolAsset),
       O.map(([sourceAssetWP, targetAssetWP]) => {
         const targetAsset = targetAssetWP.asset
         const sourceAsset = sourceAssetWP.asset
@@ -490,8 +490,8 @@ export const Swap = ({
       O.getOrElse(() => <></>)
     )
   }, [
-    oSourceAssetWP,
-    oTargetAssetWP,
+    oSourcePoolAsset,
+    oTargetPoolAsset,
     swapData.swapResult,
     swapData.slip,
     amountToSwap,
@@ -873,7 +873,7 @@ export const Swap = ({
 
         <Styled.FormContainer>
           <Styled.CurrencyInfoContainer>
-            <CurrencyInfo slip={swapData.slip} from={oSourceAssetWP} to={oTargetAssetWP} />
+            <CurrencyInfo slip={swapData.slip} from={oSourcePoolAsset} to={oTargetPoolAsset} />
           </Styled.CurrencyInfoContainer>
 
           <Styled.ValueItemContainer className={'valueItemContainer-out'}>

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -14,7 +14,15 @@ import * as O from 'fp-ts/lib/Option'
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { ZERO_BASE_AMOUNT } from '../../const'
 import { eqBaseAmount } from '../../helpers/fp/eq'
-import { DEFAULT_SWAP_DATA, isRuneSwap, getSlip, getSwapResult, getSwapData, pickAssetWithPrice } from './Swap.utils'
+import {
+  DEFAULT_SWAP_DATA,
+  isRuneSwap,
+  getSlip,
+  getSwapResult,
+  getSwapData,
+  pickPoolAsset,
+  poolAssetDetailToAsset
+} from './Swap.utils'
 
 describe('components/swap/utils', () => {
   describe('isRuneSwap', () => {
@@ -146,33 +154,44 @@ describe('components/swap/utils', () => {
     })
   })
 
-  describe('pickAssetWithPrice', () => {
+  describe('pickPoolAsset', () => {
     it('should be none', () => {
-      expect(pickAssetWithPrice([], AssetBNB)).toBeNone()
+      expect(pickPoolAsset([], AssetBNB)).toBeNone()
     })
     it('should return first element if nothing found', () => {
       expect(
-        pickAssetWithPrice(
+        pickPoolAsset(
           [
-            { asset: AssetRuneNative, priceRune: bn(0) },
-            { asset: AssetBNB, priceRune: bn(1) }
+            { asset: AssetRuneNative, assetPrice: bn(0) },
+            { asset: AssetBNB, assetPrice: bn(1) }
           ],
           ASSETS_TESTNET.FTM
         )
-      ).toEqual(O.some({ asset: AssetRuneNative, priceRune: bn(0) }))
+      ).toEqual(O.some({ asset: AssetRuneNative, assetPrice: bn(0) }))
     })
 
     it('should pick asset', () => {
       expect(
-        pickAssetWithPrice(
+        pickPoolAsset(
           [
-            { asset: AssetRuneNative, priceRune: bn(0) },
-            { asset: AssetBNB, priceRune: bn(1) },
-            { asset: AssetETH, priceRune: bn(2) }
+            { asset: AssetRuneNative, assetPrice: bn(0) },
+            { asset: AssetBNB, assetPrice: bn(1) },
+            { asset: AssetETH, assetPrice: bn(2) }
           ],
           AssetETH
         )
-      ).toEqual(O.some({ asset: AssetETH, priceRune: bn(2) }))
+      ).toEqual(O.some({ asset: AssetETH, assetPrice: bn(2) }))
+    })
+  })
+
+  describe('poolAssetToAsset', () => {
+    it('returns none', () => {
+      expect(poolAssetDetailToAsset(O.none)).toBeNone()
+    })
+    it('returns AssetRuneNative', () => {
+      expect(poolAssetDetailToAsset(O.some({ asset: AssetRuneNative, assetPrice: bn(0) }))).toEqual(
+        O.some(AssetRuneNative)
+      )
     })
   })
 })

--- a/src/renderer/services/binance/types.ts
+++ b/src/renderer/services/binance/types.ts
@@ -2,7 +2,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Transfer, Client } from '@xchainjs/xchain-binance'
 import { Address } from '@xchainjs/xchain-binance'
 import { Asset, AssetAmount, BaseAmount } from '@xchainjs/xchain-util'
-import BigNumber from 'bignumber.js'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
@@ -15,13 +14,6 @@ export type Client$ = C.Client$<Client>
 
 export type ClientState = C.ClientState<Client>
 export type ClientState$ = C.ClientState$<Client>
-
-export type AssetWithPrice = {
-  asset: Asset
-  priceRune: BigNumber
-}
-
-export type AssetsWithPrice = AssetWithPrice[]
 
 export type TransferRD = RD.RemoteData<Error, Transfer>
 

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -27,19 +27,13 @@ export type PoolAssets = Asset[]
 export type PoolAssetsRD = RD.RemoteData<Error, PoolAssets>
 export type PoolAssetsLD = LiveData<Error, PoolAssets>
 
-export type AssetDetail = {
-  asset: string
-  dateCreated: number
-  priceRune: string
+export type PoolAssetDetail = {
+  asset: Asset
+  assetPrice: BigNumber
 }
 
-export type AssetDetails = AssetDetail[]
-export type AssetDetailsRD = RD.RemoteData<Error, AssetDetails>
-export type AssetDetailsLD = LiveData<Error, AssetDetails>
-
-export type AssetDetailMap = {
-  [key in Chain]: AssetDetail
-}
+export type PoolAssetDetails = PoolAssetDetail[]
+export type PoolAssetDetailsLD = LiveData<Error, PoolAssetDetails>
 
 export type PoolDetail = MidgardPoolDetail & {
   poolSlipAverage: string
@@ -57,7 +51,7 @@ export type PriceDataIndex = {
 }
 
 export type PoolsState = {
-  assetDetails: AssetDetails
+  assetDetails: PoolAssetDetails
   poolAssets: PoolAssets
   poolDetails: PoolDetails
   pricePools: O.Option<PricePools>
@@ -66,7 +60,7 @@ export type PoolsStateRD = RD.RemoteData<Error, PoolsState>
 export type PoolsStateLD = LiveData<Error, PoolsState>
 
 export type PendingPoolsState = {
-  assetDetails: AssetDetails
+  assetDetails: PoolAssetDetails
   poolAssets: PoolAssets
   poolDetails: PoolDetails
 }


### PR DESCRIPTION

To avoid re-parsing asset strings provided by Midgard in different places again and again, this PR fixes it to do it only once in `services/midgard/pools`. Change is needed to simplify Swap state handling (more with another PR).

Changes:

- [x] Introduce `PoolAssetDetail` to get rid of `AssetWithPrice` 
- [x] Rename `AssetDetail` -> `PoolAssetDetail` etc.
- [x] Introduce `getPoolAssetDetail` + `getPoolAssetsDetail` (incl. test)