### PR TITLE
Hardcode ETH/ERC20 swap fee

### DIFF
--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -9,6 +9,7 @@ import {
   baseAmount,
   AssetRuneNative
 } from '@xchainjs/xchain-util'
+import { BigNumber } from 'ethers'
 
 import { PricePoolCurrencyWeights, PricePoolAssets } from './views/pools/Pools.types'
 
@@ -41,6 +42,9 @@ export const ZERO_ASSET_AMOUNT = assetAmount(ZERO_BN)
 export const ZERO_BASE_AMOUNT = baseAmount(ZERO_BN)
 
 export const ZERO_POOL_DATA: PoolData = { runeBalance: ZERO_BASE_AMOUNT, assetBalance: ZERO_BASE_AMOUNT }
+
+export const ETH_OUT_TX_GAS_LIMIT = BigNumber.from('35609')
+export const ERC20_OUT_TX_GAS_LIMIT = BigNumber.from('49610')
 
 export const AssetUSDTERC20: Asset = {
   chain: 'ETH',

--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -9,7 +9,6 @@ import {
   baseAmount,
   AssetRuneNative
 } from '@xchainjs/xchain-util'
-import { BigNumber } from 'ethers'
 
 import { PricePoolCurrencyWeights, PricePoolAssets } from './views/pools/Pools.types'
 
@@ -42,9 +41,6 @@ export const ZERO_ASSET_AMOUNT = assetAmount(ZERO_BN)
 export const ZERO_BASE_AMOUNT = baseAmount(ZERO_BN)
 
 export const ZERO_POOL_DATA: PoolData = { runeBalance: ZERO_BASE_AMOUNT, assetBalance: ZERO_BASE_AMOUNT }
-
-export const ETH_OUT_TX_GAS_LIMIT = BigNumber.from('35609')
-export const ERC20_OUT_TX_GAS_LIMIT = BigNumber.from('49610')
 
 export const AssetUSDTERC20: Asset = {
   chain: 'ETH',

--- a/src/renderer/services/chain/fees/swap.ts
+++ b/src/renderer/services/chain/fees/swap.ts
@@ -86,12 +86,7 @@ const swapFeeByChain$ = ({
                     memo
                   ]
             )
-          : ETH.fees$({
-              asset,
-              amount,
-              recipient,
-              memo
-            }),
+          : ETH.outTxFee$(asset),
         liveData.map((fees) => fees[FEE_OPTION_KEY])
       )
     }

