### PR TITLE
Refactor data handling for PoolDetail

### DIFF
--- a/src/renderer/components/deposit/add/SymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.stories.tsx
@@ -67,6 +67,7 @@ const defaultProps: SymDepositProps = {
   memos: O.some({ rune: 'rune-memo', asset: 'asset-memo' }),
   reloadBalances: () => console.log('reloadBalances'),
   reloadShares: (delay = 0) => console.log('reloadShares ', delay),
+  reloadSelectedPoolDetail: (delay = 0) => console.log('reloadSelectedPoolDetail ', delay),
   viewAssetTx: (txHash) => {
     console.log(txHash)
   },

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -216,6 +216,26 @@ const createPoolsService = (
   }
 
   /**
+   * `PoolDetail data from Midgard
+   */
+  const apiGetPoolDetail$ = (asset: Asset): PoolDetailLD =>
+    FP.pipe(
+      midgardDefaultApi$,
+      liveData.chain((api) => {
+        return FP.pipe(
+          api.getPool({ asset: assetToString(asset) }),
+          // Setting empty values, since we don't need those in pool detail atm
+          // TODO (@asdgdx-team: Do we still need `poolSlipAverage` + `swappingTxCount` in PoolDetail ??
+          RxOp.map((poolDetail) => ({ poolSlipAverage: '', swappingTxCount: '', ...poolDetail })),
+          RxOp.map(RD.success),
+          RxOp.startWith(RD.pending),
+          RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
+        )
+      }),
+      RxOp.shareReplay(1)
+    )
+
+  /**
    * `PoolDetails` data from Midgard
    */
   const apiGetPoolsData$: (assetOrAssets: string | string[], status?: GetPoolsStatusEnum) => PoolDetailsLD = (
@@ -223,6 +243,8 @@ const createPoolsService = (
     status
   ) => {
     const assets = Array.isArray(assetOrAssets) ? assetOrAssets : [assetOrAssets]
+
+    console.log('xxx apiGetPoolsData:', assetOrAssets, status)
 
     return FP.pipe(
       apiGetPoolsByStatus$(status),
@@ -402,34 +424,26 @@ const createPoolsService = (
     RxOp.shareReplay(1)
   )
 
+  const { get$: reloadSelectedPoolDetail$, set: _reloadSelectedPoolDetail } = observableState(0)
+
   /**
    * Stream of `PoolDetail` data based on selected pool asset
-   * It's triggered by changes of selectedPoolAsset$`
-   *
-   * Note: It checks currenlty ALL (pending/available) pool details
-   * That's needed for Deposit pages, which have not the information about status of pool right now (might be improved if needed)
+   * It's triggered by changes of selectedPoolAsset$` + `reloadSelectedPoolDetail$`
    */
-  const poolDetail$: PoolDetailLD = selectedPoolAsset$.pipe(
-    RxOp.filter(O.isSome),
-    RxOp.switchMap((selectedPoolAsset) =>
+  const selectedPoolDetail$: PoolDetailLD = Rx.combineLatest([selectedPoolAsset$, reloadSelectedPoolDetail$]).pipe(
+    RxOp.switchMap(([oSelectedPoolAsset, delay]) =>
       FP.pipe(
+        Rx.timer(delay),
+        RxOp.switchMap(() => Rx.of(oSelectedPoolAsset))
+      )
+    ),
+    RxOp.filter(O.isSome),
+    RxOp.switchMap((selectedPoolAsset) => {
+      return FP.pipe(
         selectedPoolAsset,
-        O.fold(
-          () => Rx.of(RD.initial),
-          (asset) =>
-            apiGetPoolsData$(
-              assetToString(asset),
-              undefined /* explicit set to `undefined` to remember we want data for all pools */
-            )
-        )
+        O.fold(() => Rx.of(RD.initial), apiGetPoolDetail$)
       )
-    ),
-    liveData.chain(
-      FP.flow(
-        A.head,
-        liveData.fromOption(() => Error('Empty response'))
-      )
-    ),
+    }),
     RxOp.startWith(RD.pending),
     RxOp.shareReplay(1)
   )
@@ -569,12 +583,12 @@ const createPoolsService = (
       )
     )
 
-  const { stream$: reloadPool$, trigger: reloadPool } = triggerStream()
+  const { stream$: reloadPoolStatsDetail$, trigger: reloadPoolStatsDetail } = triggerStream()
 
   // Factory to get pool stats detail from Midgard
   const apiGetPoolStatsDetail$ = (request: GetPoolStatsRequest): PoolStatsDetailLD =>
     FP.pipe(
-      Rx.combineLatest([midgardDefaultApi$, reloadPool$]),
+      Rx.combineLatest([midgardDefaultApi$, reloadPoolStatsDetail$]),
       RxOp.map(([api]) => api),
       liveData.chain((api) =>
         FP.pipe(
@@ -610,7 +624,7 @@ const createPoolsService = (
   // Factory to get pool legacy detail from Midgard
   const apiGetPoolLegacyDetail$ = (request: GetPoolStatsLegacyRequest): PoolLegacyDetailLD =>
     FP.pipe(
-      Rx.combineLatest([midgardDefaultApi$, reloadPool$]),
+      Rx.combineLatest([midgardDefaultApi$, reloadPoolStatsDetail$]),
       RxOp.map(([api]) => api),
       liveData.chain((api) =>
         FP.pipe(
@@ -644,7 +658,7 @@ const createPoolsService = (
   // Factory to get pool liquidity history from Midgard
   const apiGetPoolLiquidityHistory$ = (request: GetLiquidityHistoryRequest): PoolLiquidityHistoryLD =>
     FP.pipe(
-      Rx.combineLatest([midgardDefaultApi$, reloadPool$]),
+      Rx.combineLatest([midgardDefaultApi$, reloadPoolStatsDetail$]),
       RxOp.map(([api]) => api),
       liveData.chain((api) =>
         FP.pipe(
@@ -690,8 +704,9 @@ const createPoolsService = (
     reloadAllPools,
     selectedPoolAddress$,
     poolAddressesByChain$,
-    poolDetail$,
-    reloadPool,
+    selectedPoolDetail$,
+    reloadSelectedPoolDetail: (delayTime = 0) => _reloadSelectedPoolDetail(delayTime),
+    reloadPoolStatsDetail,
     poolStatsDetail$,
     poolLegacyDetail$,
     poolLiquidityHistory$,

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -244,8 +244,6 @@ const createPoolsService = (
   ) => {
     const assets = Array.isArray(assetOrAssets) ? assetOrAssets : [assetOrAssets]
 
-    console.log('xxx apiGetPoolsData:', assetOrAssets, status)
-
     return FP.pipe(
       apiGetPoolsByStatus$(status),
       liveData.map(A.filter((poolDetail) => assets.includes(poolDetail.asset))),

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -152,8 +152,9 @@ export type PoolsService = {
   reloadAllPools: FP.Lazy<void>
   selectedPoolAddress$: PoolAddress$
   poolAddressesByChain$: (chain: Chain) => PoolAddressLD
-  poolDetail$: PoolDetailLD
-  reloadPool: FP.Lazy<void>
+  selectedPoolDetail$: PoolDetailLD
+  reloadSelectedPoolDetail: (delay?: number) => void
+  reloadPoolStatsDetail: FP.Lazy<void>
   poolStatsDetail$: (period?: GetPoolStatsPeriodEnum) => PoolStatsDetailLD
   poolLegacyDetail$: PoolLegacyDetailLD
   poolLiquidityHistory$: (parmas: PoolLiquidityHistoryParams) => PoolLiquidityHistoryLD

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -44,6 +44,7 @@ export const DepositView: React.FC<Props> = () => {
     service: {
       setSelectedPoolAsset,
       selectedPoolAsset$,
+      pools: { reloadSelectedPoolDetail },
       shares: { shares$, reloadShares }
     }
   } = useMidgardContext()
@@ -119,7 +120,8 @@ export const DepositView: React.FC<Props> = () => {
   const reloadHandler = useCallback(() => {
     reloadBalances()
     reloadShares()
-  }, [reloadBalances, reloadShares])
+    reloadSelectedPoolDetail()
+  }, [reloadBalances, reloadSelectedPoolDetail, reloadShares])
 
   // Important note:
   // DON'T use `INITIAL_KEYSTORE_STATE` as default value for `keystoreState`

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -50,7 +50,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
 
   const {
     service: {
-      pools: { availableAssets$, priceRatio$, selectedPricePoolAsset$, poolDetail$, selectedPoolAddress$ },
+      pools: { availableAssets$, priceRatio$, selectedPricePoolAsset$, selectedPoolDetail$, selectedPoolAddress$ },
       shares: { reloadShares }
     }
   } = useMidgardContext()
@@ -88,7 +88,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     reloadShares(5000)
   }, [reloadBalances, reloadShares])
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const assetBalance: O.Option<BaseAmount> = useMemo(
     () =>

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -55,7 +55,14 @@ export const SymDepositView: React.FC<Props> = (props) => {
 
   const {
     service: {
-      pools: { availableAssets$, priceRatio$, selectedPricePoolAsset$, poolDetail$, selectedPoolAddress$ },
+      pools: {
+        availableAssets$,
+        priceRatio$,
+        selectedPricePoolAsset$,
+        selectedPoolDetail$,
+        reloadSelectedPoolDetail,
+        selectedPoolAddress$
+      },
       shares: { reloadShares }
     }
   } = useMidgardContext()
@@ -83,7 +90,7 @@ export const SymDepositView: React.FC<Props> = (props) => {
 
   const { balances: walletBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const assetBalance: O.Option<BaseAmount> = useMemo(
     () =>
@@ -176,6 +183,7 @@ export const SymDepositView: React.FC<Props> = (props) => {
           memos={O.none}
           reloadBalances={reloadBalances}
           reloadShares={reloadShares}
+          reloadSelectedPoolDetail={reloadSelectedPoolDetail}
           poolData={ZERO_POOL_DATA}
           deposit$={symDeposit$}
           network={network}
@@ -195,6 +203,7 @@ export const SymDepositView: React.FC<Props> = (props) => {
       selectedPricePoolAsset,
       reloadBalances,
       reloadShares,
+      reloadSelectedPoolDetail,
       symDeposit$,
       network,
       approveERC20Token$,
@@ -235,6 +244,7 @@ export const SymDepositView: React.FC<Props> = (props) => {
               priceAsset={selectedPricePoolAsset}
               reloadBalances={reloadBalances}
               reloadShares={reloadShares}
+              reloadSelectedPoolDetail={reloadSelectedPoolDetail}
               balances={filteredBalances}
               deposit$={symDeposit$}
               network={network}

--- a/src/renderer/views/deposit/share/ShareView.tsx
+++ b/src/renderer/views/deposit/share/ShareView.tsx
@@ -28,12 +28,12 @@ type Props = {
 export const ShareView: React.FC<Props> = ({ asset: assetWD, poolShare: poolShareRD, smallWidth }) => {
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { poolDetail$, selectedPricePoolAsset$, selectedPricePool$ }
+    pools: { selectedPoolDetail$, selectedPricePoolAsset$, selectedPricePool$ }
   } = midgardService
 
   const intl = useIntl()
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
   const oPriceAsset = useObservableState<O.Option<Asset>>(selectedPricePoolAsset$, O.none)
 
   const { poolData: pricePoolData } = useObservableState(selectedPricePool$, RUNE_PRICE_POOL)

--- a/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
+++ b/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
@@ -31,7 +31,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
   const { asset, poolShare: poolShareRD } = props
   const {
     service: {
-      pools: { poolDetail$, selectedPricePoolAsset$, priceRatio$, selectedPoolAddress$ }
+      pools: { selectedPoolDetail$, selectedPricePoolAsset$, priceRatio$, selectedPoolAddress$ }
     }
   } = useMidgardContext()
 
@@ -41,7 +41,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
 
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const [selectedPriceAssetRD]: [RD.RemoteData<Error, Asset>, unknown] = useObservableState(
     () =>

--- a/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
+++ b/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
@@ -33,7 +33,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
   const { decimal: assetDecimal } = assetWD
   const {
     service: {
-      pools: { poolDetail$, selectedPricePoolAsset$, priceRatio$ },
+      pools: { selectedPoolDetail$, selectedPricePoolAsset$, priceRatio$ },
       shares: { reloadShares }
     }
   } = useMidgardContext()
@@ -42,7 +42,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
 
   const runePrice = useObservableState(priceRatio$, bn(1))
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const [selectedPriceAssetRD]: [RD.RemoteData<Error, Asset>, unknown] = useObservableState(
     () =>

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -41,7 +41,7 @@ const renderInitialView = () => <PoolDetails {...defaultDetailsProps} />
 export const PoolDetailsView: React.FC = () => {
   const {
     service: {
-      pools: { poolDetail$, priceRatio$, selectedPricePoolAssetSymbol$ }
+      pools: { selectedPoolDetail$, priceRatio$, selectedPricePoolAssetSymbol$ }
     }
   } = useMidgardContext()
 
@@ -51,7 +51,7 @@ export const PoolDetailsView: React.FC = () => {
 
   const priceRatio = useObservableState(priceRatio$, ONE_BN)
 
-  const poolDetailRD = useObservableState(poolDetail$, RD.initial)
+  const poolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
 
   return FP.pipe(
     poolDetailRD,

--- a/src/renderer/views/wallet/PoolShareView.tsx
+++ b/src/renderer/views/wallet/PoolShareView.tsx
@@ -34,7 +34,7 @@ export const PoolShareView: React.FC = (): JSX.Element => {
 
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { allPoolDetails$, selectedPricePool$, selectedPricePoolAsset$, reloadPools },
+    pools: { allPoolDetails$, selectedPricePool$, selectedPricePoolAsset$, reloadAllPools },
     reloadNetworkInfo,
     shares: { combineSharesByAddresses$ }
   } = midgardService
@@ -104,9 +104,9 @@ export const PoolShareView: React.FC = (): JSX.Element => {
   )
 
   const clickRefreshHandler = useCallback(() => {
-    reloadPools()
+    reloadAllPools()
     reloadNetworkInfo()
-  }, [reloadNetworkInfo, reloadPools])
+  }, [reloadNetworkInfo, reloadAllPools])
 
   const renderRefreshBtn = useMemo(
     () => (

--- a/src/renderer/views/wallet/PoolShareView.tsx
+++ b/src/renderer/views/wallet/PoolShareView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react'
+import React, { useCallback, useMemo, useRef, useEffect } from 'react'
 
 import { SyncOutlined } from '@ant-design/icons'
 import * as RD from '@devexperts/remote-data-ts'
@@ -42,6 +42,11 @@ export const PoolShareView: React.FC = (): JSX.Element => {
   const thorchainContext = useThorchainContext()
   const oRuneAddress = useObservableState(thorchainContext.address$, O.none)
   const { addressByChain$ } = useChainContext()
+
+  useEffect(() => {
+    reloadAllPools()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const [poolSharesRD]: [PoolSharesRD, unknown] = useObservableState(
     () =>

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -30,7 +30,8 @@ export const WalletView: React.FC = (): JSX.Element => {
   const { keystoreService, reloadBalances } = useWalletContext()
   const {
     service: {
-      shares: { reloadCombineSharesByAddresses }
+      shares: { reloadCombineSharesByAddresses },
+      pools: { reloadAllPools }
     }
   } = useMidgardContext()
   const { reloadNodesInfo } = useThorchainContext()
@@ -69,7 +70,10 @@ export const WalletView: React.FC = (): JSX.Element => {
             <AssetsView />
           </Route>
           <Route path={walletRoutes.poolShares.template} exact>
-            {reloadButton(reloadCombineSharesByAddresses)}
+            {reloadButton(() => {
+              reloadCombineSharesByAddresses()
+              reloadAllPools()
+            })}
             <AssetsNav />
             <PoolShareView />
           </Route>
@@ -93,7 +97,7 @@ export const WalletView: React.FC = (): JSX.Element => {
         </Switch>
       </>
     ),
-    [reloadBalances, reloadButton, reloadCombineSharesByAddresses, reloadNodesInfo]
+    [reloadAllPools, reloadBalances, reloadButton, reloadCombineSharesByAddresses, reloadNodesInfo]
   )
 
   const renderWalletRoute = useCallback(


### PR DESCRIPTION
- [x] Introduce `apiGetPoolDetail$`
- [x] Refactor `selectedPoolDetail$` (previously `poolDetail$`) to use `apiGetPoolDetail$` (instead of loading data for all pools)
- [x] Re-load `PoolDetails` in deposit to re-calculate pool shares
- [x] Fix re-loading of pool data in `wallet/poolshares` 


Fixes #1184 