### PR TITLE
Fix decimal for swap output

### DIFF
--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
+import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
 import { assetAmount, AssetBTC, AssetRuneNative, assetToBase, baseAmount, bn } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
@@ -22,7 +23,7 @@ const defaultProps: SwapProps = {
     { asset: AssetRuneNative, assetPrice: ONE_BN }
   ],
   sourceAsset: { asset: AssetRuneNative, decimal: THORCHAIN_DECIMAL },
-  targetAsset: AssetBTC,
+  targetAsset: { asset: AssetBTC, decimal: BTC_DECIMAL },
   poolAddress: O.some({ chain: 'BNB', address: 'vault-address', router: O.some('router-address') }),
   // mock successfull result of swap$
   swap$: (params) =>

--- a/src/renderer/components/swap/Swap.styles.tsx
+++ b/src/renderer/components/swap/Swap.styles.tsx
@@ -166,7 +166,7 @@ export const BalanceErrorLabel = styled(ErrorLabel)`
 `
 
 export const NoteLabel = styled(UILabel)`
-  color: ${palette('gray', 2)};
+  color: ${palette('text', 2)};
 `
 
 export const AssetSelect = styled(AssetSelectUI)`

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -63,6 +63,11 @@ export const getSlip = ({
   )
 }
 
+/**
+ * Result of swap
+ *
+ * Note: Returned `amountToSwap` is `1e8` decimal based
+ */
 export const getSwapResult = ({
   sourceAsset,
   targetAsset,
@@ -109,6 +114,11 @@ export const DEFAULT_SWAP_DATA: SwapData = {
   swapResult: ZERO_BASE_AMOUNT
 }
 
+/**
+ * Returns `SwapData`
+ *
+ * Note: `amountToSwap` of `swapResult` is `1e8` decimal based
+ */
 export const getSwapData = ({
   amountToSwap,
   sourceAsset,

--- a/src/renderer/components/uielements/fees/Fees.helper.ts
+++ b/src/renderer/components/uielements/fees/Fees.helper.ts
@@ -1,8 +1,10 @@
 import { BaseAmount, Asset, formatAssetAmountCurrency, baseToAsset } from '@xchainjs/xchain-util'
 
+import { getTwoSigfigAssetAmount } from '../../../helpers/assetHelper'
+
 export const formatFee = ({ amount, asset }: { amount: BaseAmount; asset: Asset }) =>
   formatAssetAmountCurrency({
-    amount: baseToAsset(amount),
+    amount: getTwoSigfigAssetAmount(baseToAsset(amount)),
     asset,
     trimZeros: true
   })

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -24,7 +24,7 @@ import { useWalletContext } from '../../contexts/WalletContext'
 import { isRuneNativeAsset } from '../../helpers/assetHelper'
 import { sequenceTRD } from '../../helpers/fpHelpers'
 import { SwapRouteParams } from '../../routes/swap'
-import { AssetWithDecimalRD } from '../../services/chain/types'
+import { AssetWithDecimalLD, AssetWithDecimalRD } from '../../services/chain/types'
 import { DEFAULT_NETWORK } from '../../services/const'
 import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 import * as Styled from './SwapView.styles'
@@ -96,9 +96,20 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
     RD.initial
   )
 
-  const targetAssetRD = RD.fromOption(oRouteTarget, () =>
-    Error(intl.formatMessage({ id: 'swap.errors.asset.missingTargetAsset' }))
+  const targetAssetDecimal$: AssetWithDecimalLD = useMemo(
+    () =>
+      FP.pipe(
+        oRouteTarget,
+        O.fold(
+          () => Rx.of(RD.failure(Error(intl.formatMessage({ id: 'swap.errors.asset.missingTargetAsset' })))),
+          (asset) => assetWithDecimal$(asset, network)
+        )
+      ),
+    [assetWithDecimal$, intl, network, oRouteTarget]
   )
+
+  const targetAssetRD: AssetWithDecimalRD = useObservableState(targetAssetDecimal$, RD.initial)
+  // const targetAssetRD: AssetWithDecimalRD = RD.success({ asset, decimal: 18 })
 
   const { balances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -109,7 +109,6 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   )
 
   const targetAssetRD: AssetWithDecimalRD = useObservableState(targetAssetDecimal$, RD.initial)
-  // const targetAssetRD: AssetWithDecimalRD = RD.success({ asset, decimal: 18 })
 
   const { balances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 


### PR DESCRIPTION
- [x] Swap: Fix decimal for output 
- [x] Remove unneeded fee error handling for target chain
- [x] Rename few `xyzAmount` values / functions to `xyzAmountMax1e2`
- [x] Enable slider for unlocked wallet user only
- [x] Use `getTwoSigfigAssetAmount` in `formatFee` helper 

Fix #1173 