### PR TITLE
[Swap] Fix decimal for locked / not imported wallet users

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@xchainjs/xchain-client": "^0.7.0",
     "@xchainjs/xchain-cosmos": "^0.11.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
-    "@xchainjs/xchain-ethereum": "^0.14.2",
+    "@xchainjs/xchain-ethereum": "^0.16.0",
     "@xchainjs/xchain-litecoin": "^0.4.0",
     "@xchainjs/xchain-polkadot": "^0.7.0",
     "@xchainjs/xchain-thorchain": "^0.13.1",

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -9,6 +9,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { mockValidatePassword$ } from '../../../shared/mock/wallet'
 import { ONE_BN } from '../../const'
+import { THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { INITIAL_SWAP_STATE } from '../../services/chain/const'
 import { SwapState } from '../../services/chain/types'
 import { Swap, SwapProps } from './Swap'
@@ -20,7 +21,7 @@ const defaultProps: SwapProps = {
     { asset: AssetBTC, assetPrice: bn('56851.67420275761') },
     { asset: AssetRuneNative, assetPrice: ONE_BN }
   ],
-  sourceAsset: AssetRuneNative,
+  sourceAsset: { asset: AssetRuneNative, decimal: THORCHAIN_DECIMAL },
   targetAsset: AssetBTC,
   poolAddress: O.some({ chain: 'BNB', address: 'vault-address', router: O.some('router-address') }),
   // mock successfull result of swap$

--- a/src/renderer/services/chain/decimal.ts
+++ b/src/renderer/services/chain/decimal.ts
@@ -2,7 +2,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
 import { BCH_DECIMAL } from '@xchainjs/xchain-bitcoincash'
 import { DECIMAL as COSMOS_DECIMAL } from '@xchainjs/xchain-cosmos'
-import { ETH_DECIMAL } from '@xchainjs/xchain-ethereum'
 import { LTC_DECIMAL } from '@xchainjs/xchain-litecoin'
 import { getDecimal as getDecimalDot } from '@xchainjs/xchain-polkadot'
 import {
@@ -14,17 +13,15 @@ import {
   BCHChain,
   LTCChain,
   Asset,
-  assetToString,
   BTCChain
 } from '@xchainjs/xchain-util'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../shared/api/types'
-import { BNB_DECIMAL, getEthAssetAddress, isEthAsset, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
+import { BNB_DECIMAL, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { getERC20Decimal } from '../ethereum/common'
+import { toThorNetwork } from '../thorchain/common'
 import { AssetWithDecimalLD } from './types'
 
 const getDecimal = (asset: Asset, network: Network): Promise<number> => {
@@ -34,23 +31,13 @@ const getDecimal = (asset: Asset, network: Network): Promise<number> => {
     case BTCChain:
       return Promise.resolve(BTC_DECIMAL)
     case ETHChain:
-      // ETH
-      if (isEthAsset(asset)) return Promise.resolve(ETH_DECIMAL)
-      // ERC20
-      // Needs to be done with `xchain-js` first
-      // see https://github.com/xchainjs/xchainjs-lib/issues/284
-      return FP.pipe(
-        getEthAssetAddress(asset),
-        O.fold(
-          () => Promise.reject(Error(`Unknown asset: ${assetToString(asset)}`)),
-          (address) => getERC20Decimal(address, network)
-        )
-      )
-
+      return getERC20Decimal(asset, network)
     case THORChain:
       return Promise.resolve(THORCHAIN_DECIMAL)
-    case PolkadotChain:
-      return Promise.resolve(getDecimalDot(network === 'mainnet' ? 'mainnet' : 'testnet'))
+    case PolkadotChain: {
+      const thorNetwork = toThorNetwork(network)
+      return Promise.resolve(getDecimalDot(thorNetwork))
+    }
     case CosmosChain:
       return Promise.resolve(COSMOS_DECIMAL)
     case BCHChain:

--- a/src/renderer/services/ethereum/common.ts
+++ b/src/renderer/services/ethereum/common.ts
@@ -1,12 +1,16 @@
-import { Network as ClientNetwork } from '@xchainjs/xchain-client'
+import { Contract } from '@ethersproject/contracts'
+import { EtherscanProvider } from '@ethersproject/providers'
+import { Address, Network as ClientNetwork } from '@xchainjs/xchain-client'
 import { Client } from '@xchainjs/xchain-ethereum'
+import { ethers, BigNumberish } from 'ethers'
 import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import * as RxOp from 'rxjs/operators'
 
+import { Network } from '../../../shared/api/types'
 import { envOrDefault } from '../../helpers/envHelper'
 import { network$ } from '../app/service'
 import * as C from '../clients'
@@ -17,16 +21,15 @@ import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState, ClientState$, Client$ } from './types'
 
+export const toEthNetwork = (network: Network) => {
+  if (network === 'chaosnet') return 'mainnet'
+  return network
+}
+
 /**
  * Ethereum network depending on `Network`
  */
-const ethereumNetwork$: Observable<ClientNetwork> = network$.pipe(
-  map((network) => {
-    if (network === 'chaosnet') return 'mainnet'
-
-    return network
-  })
-)
+const ethereumNetwork$: Observable<ClientNetwork> = network$.pipe(RxOp.map(toEthNetwork))
 
 const ETHERSCAN_API_KEY = envOrDefault(process.env.REACT_APP_ETHERSCAN_API_KEY, '')
 const INFURA_PROJECT_ID = envOrDefault(process.env.REACT_APP_INFURA_PROJECT_ID, '')
@@ -39,7 +42,7 @@ const INFURA_PROJECT_ID = envOrDefault(process.env.REACT_APP_INFURA_PROJECT_ID, 
  * A EthereumClient will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = Rx.combineLatest([keystoreService.keystore$, ethereumNetwork$]).pipe(
-  mergeMap(
+  RxOp.mergeMap(
     ([keystore, network]) =>
       new Observable((observer: Observer<ClientState>) => {
         const client: ClientState = FP.pipe(
@@ -70,13 +73,13 @@ const clientState$: ClientState$ = Rx.combineLatest([keystoreService.keystore$, 
   )
 )
 
-const client$: Client$ = clientState$.pipe(map(getClient), shareReplay(1))
+const client$: Client$ = clientState$.pipe(RxOp.map(getClient), RxOp.shareReplay(1))
 
 /**
  * Helper stream to provide "ready-to-go" state of latest `EthereumClient`, but w/o exposing the client
  * It's needed by views only.
  */
-const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(map(getClientStateForViews))
+const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(RxOp.map(getClientStateForViews))
 
 /**
  * Current `Address` depending on selected network
@@ -103,6 +106,26 @@ const getExplorerTxUrl$: GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
  */
 const getExplorerAddressUrl$: GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
+/**
+ * Helper to get decimals for ERC20
+ *
+ * Similar helper function will be provided by xchain-eth soon
+ * TODO(@Veado) Remove it in this case ^
+ */
+const getERC20Decimal = async (address: Address, network: Network): Promise<number> => {
+  const abi = ['function decimals() view returns (uint8)']
+  const ethNetwork = toEthNetwork(network)
+  const provider = new EtherscanProvider(ethNetwork, ETHERSCAN_API_KEY)
+  const erc20 = new Contract(address, abi, provider)
+
+  try {
+    const result: BigNumberish = await erc20.decimals()
+    return ethers.BigNumber.from(result).toNumber()
+  } catch (error: unknown) {
+    return Promise.reject(error)
+  }
+}
+
 export {
   client$,
   clientState$,
@@ -111,5 +134,6 @@ export {
   addressUI$,
   explorerUrl$,
   getExplorerTxUrl$,
-  getExplorerAddressUrl$
+  getExplorerAddressUrl$,
+  getERC20Decimal
 }

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -474,7 +474,7 @@ const createPoolsService = (
   // Shared stream to avoid reloading same data by subscribing
   const inboundAddressesShared$: PoolAddressesLD = loadInboundAddresses$().pipe(RxOp.shareReplay(1))
 
-  const selectedPoolAddresses$: PoolAddress$ = Rx.combineLatest([inboundAddressesShared$, selectedPoolAsset$]).pipe(
+  const selectedPoolAddress$: PoolAddress$ = Rx.combineLatest([inboundAddressesShared$, selectedPoolAsset$]).pipe(
     RxOp.map(([poolAddresses, oSelectedPoolAsset]) => {
       return FP.pipe(
         poolAddresses,
@@ -568,7 +568,7 @@ const createPoolsService = (
     reloadPools,
     reloadPendingPools,
     reloadAllPools,
-    selectedPoolAddress$: selectedPoolAddresses$,
+    selectedPoolAddress$,
     poolAddressesByChain$,
     poolDetail$,
     priceRatio$,

--- a/src/renderer/services/thorchain/common.ts
+++ b/src/renderer/services/thorchain/common.ts
@@ -7,6 +7,7 @@ import * as Rx from 'rxjs'
 import { Observable, Observer } from 'rxjs'
 import { map, mergeMap, shareReplay } from 'rxjs/operators'
 
+import { Network } from '../../../shared/api/types'
 import { network$ } from '../app/service'
 import * as C from '../clients'
 import { getClient } from '../clients/utils'
@@ -14,17 +15,16 @@ import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { Client$, ClientState } from './types'
 
+const toThorNetwork = (network: Network) => {
+  // In case of 'chaosnet' + 'mainnet` we stick on `mainnet`
+  if (network === 'chaosnet') return 'mainnet'
+  return network
+}
+
 /**
  * Thorchain network depending on selected `Network`
  */
-const thorchainNetwork$: Observable<ClientNetwork> = network$.pipe(
-  map((network) => {
-    // In case of 'chaosnet' + 'mainnet` we stick on `mainnet`
-    if (network === 'chaosnet') return 'mainnet'
-
-    return network
-  })
-)
+const thorchainNetwork$: Observable<ClientNetwork> = network$.pipe(map(toThorNetwork))
 
 /**
  * Stream to create an observable ThorchainClient depending on existing phrase in keystore
@@ -83,4 +83,13 @@ const getExplorerTxUrl$: C.GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
  */
 const getExplorerAddressUrl$: C.GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
-export { client$, clientState$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }
+export {
+  toThorNetwork,
+  client$,
+  clientState$,
+  address$,
+  addressUI$,
+  explorerUrl$,
+  getExplorerTxUrl$,
+  getExplorerAddressUrl$
+}

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -52,17 +52,17 @@ export const DepositView: React.FC<Props> = () => {
 
   const { addressByChain$, assetWithDecimal$ } = useChainContext()
 
-  const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset.toUpperCase())), [asset])
+  const oRouteAsset = useMemo(() => O.fromNullable(assetFromString(asset.toUpperCase())), [asset])
 
   // Set selected pool asset whenever an asset in route has been changed
   // Needed to get all data for this pool (pool details etc.)
   useEffect(() => {
-    setSelectedPoolAsset(oSelectedAsset)
+    setSelectedPoolAsset(oRouteAsset)
     // Reset selectedPoolAsset on view's unmount to avoid effects with depending streams
     return () => {
       setSelectedPoolAsset(O.none)
     }
-  }, [oSelectedAsset, setSelectedPoolAsset])
+  }, [oRouteAsset, setSelectedPoolAsset])
 
   const [assetRD] = useObservableState<AssetWithDecimalRD>(
     () =>
@@ -80,13 +80,15 @@ export const DepositView: React.FC<Props> = () => {
     RD.initial
   )
 
+  const oSelectedAsset = useMemo(() => RD.toOption(assetRD), [assetRD])
+
   const address$ = useMemo(
     () =>
       FP.pipe(
         oSelectedAsset,
         O.fold(
           () => Rx.EMPTY,
-          ({ chain }) => addressByChain$(chain)
+          ({ asset }) => addressByChain$(asset.chain)
         )
       ),
 

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -169,29 +169,26 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
               }
 
               return (
-                <>
-                  <div>DECIMAL: {sourceAsset.decimal}</div>
-                  <Swap
-                    keystore={keystore}
-                    validatePassword$={validatePassword$}
-                    goToTransaction={goToTransaction}
-                    sourceAsset={sourceAsset}
-                    targetAsset={targetAsset}
-                    poolAddress={selectedPoolAddress}
-                    availableAssets={availableAssets}
-                    poolDetails={poolDetails}
-                    walletBalances={balances}
-                    reloadFees={reloadSwapFees}
-                    fees$={swapFees$}
-                    targetWalletAddress={targetWalletAddress}
-                    swap$={swap$}
-                    reloadBalances={reloadBalances}
-                    onChangePath={onChangePath}
-                    network={network}
-                    approveERC20Token$={approveERC20Token$}
-                    isApprovedERC20Token$={isApprovedERC20Token$}
-                  />
-                </>
+                <Swap
+                  keystore={keystore}
+                  validatePassword$={validatePassword$}
+                  goToTransaction={goToTransaction}
+                  sourceAsset={sourceAsset}
+                  targetAsset={targetAsset}
+                  poolAddress={selectedPoolAddress}
+                  availableAssets={availableAssets}
+                  poolDetails={poolDetails}
+                  walletBalances={balances}
+                  reloadFees={reloadSwapFees}
+                  fees$={swapFees$}
+                  targetWalletAddress={targetWalletAddress}
+                  swap$={swap$}
+                  reloadBalances={reloadBalances}
+                  onChangePath={onChangePath}
+                  network={network}
+                  approveERC20Token$={approveERC20Token$}
+                  isApprovedERC20Token$={isApprovedERC20Token$}
+                />
               )
             }
           )

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -24,6 +24,7 @@ import { useWalletContext } from '../../contexts/WalletContext'
 import { isRuneNativeAsset } from '../../helpers/assetHelper'
 import { sequenceTRD } from '../../helpers/fpHelpers'
 import { SwapRouteParams } from '../../routes/swap'
+import { AssetWithDecimalRD } from '../../services/chain/types'
 import { DEFAULT_NETWORK } from '../../services/const'
 import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 import * as Styled from './SwapView.styles'
@@ -44,7 +45,14 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
     setSelectedPoolAsset,
     selectedPoolAsset$
   } = midgardService
-  const { reloadSwapFees, swapFees$, getExplorerUrlByAsset$, addressByChain$, swap$ } = useChainContext()
+  const {
+    reloadSwapFees,
+    swapFees$,
+    getExplorerUrlByAsset$,
+    addressByChain$,
+    swap$,
+    assetWithDecimal$
+  } = useChainContext()
 
   const {
     balancesState$,
@@ -58,33 +66,37 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
   const poolsState = useObservableState(poolsState$, RD.initial)
 
-  const oSource = useMemo(() => O.fromNullable(assetFromString(source.toUpperCase())), [source])
-  const oTarget = useMemo(() => O.fromNullable(assetFromString(target.toUpperCase())), [target])
+  const oRouteSource = useMemo(() => O.fromNullable(assetFromString(source.toUpperCase())), [source])
+  const oRouteTarget = useMemo(() => O.fromNullable(assetFromString(target.toUpperCase())), [target])
 
   useEffect(() => {
     // Source asset is the asset of the pool we need to interact with
     // Store it in global state, all depending streams will be updated then
-    setSelectedPoolAsset(oSource)
+    setSelectedPoolAsset(oRouteSource)
 
     // Reset selectedPoolAsset on view's unmount to avoid effects with depending streams
     return () => {
       setSelectedPoolAsset(O.none)
     }
-  }, [oSource, setSelectedPoolAsset])
+  }, [oRouteSource, setSelectedPoolAsset])
 
-  const [selectedPoolAssetRD] = useObservableState(
+  const [selectedPoolAssetRD] = useObservableState<AssetWithDecimalRD>(
     () =>
       selectedPoolAsset$.pipe(
-        RxOp.map((selectedPoolAsset) =>
-          RD.fromOption(selectedPoolAsset, () =>
-            Error(intl.formatMessage({ id: 'swap.errors.asset.missingSourceAsset' }))
+        RxOp.switchMap((oAsset) =>
+          FP.pipe(
+            oAsset,
+            O.fold(
+              () => Rx.of(RD.initial),
+              (asset) => assetWithDecimal$(asset, network)
+            )
           )
         )
       ),
     RD.initial
   )
 
-  const targetAssetRD = RD.fromOption(oTarget, () =>
+  const targetAssetRD = RD.fromOption(oRouteTarget, () =>
     Error(intl.formatMessage({ id: 'swap.errors.asset.missingTargetAsset' }))
   )
 
@@ -95,14 +107,14 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   const address$ = useMemo(
     () =>
       FP.pipe(
-        oTarget,
+        oRouteTarget,
         O.fold(
           () => Rx.EMPTY,
           ({ chain }) => addressByChain$(chain)
         )
       ),
 
-    [addressByChain$, oTarget]
+    [addressByChain$, oRouteTarget]
   )
   const targetWalletAddress = useObservableState(address$, O.none)
 
@@ -157,26 +169,29 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
               }
 
               return (
-                <Swap
-                  keystore={keystore}
-                  validatePassword$={validatePassword$}
-                  goToTransaction={goToTransaction}
-                  sourceAsset={sourceAsset}
-                  targetAsset={targetAsset}
-                  poolAddress={selectedPoolAddress}
-                  availableAssets={availableAssets}
-                  poolDetails={poolDetails}
-                  walletBalances={balances}
-                  reloadFees={reloadSwapFees}
-                  fees$={swapFees$}
-                  targetWalletAddress={targetWalletAddress}
-                  swap$={swap$}
-                  reloadBalances={reloadBalances}
-                  onChangePath={onChangePath}
-                  network={network}
-                  approveERC20Token$={approveERC20Token$}
-                  isApprovedERC20Token$={isApprovedERC20Token$}
-                />
+                <>
+                  <div>DECIMAL: {sourceAsset.decimal}</div>
+                  <Swap
+                    keystore={keystore}
+                    validatePassword$={validatePassword$}
+                    goToTransaction={goToTransaction}
+                    sourceAsset={sourceAsset}
+                    targetAsset={targetAsset}
+                    poolAddress={selectedPoolAddress}
+                    availableAssets={availableAssets}
+                    poolDetails={poolDetails}
+                    walletBalances={balances}
+                    reloadFees={reloadSwapFees}
+                    fees$={swapFees$}
+                    targetWalletAddress={targetWalletAddress}
+                    swap$={swap$}
+                    reloadBalances={reloadBalances}
+                    onChangePath={onChangePath}
+                    network={network}
+                    approveERC20Token$={approveERC20Token$}
+                    isApprovedERC20Token$={isApprovedERC20Token$}
+                  />
+                </>
               )
             }
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5011,10 +5011,10 @@
     hdkey "^2.0.1"
     uuid "^8.1.0"
 
-"@xchainjs/xchain-ethereum@^0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-ethereum/-/xchain-ethereum-0.14.2.tgz#59974207fc07bd72f8190f0b96f6d992daf467ec"
-  integrity sha512-n26E2OQKq/+WBYq3UrugLfA7s5/5xf3xbEFmS/ZRpF+MochOW/rqSTRTOLryHkH/ViuAtarEJcj2LaiuhfciVA==
+"@xchainjs/xchain-ethereum@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-ethereum/-/xchain-ethereum-0.16.0.tgz#a28371e27139f3a390b00ead2fef2a2759521b2d"
+  integrity sha512-2WAq7vql3/V6KLjX1dB6fEpACRTPT11lOz7YmvYnbLM+Tl25hlzLnUf00xZdkbaPujEon5khWW5+2r8NS0mOAA==
 
 "@xchainjs/xchain-litecoin@^0.4.0":
   version "0.4.0"


### PR DESCRIPTION
Main changes:
- [x]  Get decimal using `xchain-eth` helper `getDecimal` + cache result 
- [x] Use Latest xchain-eth@0.16.0

Quick fixes:
- [x] Extract `toThorNetwork`
- [x]  DepositView: Get selectedPoolAsset from stream, not from route
- [x] `selectedPoolAddresses$` -> `selectedPoolAddress$`


Fix #1165 