--- a/src/renderer/services/chain/fees/swap.ts
+++ b/src/renderer/services/chain/fees/swap.ts
@@ -65,11 +65,11 @@ const swapFeeByChain$ = ({
     case ETHChain: {
       return FP.pipe(
         type === 'source' && router
-          ? ETH.callFees$(
-              router,
-              ethRouterABI,
-              'deposit',
-              isEthAsset(asset)
+          ? ETH.callFees$({
+              address: router,
+              abi: ethRouterABI,
+              func: 'deposit',
+              params: isEthAsset(asset)
                 ? [
                     ethers.utils.getAddress(recipient.toLowerCase()),
                     ETHAddress,
@@ -85,7 +85,7 @@ const swapFeeByChain$ = ({
                     amount.amount().toFixed(),
                     memo
                   ]
-            )
+            })
           : ETH.outTxFee$(asset),
         liveData.map((fees) => fees[FEE_OPTION_KEY])
       )

--- a/src/renderer/services/ethereum/fees.ts
+++ b/src/renderer/services/ethereum/fees.ts
@@ -1,6 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Fees } from '@xchainjs/xchain-client'
-import { Address, getFee, getDefaultFees } from '@xchainjs/xchain-ethereum'
+import { getFee, getDefaultFees, FeesParams } from '@xchainjs/xchain-ethereum'
 import { Asset, Chain } from '@xchainjs/xchain-util'
 import { ethers } from 'ethers'
 import * as FP from 'fp-ts/lib/function'
@@ -8,73 +8,75 @@ import * as O from 'fp-ts/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT } from '../../const'
 import { isEthAsset } from '../../helpers/assetHelper'
 import * as C from '../clients'
-import { client$ } from './common'
-import { FeesService, Client$ } from './types'
+import { FeesService, Client$, CallFeeParams } from './types'
 
-export const createFeesService: ({ client$, chain }: { client$: Client$; chain: Chain }) => FeesService =
-  C.createFeesService
+export const ETH_OUT_TX_GAS_LIMIT = ethers.BigNumber.from('35609')
+export const ERC20_OUT_TX_GAS_LIMIT = ethers.BigNumber.from('49610')
 
-export const callFees$ = (
-  address: Address,
-  abi: ethers.ContractInterface,
-  func: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: Array<any>
-): C.FeesLD =>
-  Rx.combineLatest([client$]).pipe(
-    RxOp.switchMap(([oClient]) =>
-      FP.pipe(
-        oClient,
-        O.fold(
-          () => Rx.EMPTY,
-          (client) =>
-            Rx.combineLatest([client.estimateCall(address, abi, func, params), client.estimateGasPrices()]).pipe(
-              RxOp.map(
-                ([gasLimit, gasPrices]) =>
-                  ({
-                    type: 'byte',
-                    average: getFee({ gasPrice: gasPrices.average, gasLimit }),
-                    fast: getFee({ gasPrice: gasPrices.fast, gasLimit }),
-                    fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit })
-                  } as Fees)
+export const createFeesService = ({ client$, chain }: { client$: Client$; chain: Chain }): FeesService => {
+  const common = C.createFeesService<FeesParams>({ client$, chain })
+
+  const callFees$ = ({ address, abi, func, params }: CallFeeParams): C.FeesLD =>
+    client$.pipe(
+      RxOp.switchMap((oClient) =>
+        FP.pipe(
+          oClient,
+          O.fold(
+            () => Rx.EMPTY,
+            (client) =>
+              Rx.combineLatest([client.estimateCall(address, abi, func, params), client.estimateGasPrices()]).pipe(
+                RxOp.map(
+                  ([gasLimit, gasPrices]) =>
+                    ({
+                      type: 'byte',
+                      average: getFee({ gasPrice: gasPrices.average, gasLimit }),
+                      fast: getFee({ gasPrice: gasPrices.fast, gasLimit }),
+                      fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit })
+                    } as Fees)
+                )
               )
-            )
+          )
         )
-      )
-    ),
-    RxOp.map(RD.success),
-    RxOp.catchError((_) => Rx.of(RD.success(getDefaultFees()))),
-    RxOp.startWith(RD.pending)
-  )
+      ),
+      RxOp.map(RD.success),
+      RxOp.catchError((_) => Rx.of(RD.success(getDefaultFees()))),
+      RxOp.startWith(RD.pending)
+    )
 
-export const outTxFee$ = (asset: Asset): C.FeesLD =>
-  Rx.combineLatest([client$]).pipe(
-    RxOp.switchMap(([oClient]) =>
-      FP.pipe(
-        oClient,
-        O.fold(
-          () => Rx.EMPTY,
-          (client) => {
-            const gasLimit = isEthAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-            return Rx.from(client.estimateGasPrices()).pipe(
-              RxOp.map(
-                (gasPrices) =>
-                  ({
-                    type: 'byte',
-                    average: getFee({ gasPrice: gasPrices.average, gasLimit }),
-                    fast: getFee({ gasPrice: gasPrices.fast, gasLimit }),
-                    fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit })
-                  } as Fees)
+  const outTxFee$ = (asset: Asset): C.FeesLD =>
+    client$.pipe(
+      RxOp.switchMap((oClient) =>
+        FP.pipe(
+          oClient,
+          O.fold(
+            () => Rx.EMPTY,
+            (client) => {
+              const gasLimit = isEthAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
+              return Rx.from(client.estimateGasPrices()).pipe(
+                RxOp.map(
+                  (gasPrices) =>
+                    ({
+                      type: 'byte',
+                      average: getFee({ gasPrice: gasPrices.average, gasLimit }),
+                      fast: getFee({ gasPrice: gasPrices.fast, gasLimit }),
+                      fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit })
+                    } as Fees)
+                )
               )
-            )
-          }
+            }
+          )
         )
-      )
-    ),
-    RxOp.map(RD.success),
-    RxOp.catchError((_) => Rx.of(RD.success(getDefaultFees()))),
-    RxOp.startWith(RD.pending)
-  )
+      ),
+      RxOp.map(RD.success),
+      RxOp.catchError((_) => Rx.of(RD.success(getDefaultFees()))),
+      RxOp.startWith(RD.pending)
+    )
+
+  return {
+    ...common,
+    callFees$,
+    outTxFee$
+  }
+}

