### PR TITLE
Fix sym. deposit (part 1)

### DIFF
--- a/src/renderer/components/deposit/add/Deposit.helper.test.ts
+++ b/src/renderer/components/deposit/add/Deposit.helper.test.ts
@@ -28,20 +28,20 @@ describe('deposit/Deposit.helper', () => {
       const runeBalance = baseAmount(50)
       const assetBalance = baseAmount(100)
       const result = maxRuneAmountToDeposit({ poolData, assetBalance, runeBalance })
+
       expect(eqBaseAmount.equals(result, baseAmount(50))).toBeTruthy()
     })
   })
 
   describe('maxAssetAmountToDeposit', () => {
-    it('is 50', () => {
+    it('is 200', () => {
       const result = maxAssetAmountToDeposit({ poolData, assetBalance, runeBalance })
-      expect(eqBaseAmount.equals(result, baseAmount(50))).toBeTruthy()
+      expect(eqBaseAmount.equals(result, baseAmount(200))).toBeTruthy()
     })
     it('is 100', () => {
       const runeBalance = baseAmount(200)
       const assetBalance = baseAmount(100)
       const result = maxAssetAmountToDeposit({ poolData, assetBalance, runeBalance })
-
       expect(eqBaseAmount.equals(result, baseAmount(100))).toBeTruthy()
     })
   })

--- a/src/renderer/components/deposit/add/Deposit.helper.ts
+++ b/src/renderer/components/deposit/add/Deposit.helper.ts
@@ -36,7 +36,7 @@ export const maxAssetAmountToDeposit = ({
     .dividedBy(poolRuneBalance.amount())
     .multipliedBy(runeBalance.amount())
 
-  return assetBalance.amount().isGreaterThan(maxAssetAmountBN)
+  return assetBalance.amount().isGreaterThanOrEqualTo(maxAssetAmountBN)
     ? assetBalance
     : baseAmount(maxAssetAmountBN, assetBalance.decimal)
 }

--- a/src/renderer/components/deposit/add/Deposit.helper.ts
+++ b/src/renderer/components/deposit/add/Deposit.helper.ts
@@ -31,11 +31,14 @@ export const maxAssetAmountToDeposit = ({
   assetBalance: BaseAmount
 }): BaseAmount => {
   const { runeBalance: poolRuneBalance, assetBalance: poolAssetBalance } = poolData
-  const maxAssetAmount: BigNumber = poolAssetBalance
+  const maxAssetAmountBN: BigNumber = poolAssetBalance
     .amount()
     .dividedBy(poolRuneBalance.amount())
     .multipliedBy(runeBalance.amount())
-  return maxAssetAmount.isGreaterThan(assetBalance.amount()) ? assetBalance : baseAmount(maxAssetAmount)
+
+  return assetBalance.amount().isGreaterThan(maxAssetAmountBN)
+    ? assetBalance
+    : baseAmount(maxAssetAmountBN, assetBalance.decimal)
 }
 
 export const getRuneAmountToDeposit = (
@@ -55,5 +58,5 @@ export const getAssetAmountToDeposit = (
   baseAmount(
     // formula: runeAmount * poolRuneBalance / poolAssetBalance
     runeAmount.amount().times(poolAssetBalance.amount().dividedBy(poolRuneBalance.amount())),
-    THORCHAIN_DECIMAL
+    poolAssetBalance.decimal
   )

--- a/src/renderer/components/deposit/add/SymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.stories.tsx
@@ -46,7 +46,7 @@ const defaultProps: SymDepositProps = {
   priceAsset: AssetRuneNative,
   assets: [AssetBNB, AssetBTC, ASSETS_MAINNET.TOMO],
   poolAddress: O.none,
-  memo: O.some({ rune: 'rune-memo', asset: 'asset-memo' }),
+  memos: O.some({ rune: 'rune-memo', asset: 'asset-memo' }),
   reloadBalances: () => console.log('reloadBalances'),
   viewAssetTx: (txHash) => {
     console.log(txHash)

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -233,10 +233,6 @@ export const Swap = ({
     () =>
       FP.pipe(
         oSwapFeesParams,
-        (x) => {
-          console.log('chainFeesRD', x)
-          return x
-        },
         O.map(chainFees$),
         O.getOrElse<SwapFeesLD>(() => Rx.of(RD.initial))
       ),

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -201,8 +201,8 @@ export const Swap = ({
   const oSwapFeesParams: O.Option<SwapFeesParams> = useMemo(
     () =>
       FP.pipe(
-        sequenceTOption(oSwapParams),
-        O.map(([swapParams]) => ({
+        oSwapParams,
+        O.map((swapParams) => ({
           inTx: swapParams,
           outTx: {
             asset: targetAssetProp,
@@ -233,6 +233,10 @@ export const Swap = ({
     () =>
       FP.pipe(
         oSwapFeesParams,
+        (x) => {
+          console.log('chainFeesRD', x)
+          return x
+        },
         O.map(chainFees$),
         O.getOrElse<SwapFeesLD>(() => Rx.of(RD.initial))
       ),

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -3,8 +3,10 @@ import React, { createContext, useContext } from 'react'
 import {
   addressByChain$,
   clientByChain$,
-  depositFees$,
-  reloadDepositFees,
+  symDepositFees$,
+  reloadSymDepositFees,
+  asymDepositFee$,
+  reloadAsymDepositFee,
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,
@@ -29,8 +31,10 @@ import {
 type ChainContextValue = {
   addressByChain$: typeof addressByChain$
   clientByChain$: typeof clientByChain$
-  depositFees$: typeof depositFees$
-  reloadDepositFees: typeof reloadDepositFees
+  symDepositFees$: typeof symDepositFees$
+  reloadSymDepositFees: typeof reloadSymDepositFees
+  asymDepositFee$: typeof asymDepositFee$
+  reloadAsymDepositFee: typeof reloadAsymDepositFee
   withdrawFee$: typeof withdrawFee$
   reloadWithdrawFees: typeof reloadWithdrawFee
   symDepositTxMemo$: typeof symDepositTxMemo$
@@ -55,8 +59,10 @@ type ChainContextValue = {
 const initialContext: ChainContextValue = {
   addressByChain$,
   clientByChain$,
-  depositFees$,
-  reloadDepositFees,
+  symDepositFees$,
+  reloadSymDepositFees,
+  asymDepositFee$,
+  reloadAsymDepositFee,
   withdrawFee$,
   reloadWithdrawFees: reloadWithdrawFee,
   symDepositTxMemo$,

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -170,61 +170,6 @@ describe('helpers/fp/eq', () => {
     })
   })
 
-  // describe('eqDepositFeesParams', () => {
-  //   it('is equal', () => {
-  //     const a: SymDepositFeesParams = {
-  //       memos: O.none,
-  //       recipient: O.none,
-  //       type: 'sym',
-  //       amount: baseAmount('1'),
-  //       asset: AssetBNB
-  //     }
-  //     expect(eqBalance.equals(a, a)).toBeTruthy()
-  //   })
-  //   it('is not equal', () => {
-  //     const a: SymDepositFeesParams = {
-  //       memos: O.none,
-  //       recipient: O.none,
-  //       type: 'sym',
-  //       amount: baseAmount('1'),
-  //       asset: AssetETH
-  //     }
-  //     // b = same as a, but another amount
-  //     const b: SymDepositFeesParams = {
-  //       ...a,
-  //       asset: AssetRuneERC20
-  //     }
-  //     // c = same as a, but another asset
-  //     const c: SymDepositFeesParams = {
-  //       ...a,
-  //       asset: AssetRuneNative
-  //     }
-  //     expect(eqBalance.equals(a, b)).toBeFalsy()
-  //     expect(eqBalance.equals(a, c)).toBeFalsy()
-  //   })
-  //   it('is not equal', () => {
-  //     const a: SymDepositFeesParams = {
-  //       memos: O.none,
-  //       recipient: O.none,
-  //       type: 'sym',
-  //       amount: baseAmount('1'),
-  //       asset: AssetBNB
-  //     }
-  //     // b = same as a, but another amount
-  //     const b: SymDepositFeesParams = {
-  //       ...a,
-  //       amount: baseAmount('2')
-  //     }
-  //     // c = same as a, but another asset
-  //     const c: SymDepositFeesParams = {
-  //       ...a,
-  //       asset: AssetRuneNative
-  //     }
-  //     expect(eqBalance.equals(a, b)).toBeFalsy()
-  //     expect(eqBalance.equals(a, c)).toBeFalsy()
-  //   })
-  // })
-
   describe('eqAssetsWithBalance', () => {
     const a: Balance = {
       amount: baseAmount('1'),

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -1,18 +1,8 @@
 import { Balance } from '@xchainjs/xchain-client'
-import {
-  AssetBNB,
-  AssetBTC,
-  AssetETH,
-  AssetRuneERC20,
-  AssetRuneNative,
-  baseAmount,
-  bn,
-  Chain
-} from '@xchainjs/xchain-util'
+import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn, Chain } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
-import { SymDepositFeesParams } from '../../services/chain/types'
 import { PoolAddress, PoolShare } from '../../services/midgard/types'
 import { ApiError, ErrorId } from '../../services/wallet/types'
 import {
@@ -180,60 +170,60 @@ describe('helpers/fp/eq', () => {
     })
   })
 
-  describe('eqDepositFeesParams', () => {
-    it('is equal', () => {
-      const a: SymDepositFeesParams = {
-        memos: O.none,
-        recipient: O.none,
-        type: 'sym',
-        amount: baseAmount('1'),
-        asset: AssetBNB
-      }
-      expect(eqBalance.equals(a, a)).toBeTruthy()
-    })
-    it('is not equal', () => {
-      const a: SymDepositFeesParams = {
-        memos: O.none,
-        recipient: O.none,
-        type: 'sym',
-        amount: baseAmount('1'),
-        asset: AssetETH
-      }
-      // b = same as a, but another amount
-      const b: SymDepositFeesParams = {
-        ...a,
-        asset: AssetRuneERC20
-      }
-      // c = same as a, but another asset
-      const c: SymDepositFeesParams = {
-        ...a,
-        asset: AssetRuneNative
-      }
-      expect(eqBalance.equals(a, b)).toBeFalsy()
-      expect(eqBalance.equals(a, c)).toBeFalsy()
-    })
-    it('is not equal', () => {
-      const a: SymDepositFeesParams = {
-        memos: O.none,
-        recipient: O.none,
-        type: 'sym',
-        amount: baseAmount('1'),
-        asset: AssetBNB
-      }
-      // b = same as a, but another amount
-      const b: SymDepositFeesParams = {
-        ...a,
-        amount: baseAmount('2')
-      }
-      // c = same as a, but another asset
-      const c: SymDepositFeesParams = {
-        ...a,
-        asset: AssetRuneNative
-      }
-      expect(eqBalance.equals(a, b)).toBeFalsy()
-      expect(eqBalance.equals(a, c)).toBeFalsy()
-    })
-  })
+  // describe('eqDepositFeesParams', () => {
+  //   it('is equal', () => {
+  //     const a: SymDepositFeesParams = {
+  //       memos: O.none,
+  //       recipient: O.none,
+  //       type: 'sym',
+  //       amount: baseAmount('1'),
+  //       asset: AssetBNB
+  //     }
+  //     expect(eqBalance.equals(a, a)).toBeTruthy()
+  //   })
+  //   it('is not equal', () => {
+  //     const a: SymDepositFeesParams = {
+  //       memos: O.none,
+  //       recipient: O.none,
+  //       type: 'sym',
+  //       amount: baseAmount('1'),
+  //       asset: AssetETH
+  //     }
+  //     // b = same as a, but another amount
+  //     const b: SymDepositFeesParams = {
+  //       ...a,
+  //       asset: AssetRuneERC20
+  //     }
+  //     // c = same as a, but another asset
+  //     const c: SymDepositFeesParams = {
+  //       ...a,
+  //       asset: AssetRuneNative
+  //     }
+  //     expect(eqBalance.equals(a, b)).toBeFalsy()
+  //     expect(eqBalance.equals(a, c)).toBeFalsy()
+  //   })
+  //   it('is not equal', () => {
+  //     const a: SymDepositFeesParams = {
+  //       memos: O.none,
+  //       recipient: O.none,
+  //       type: 'sym',
+  //       amount: baseAmount('1'),
+  //       asset: AssetBNB
+  //     }
+  //     // b = same as a, but another amount
+  //     const b: SymDepositFeesParams = {
+  //       ...a,
+  //       amount: baseAmount('2')
+  //     }
+  //     // c = same as a, but another asset
+  //     const c: SymDepositFeesParams = {
+  //       ...a,
+  //       asset: AssetRuneNative
+  //     }
+  //     expect(eqBalance.equals(a, b)).toBeFalsy()
+  //     expect(eqBalance.equals(a, c)).toBeFalsy()
+  //   })
+  // })
 
   describe('eqAssetsWithBalance', () => {
     const a: Balance = {

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -48,21 +48,6 @@ export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
   }
 }
 
-// export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
-//   equals: (x, y) => {
-//     // Check if entered chain was changed
-//     // Check if entered amount was changed
-//     // Check if router was changed
-//     // For ETH chain, need to check if asset was changed (ETH assets have different fees)
-//     return (
-//       eqChain.equals(x.asset.chain, y.asset.chain) &&
-//       (!isEthChain(x.asset.chain) || eqAsset.equals(x.asset, y.asset)) &&
-//       eqBaseAmount.equals(x.amount, y.amount) &&
-//       eqONullableString.equals(x.router, y.router)
-//     )
-//   }
-// }
-
 export const eqErrorId = Eq.eqString
 
 export const eqApiError = Eq.getStructEq<ApiError>({

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -6,11 +6,9 @@ import * as A from 'fp-ts/lib/Array'
 import * as Eq from 'fp-ts/lib/Eq'
 import * as O from 'fp-ts/lib/Option'
 
-import { DepositFeesParams } from '../../services/chain/types'
 import { PoolAddress, PoolShare } from '../../services/midgard/types'
 import { ApiError } from '../../services/wallet/types'
 import { WalletBalance } from '../../types/wallet'
-import { isEthChain } from '../chainHelper'
 
 export const eqOString = O.getEq(Eq.eqString)
 
@@ -50,20 +48,20 @@ export const eqONullableString: Eq.Eq<O.Option<string> | undefined> = {
   }
 }
 
-export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
-  equals: (x, y) => {
-    // Check if entered chain was changed
-    // Check if entered amount was changed
-    // Check if router was changed
-    // For ETH chain, need to check if asset was changed (ETH assets have different fees)
-    return (
-      eqChain.equals(x.asset.chain, y.asset.chain) &&
-      (!isEthChain(x.asset.chain) || eqAsset.equals(x.asset, y.asset)) &&
-      eqBaseAmount.equals(x.amount, y.amount) &&
-      eqONullableString.equals(x.router, y.router)
-    )
-  }
-}
+// export const eqDepositFeesParams: Eq.Eq<DepositFeesParams> = {
+//   equals: (x, y) => {
+//     // Check if entered chain was changed
+//     // Check if entered amount was changed
+//     // Check if router was changed
+//     // For ETH chain, need to check if asset was changed (ETH assets have different fees)
+//     return (
+//       eqChain.equals(x.asset.chain, y.asset.chain) &&
+//       (!isEthChain(x.asset.chain) || eqAsset.equals(x.asset, y.asset)) &&
+//       eqBaseAmount.equals(x.amount, y.amount) &&
+//       eqONullableString.equals(x.router, y.router)
+//     )
+//   }
+// }
 
 export const eqErrorId = Eq.eqString
 

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -1,5 +1,4 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { Address } from '@xchainjs/xchain-client'
 import { ETHAddress } from '@xchainjs/xchain-ethereum'
 import {
   Asset,
@@ -8,7 +7,6 @@ import {
   BCHChain,
   BNBChain,
   BTCChain,
-  Chain,
   CosmosChain,
   ETHChain,
   LTCChain,
@@ -20,10 +18,8 @@ import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { getEthChecksumAddress } from '../../../helpers/addressHelper'
 import { getEthTokenAddress, isEthAsset } from '../../../helpers/assetHelper'
-import { eqDepositFeesParams } from '../../../helpers/fp/eq'
-import { sequenceSOption, sequenceTRDFromArray } from '../../../helpers/fpHelpers'
+import { sequenceTRDFromArray } from '../../../helpers/fpHelpers'
 import { liveData } from '../../../helpers/rx/liveData'
 import { observableState } from '../../../helpers/stateHelper'
 import * as BNB from '../../binance'
@@ -32,66 +28,27 @@ import * as BCH from '../../bitcoincash'
 import { ethRouterABI } from '../../const'
 import * as ETH from '../../ethereum'
 import * as LTC from '../../litecoin'
-import { selectedPoolChain$ } from '../../midgard/common'
+import { PoolAddress } from '../../midgard/types'
 import * as THOR from '../../thorchain'
 import { FeeOptionKeys } from '../const'
-import { FeeLD, LoadFeesHandler, DepositFeesParams, DepositFeesLD, Memo } from '../types'
+import { FeeLD, DepositFeesLD, Memo, SymDepositParams, AsymDepositParams } from '../types'
 
-const reloadFeesByChain = (chain: Chain) => {
-  switch (chain) {
-    case BNBChain:
-      return BNB.reloadFees
-    case BTCChain:
-      return BTC.reloadFees
-    case BCHChain:
-      return BCH.reloadFees
-    case ETHChain:
-      // reload ETH balances - not available yet
-      return () => {}
-    case THORChain:
-      return THOR.reloadFees
-    case LTCChain:
-      return LTC.reloadFees
-    default:
-      return () => {}
-  }
-}
-
-export const reloadFees$: Rx.Observable<O.Option<LoadFeesHandler>> = selectedPoolChain$.pipe(
-  RxOp.map(O.map(reloadFeesByChain))
-)
-
-// State to reload deposit fees
-const { get$: reloadDepositFees$, set: reloadDepositFees } = observableState<DepositFeesParams | undefined>(undefined)
-
-type DepositByChainParams = {
-  asset: Asset
-  recipient?: O.Option<Address>
-  router?: O.Option<Address>
-  amount?: O.Option<BaseAmount>
-  memo?: O.Option<Memo>
-}
-
-const depositFeeByChain$ = ({
+const depositFee$ = ({
   asset,
-  recipient = O.none,
-  amount = O.none,
-  memo = O.none,
-  router = O.none
-}: DepositByChainParams): FeeLD => {
+  poolAddress: oPoolAddress,
+  amount,
+  memo
+}: {
+  readonly poolAddress: O.Option<PoolAddress>
+  readonly asset: Asset
+  readonly amount: BaseAmount
+  readonly memo: Memo
+}): FeeLD => {
   switch (asset.chain) {
     case BNBChain:
       return BNB.fees$().pipe(liveData.map(({ fast }) => fast))
     case BTCChain: {
-      // deposit fee for BTC txs based on a memo,
-      // and memo depends on deposit type
-      return FP.pipe(
-        memo,
-        O.fold(
-          () => Rx.of(RD.initial),
-          (memo) => BTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
-        )
-      )
+      return BTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
     }
 
     case THORChain: {
@@ -99,17 +56,19 @@ const depositFeeByChain$ = ({
     }
     case ETHChain: {
       return FP.pipe(
-        sequenceSOption({ recipient, router, amount, memo }),
+        oPoolAddress,
+        O.chain(({ router }) => router),
         O.fold(
-          () => Rx.of(RD.initial),
-          ({ recipient, router, amount, memo }) =>
-            ETH.poolInTxFees$({
+          () => Rx.of(RD.failure(Error('ETH router address is missing'))),
+          (router) => {
+            const routerAddress = router.toLowerCase()
+            return ETH.poolInTxFees$({
               address: router,
               abi: ethRouterABI,
               func: 'deposit',
               params: isEthAsset(asset)
                 ? [
-                    FP.pipe(getEthChecksumAddress(recipient), O.toUndefined),
+                    routerAddress,
                     ETHAddress,
                     0,
                     memo,
@@ -117,14 +76,11 @@ const depositFeeByChain$ = ({
                       value: amount.amount().toFixed()
                     }
                   ]
-                : [
-                    FP.pipe(getEthChecksumAddress(recipient), O.toUndefined),
-                    FP.pipe(getEthTokenAddress(asset), O.toUndefined),
-                    amount.amount().toFixed(),
-                    memo
-                  ]
-            }).pipe(liveData.map((fees) => fees[FeeOptionKeys.DEPOSIT]))
-        )
+                : [routerAddress, FP.pipe(getEthTokenAddress(asset), O.toUndefined), amount.amount().toFixed(), memo]
+            })
+          }
+        ),
+        liveData.map((fees) => fees[FeeOptionKeys.DEPOSIT])
       )
     }
     case CosmosChain:
@@ -132,87 +88,60 @@ const depositFeeByChain$ = ({
     case PolkadotChain:
       return Rx.of(RD.failure(Error('Deposit fee for Polkadot has not been implemented')))
     case BCHChain: {
-      // deposit fee for BCH txs based on a memo,
-      // and memo depends on deposit type
-      return FP.pipe(
-        memo,
-        O.fold(
-          () => Rx.of(RD.initial),
-          (memo) => BCH.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
-        )
-      )
+      return BCH.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
     }
     case LTCChain: {
-      // deposit fee for LTC txs based on a memo,
-      // and memo depends on deposit type
-      return FP.pipe(
-        memo,
-        O.fold(
-          () => Rx.of(RD.initial),
-          (memo) => LTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
-        )
-      )
+      return LTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
     }
   }
 }
 
-const depositFees$ = (initialParams: DepositFeesParams): DepositFeesLD =>
-  FP.pipe(
-    reloadDepositFees$,
+// State to reload sym deposit fees
+const { get$: reloadSymDepositFees$, set: reloadSymDepositFees } = observableState<SymDepositParams | undefined>(
+  undefined
+)
+
+const symDepositFees$ = (params: SymDepositParams): DepositFeesLD => {
+  return FP.pipe(
+    reloadSymDepositFees$,
     RxOp.debounceTime(300),
-    RxOp.distinctUntilChanged((prev, next) => {
-      if (prev && next) {
-        /**
-         * Pass values only in cases when:
-         * 1 - chain was changed
-         * 2 - Amount to deposit was changed. Some chains' fess depends on amount too (e.g. ETH)
-         */
-        return eqDepositFeesParams.equals(prev, next)
-      }
-      return false
-    }),
-    RxOp.switchMap((params = initialParams) =>
-      FP.pipe(
-        Rx.combineLatest(
-          params.type === 'asym'
-            ? // for asym deposits, one tx needed at asset chain only == one fee)
-              [
-                depositFeeByChain$({
-                  amount: O.some(params.amount),
-                  memo: params.memo,
-                  asset: params.asset,
-                  recipient: params.recipient,
-                  router: params.router
-                })
-              ]
-            : // for sym deposits, two txs at thorchain an asset chain needed == 2 fees,
-              [
-                depositFeeByChain$({
-                  amount: O.some(params.amount),
-                  memo: FP.pipe(
-                    params.memos,
-                    O.map(({ asset }) => asset)
-                  ),
-                  asset: params.asset,
-                  recipient: params.recipient,
-                  router: params.router
-                }),
-                depositFeeByChain$({
-                  asset: AssetRuneNative,
-                  memo: FP.pipe(
-                    params.memos,
-                    O.map(({ rune }) => rune)
-                  )
-                })
-              ]
-        ),
+    RxOp.switchMap((reloadParams) => {
+      const { amounts, poolAddress, asset, memos } = reloadParams || params
+      return FP.pipe(
+        Rx.combineLatest([
+          // asset
+          depositFee$({
+            asset,
+            amount: amounts.asset,
+            poolAddress: O.some(poolAddress),
+            memo: memos.asset
+          }),
+          // rune
+          depositFee$({
+            asset: AssetRuneNative,
+            amount: amounts.rune,
+            memo: memos.rune,
+            poolAddress: O.none
+          })
+        ]),
         RxOp.map(sequenceTRDFromArray),
         liveData.map(([asset, thor]) => ({
           asset,
           thor: O.fromNullable(thor)
         }))
       )
-    )
+    })
+  )
+}
+// State to reload sym deposit fees
+const { get$: reloadAsymDepositFee$, set: reloadAsymDepositFee } = observableState<AsymDepositParams | undefined>(
+  undefined
+)
+const asymDepositFee$ = (_: AsymDepositParams): DepositFeesLD =>
+  FP.pipe(
+    reloadAsymDepositFee$,
+    RxOp.debounceTime(300),
+    RxOp.map((_) => RD.failure(Error('not implemented yet')))
   )
 
-export { depositFees$, reloadDepositFees, depositFeeByChain$ }
+export { symDepositFees$, asymDepositFee$, reloadSymDepositFees, reloadAsymDepositFee }

--- a/src/renderer/services/chain/fees/swap.ts
+++ b/src/renderer/services/chain/fees/swap.ts
@@ -35,7 +35,7 @@ import { FeeLD, SwapFeesHandler, SwapFeesParams, SwapOutTx, SwapTxParams } from 
  * Fees for swap txs into a pool
  */
 const txInFee$ = ({ asset, poolAddress, memo, amount }: SwapTxParams): FeeLD => {
-  switch (poolAddress.chain) {
+  switch (asset.chain) {
     case BNBChain:
       return FP.pipe(
         BNB.fees$(),
@@ -166,7 +166,7 @@ const swapFees$: SwapFeesHandler = (params) => {
         // In case chains of source and target are the same, but no ETH
         // then we don't need to do another request
         // and can use same fee provided by `in$` stream to fees for OUT tx
-        () => eqChain.equals(inTx.poolAddress.chain, outTx.asset.chain) && !isEthChain(inTx.poolAddress.chain),
+        () => eqChain.equals(inTx.asset.chain, outTx.asset.chain) && !isEthChain(inTx.poolAddress.chain),
         in$,
         txOutFee$(outTx)
       ) // Result needs to be 3 times as "normal" fee

--- a/src/renderer/services/chain/index.ts
+++ b/src/renderer/services/chain/index.ts
@@ -1,7 +1,16 @@
 import { addressByChain$, assetAddress$ } from './address'
 import { clientByChain$ } from './client'
 import { getExplorerUrlByAsset$, getExplorerAddressByChain$ } from './explorerUrl'
-import { reloadDepositFees, depositFees$, withdrawFee$, reloadWithdrawFee, reloadSwapFees, swapFees$ } from './fees'
+import {
+  reloadSymDepositFees,
+  symDepositFees$,
+  reloadAsymDepositFee,
+  asymDepositFee$,
+  withdrawFee$,
+  reloadWithdrawFee,
+  reloadSwapFees,
+  swapFees$
+} from './fees'
 import { retrieveLedgerAddress, removeLedgerAddress, removeAllLedgerAddress } from './ledger'
 import { asymDepositTxMemo$, symDepositTxMemo$, getWithdrawMemo$ } from './memo'
 import { swap$, asymDeposit$, symDeposit$, upgradeBnbRune$, withdraw$, transfer$ } from './transaction'
@@ -12,8 +21,10 @@ import { swap$, asymDeposit$, symDeposit$, upgradeBnbRune$, withdraw$, transfer$
 export {
   addressByChain$,
   clientByChain$,
-  reloadDepositFees,
-  depositFees$,
+  reloadSymDepositFees,
+  symDepositFees$,
+  reloadAsymDepositFee,
+  asymDepositFee$,
   withdrawFee$,
   reloadWithdrawFee,
   symDepositTxMemo$,

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -112,7 +112,7 @@ export const sendPoolTx$ = ({
       })
 
     case THORChain:
-      return THOR.sendDepositTx({ amount, asset, memo })
+      return THOR.sendPoolTx$({ amount, asset, memo })
 
     default:
       return sendTx$({ asset, recipient, amount, memo, feeOptionKey })

--- a/src/renderer/services/chain/transaction/deposit.ts
+++ b/src/renderer/services/chain/transaction/deposit.ts
@@ -173,20 +173,19 @@ export const symDeposit$ = ({
   // to update `SymDepositState` step by step
   const requests$ = Rx.of(poolAddresses).pipe(
     // 1. Validation pool address + node
-    RxOp.switchMap((poolAddresses) => {
-      console.log(poolAddresses)
-      return liveData.sequenceS({
+    RxOp.switchMap((poolAddresses) =>
+      liveData.sequenceS({
         pool: midgardPoolsService.validatePool$(poolAddresses, asset.chain),
         node: validateNode$()
       })
-    }),
+    ),
     // 2. send RUNE deposit txs
     liveData.chain<ApiError, SymDepositValidationResult, TxHash>((_) => {
       setState({ ...getState(), step: 2, deposit: RD.progress({ loaded: 40, total }) })
       return sendPoolTx$({
-        router: poolAddresses.router,
+        router: O.none, // no router for RUNE
         asset: AssetRuneNative,
-        recipient: '',
+        recipient: '', // no recipient for RUNE needed
         amount: amounts.rune,
         memo: memos.rune,
         feeOptionKey: FeeOptionKeys.DEPOSIT

--- a/src/renderer/services/chain/transaction/swap.ts
+++ b/src/renderer/services/chain/transaction/swap.ts
@@ -54,9 +54,9 @@ export const swap$ = ({ poolAddress: poolAddresses, asset, amount, memo }: SwapT
       setState({ ...getState(), step: 2, swapTx: RD.pending, swap: RD.progress({ loaded: 50, total }) })
       // 2. send swap tx
       return sendPoolTx$({
-        router: poolAddresses.router,
+        router: poolAddresses.router, // emtpy string for RuneNative
         asset,
-        recipient: poolAddresses.address, // emtpy string for Native
+        recipient: poolAddresses.address, // emtpy string for RuneNative
         amount,
         memo,
         feeOptionKey: FeeOptionKeys.SWAP

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -37,8 +37,8 @@ export type SymDepositMemoRx = Rx.Observable<O.Option<SymDepositMemo>>
 
 /**
  * Deposit fees
- *
- * For deposits we do need one fee (asymmetrical deposit) or two fees (symmetrical deposit):
+
+ * One fee (asymmetrical deposit) or two fees (symmetrical deposit):
  *
  * thor: Fee for transaction on Thorchain. Needed for sym deposit txs. It's `O.none` for asym deposit txs
  * asset: Fee for transaction on asset chain
@@ -46,31 +46,22 @@ export type SymDepositMemoRx = Rx.Observable<O.Option<SymDepositMemo>>
 export type DepositFees = { thor: O.Option<BaseAmount>; asset: BaseAmount }
 export type DepositFeesRD = RD.RemoteData<Error, DepositFees>
 export type DepositFeesLD = LiveData<Error, DepositFees>
+
+export type AsymDepositParams = {
+  readonly poolAddress: PoolAddress
+  readonly asset: Asset
+  readonly amount: BaseAmount
+  readonly memo: string
+}
+
 export type SymDepositAmounts = { rune: BaseAmount; asset: BaseAmount }
 
-export type AsymDepositFeesParams = {
+export type SymDepositParams = {
+  readonly poolAddress: PoolAddress
   readonly asset: Asset
-  readonly amount: BaseAmount
-  readonly memo: O.Option<Memo>
-  readonly recipient?: O.Option<Address>
-  readonly router?: O.Option<Address>
-  readonly type: 'asym'
+  readonly amounts: SymDepositAmounts
+  readonly memos: SymDepositMemo
 }
-
-export type SymDepositFeesParams = {
-  readonly asset: Asset
-  readonly amount: BaseAmount
-  readonly memos: O.Option<SymDepositMemo>
-  readonly recipient?: O.Option<Address>
-  readonly router?: O.Option<Address>
-  readonly type: 'sym'
-}
-
-export type DepositFeesParams = AsymDepositFeesParams | SymDepositFeesParams
-
-export type DepositFeesHandler = (p: DepositFeesParams) => DepositFeesLD
-
-export type LoadDepositFeesHandler = (p: DepositFeesParams) => void
 
 export type SendDepositTxParams = { chain: Chain; asset: Asset; poolAddress: string; amount: BaseAmount; memo: Memo }
 
@@ -156,13 +147,6 @@ export type AsymDepositState = {
 
 export type AsymDepositState$ = Rx.Observable<AsymDepositState>
 
-export type AsymDepositParams = {
-  readonly poolAddress: PoolAddress
-  readonly asset: Asset
-  readonly amount: BaseAmount
-  readonly memo: string
-}
-
 export type AsymDepositStateHandler = (p: AsymDepositParams) => AsymDepositState$
 
 export type SymDepositValidationResult = { pool: boolean; node: boolean }
@@ -184,13 +168,6 @@ export type SymDepositState = {
 }
 
 export type SymDepositState$ = Rx.Observable<SymDepositState>
-
-export type SymDepositParams = {
-  readonly poolAddress: PoolAddress
-  readonly asset: Asset
-  readonly amounts: SymDepositAmounts
-  readonly memos: SymDepositMemo
-}
 
 export type SymDepositStateHandler = (p: SymDepositParams) => SymDepositState$
 

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -491,7 +491,16 @@ const createPoolsService = (
         eqOPoolAddresses.equals(oAddresses, O.some(poolAddresses))
           ? Rx.of(RD.success(true))
           : // TODO (@veado) Add i18n
-            Rx.of(RD.failure(Error(`Pool with address ${poolAddresses} is not available`)))
+            Rx.of(
+              RD.failure(
+                Error(
+                  `Pool address ${poolAddresses.address} and/or router address ${FP.pipe(
+                    poolAddresses.router,
+                    O.getOrElse(() => '')
+                  )} ) are not available`
+                )
+              )
+            )
       ),
       liveData.mapLeft((error) => ({
         errorId: ErrorId.VALIDATE_POOL,

--- a/src/renderer/services/thorchain/index.ts
+++ b/src/renderer/services/thorchain/index.ts
@@ -7,9 +7,9 @@ import { createInteractService$ } from './interact'
 import { getNodeInfo$, reloadNodesInfo } from './thorNode'
 import { createTransactionService } from './transaction'
 
-const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$, sendDepositTx } = createTransactionService(client$)
+const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$, sendPoolTx$ } = createTransactionService(client$)
 const { reloadFees, fees$ } = createFeesService({ client$, chain: THORChain })
-const interact$ = createInteractService$(sendDepositTx, txStatus$)
+const interact$ = createInteractService$(sendPoolTx$, txStatus$)
 
 export {
   address$,
@@ -29,7 +29,7 @@ export {
   txRD$,
   getExplorerTxUrl$,
   getExplorerAddressUrl$,
-  sendDepositTx,
+  sendPoolTx$,
   interact$,
   getNodeInfo$,
   reloadNodesInfo

--- a/src/renderer/services/thorchain/transaction.ts
+++ b/src/renderer/services/thorchain/transaction.ts
@@ -14,7 +14,7 @@ export const createTransactionService = (client$: Client$): TransactionService =
   /**
    * Sends a deposit request by given `DepositParam`
    */
-  const sendDepositTx = (params: DepositParam): TxHashLD =>
+  const sendPoolTx = (params: DepositParam): TxHashLD =>
     client$.pipe(
       RxOp.switchMap((oClient) => (O.isSome(oClient) ? Rx.of(oClient.value) : Rx.EMPTY)),
       RxOp.switchMap((client) => Rx.from(client.deposit(params))),
@@ -33,6 +33,6 @@ export const createTransactionService = (client$: Client$): TransactionService =
 
   return {
     ...common,
-    sendDepositTx
+    sendPoolTx$: sendPoolTx
   }
 }

--- a/src/renderer/services/thorchain/types.ts
+++ b/src/renderer/services/thorchain/types.ts
@@ -25,7 +25,7 @@ export type SendTxParams = {
 export type AddressValidation = Client['validateAddress']
 
 export type TransactionService = {
-  sendDepositTx: (params: DepositParam) => TxHashLD
+  sendPoolTx$: (params: DepositParam) => TxHashLD
 } & C.TransactionService<SendTxParams>
 
 export type InteractParams = {

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -53,9 +53,9 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
   } = useMidgardContext()
 
   const {
-    depositFees$,
+    asymDepositFee$,
     asymDeposit$,
-    reloadDepositFees,
+    reloadAsymDepositFee,
     asymDepositTxMemo$,
     getExplorerUrlByAsset$
   } = useChainContext()
@@ -139,7 +139,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
           assetPrice={ZERO_BN}
           assetBalance={O.none}
           chainAssetBalance={O.none}
-          fees$={depositFees$}
+          fees$={asymDepositFee$}
           reloadFees={FP.constVoid}
           priceAsset={selectedPricePoolAsset}
           disabled={true}
@@ -153,14 +153,14 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
       </>
     ),
     [
+      intl,
       validatePassword$,
       viewAssetTx,
       asset,
-      depositFees$,
+      asymDepositFee$,
       selectedPricePoolAsset,
       reloadBalances,
       asymDeposit$,
-      intl,
       network
     ]
   )
@@ -185,8 +185,8 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
               chainAssetBalance={chainAssetBalance}
               poolAddress={oPoolAddress}
               memo={memo}
-              fees$={depositFees$}
-              reloadFees={reloadDepositFees}
+              fees$={asymDepositFee$}
+              reloadFees={reloadAsymDepositFee}
               priceAsset={selectedPricePoolAsset}
               reloadBalances={reloadBalances}
               assets={poolAssets}

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -53,7 +53,13 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
     }
   } = useMidgardContext()
 
-  const { depositFees$, symDeposit$, reloadDepositFees, symDepositTxMemo$, getExplorerUrlByAsset$ } = useChainContext()
+  const {
+    symDepositFees$,
+    symDeposit$,
+    reloadSymDepositFees,
+    symDepositTxMemo$,
+    getExplorerUrlByAsset$
+  } = useChainContext()
 
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
@@ -162,12 +168,12 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
           assetBalance={O.none}
           runeBalance={O.none}
           chainAssetBalance={O.none}
-          fees$={depositFees$}
+          fees$={symDepositFees$}
           reloadFees={FP.constVoid}
           priceAsset={selectedPricePoolAsset}
           disabled={true}
           poolAddress={O.none}
-          memo={O.none}
+          memos={O.none}
           reloadBalances={reloadBalances}
           poolData={ZERO_POOL_DATA}
           deposit$={symDeposit$}
@@ -183,7 +189,7 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
       viewRuneTx,
       viewAssetTx,
       asset,
-      depositFees$,
+      symDepositFees$,
       selectedPricePoolAsset,
       reloadBalances,
       symDeposit$,
@@ -215,9 +221,9 @@ export const SymDepositView: React.FC<Props> = ({ asset }) => {
               runeBalance={runeBalance}
               chainAssetBalance={chainAssetBalance}
               poolAddress={oPoolAddress}
-              memo={depositTxMemo}
-              fees$={depositFees$}
-              reloadFees={reloadDepositFees}
+              memos={depositTxMemo}
+              fees$={symDepositFees$}
+              reloadFees={reloadSymDepositFees}
               priceAsset={selectedPricePoolAsset}
               reloadBalances={reloadBalances}
               assets={poolAssets}


### PR DESCRIPTION
In `SymDeposit.tsx`
  - [x] Fix state handling for `fee$` by using `useSubscriptionState` (useObservableState don't work here)
  - [x] Introduce `oDepositParams` 
  - [x] Fix `maxAssetAmountToDeposit` in `Deposit.helper`

In `services/chain/fees/deposit.ts `
  - [x] Split `depositFees$` handling into `symDepositFees$' + `asymDepositFee$`
  - [x] Remove deprecated `reloadFeesByChain`

In`eqHelper`
  - [x] Remove deprecated `eqDepositFeesParams`