--- a/src/renderer/services/ethereum/index.ts
+++ b/src/renderer/services/ethereum/index.ts
@@ -10,7 +10,7 @@ import {
   getExplorerTxUrl$,
   getExplorerAddressUrl$
 } from './common'
-import { createFeesService, callFees$ } from './fees'
+import { createFeesService, callFees$, outTxFee$ } from './fees'
 import { createTransactionService } from './transaction'
 
 const {
@@ -48,6 +48,7 @@ export {
   fees$,
   sendDepositTx$,
   callFees$,
+  outTxFee$,
   approveERC20Token$,
   isApprovedERC20Token$
 }

--- a/src/renderer/services/ethereum/index.ts
+++ b/src/renderer/services/ethereum/index.ts
@@ -10,7 +10,7 @@ import {
   getExplorerTxUrl$,
   getExplorerAddressUrl$
 } from './common'
-import { createFeesService, callFees$, outTxFee$ } from './fees'
+import { createFeesService } from './fees'
 import { createTransactionService } from './transaction'
 
 const {
@@ -25,7 +25,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$)
-const { reloadFees, fees$ } = createFeesService({ client$, chain: ETHChain })
+const { reloadFees, fees$, callFees$, outTxFee$ } = createFeesService({ client$, chain: ETHChain })
 
 export {
   client$,

--- a/src/renderer/services/ethereum/types.ts
+++ b/src/renderer/services/ethereum/types.ts
@@ -2,7 +2,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { FeeOptionKey } from '@xchainjs/xchain-client'
 import { Address, Client, FeesParams, FeesWithGasPricesAndLimits } from '@xchainjs/xchain-ethereum'
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
-import { BigNumber } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 
 import { LiveData } from '../../helpers/rx/liveData'
 import { Memo } from '../chain/types'
@@ -42,6 +42,14 @@ export type DepositParams = {
   memo: Memo
 }
 
+export type CallFeeParams = {
+  address: Address
+  abi: ethers.ContractInterface
+  func: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Array<any>
+}
+
 export type IsApprovedRD = RD.RemoteData<ApiError, boolean>
 export type IsApprovedLD = LiveData<ApiError, boolean>
 
@@ -51,4 +59,7 @@ export type TransactionService = {
   isApprovedERC20Token$: (params: ApproveParams) => LiveData<ApiError, boolean>
 } & C.TransactionService<SendTxParams>
 
-export type FeesService = C.FeesService<FeesParams>
+export type FeesService = {
+  callFees$: (params: CallFeeParams) => C.FeesLD
+  outTxFee$: (asset: Asset) => C.FeesLD
+} & C.FeesService<FeesParams>


### PR DESCRIPTION
Here are swap out-tx transactions: 

For ETH
https://ropsten.etherscan.io/tx/0xd74d4e784695c20cb4cb4322dc7961293a8ad653a91a76043e7a14834f9a4207
https://ropsten.etherscan.io/tx/0xfc3c352960a55ca5c53d9e325a5149588b68aac23c4185f96d305a1f2ab79498

For ERC20
https://ropsten.etherscan.io/tx/0xf1d6bbdc5e864c05825d2c241b28227fb71746e9769f5aeec76bfd2c59334273
https://ropsten.etherscan.io/tx/0x8a86f22f8e57d8e50b97fa9926dd4f8cb885986eb771a58b247d42ec8da4949d
https://ropsten.etherscan.io/tx/0x3ce8702154be66bd22b263c3162f49502a4b7869510fcbcef691466dcfd7caa7

We hardcode Gas limit as following and calculate fee as (gasPrice * gasLimit)
- Gas limit for ETH is 35609
- Gas limit for ERC20 is 49610