### PR TITLE
Introduce `PoolOverviewDetail` type

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -56,7 +56,7 @@ import {
 } from '../../services/chain/types'
 import { ApproveParams, IsApprovedRD } from '../../services/ethereum/types'
 import { PoolAssetDetail, PoolAssetDetails, PoolAddress, PoolsDataMap } from '../../services/midgard/types'
-import { PoolDetails } from '../../services/midgard/types'
+import { PoolOverviewDetails } from '../../services/midgard/types'
 import { getPoolDetailsHashMap } from '../../services/midgard/utils'
 import {
   ApiError,
@@ -88,7 +88,7 @@ export type SwapProps = {
   targetAsset: AssetWithDecimal
   poolAddress: O.Option<PoolAddress>
   swap$: SwapStateHandler
-  poolDetails: PoolDetails
+  poolDetails: PoolOverviewDetails
   walletBalances: O.Option<NonEmptyWalletBalances>
   goToTransaction: (txHash: string) => void
   validatePassword$: ValidatePasswordHandler

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
@@ -17,7 +17,7 @@ import { isRuneBnbAsset } from '../../../helpers/assetHelper'
 import { getPoolPriceValue } from '../../../helpers/poolHelper'
 import * as walletRoutes from '../../../routes/wallet'
 import { WalletBalancesRD } from '../../../services/clients'
-import { PoolDetails } from '../../../services/midgard/types'
+import { PoolOverviewDetails } from '../../../services/midgard/types'
 import { ApiError, ChainBalance, ChainBalances } from '../../../services/wallet/types'
 import { WalletBalance, WalletBalances } from '../../../types/wallet'
 import { PricePool } from '../../../views/pools/Pools.types'
@@ -30,7 +30,7 @@ const { Panel } = Collapse
 type Props = {
   chainBalances: ChainBalances
   pricePool: PricePool
-  poolDetails: PoolDetails
+  poolDetails: PoolOverviewDetails
   selectAssetHandler?: (asset: Asset, walletAddress: string) => void
   setSelectedAsset?: (oAsset: O.Option<Asset>) => void
   network: Network

--- a/src/renderer/helpers/poolHelper.test.ts
+++ b/src/renderer/helpers/poolHelper.test.ts
@@ -5,16 +5,16 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../shared/mock/assets'
-import { PoolDetails, PoolDetail } from '../services/midgard/types'
+import { PoolOverviewDetails, PoolOverviewDetail } from '../services/midgard/types'
 import { toPoolData } from '../services/midgard/utils'
 import { GetPoolsStatusEnum } from '../types/generated/midgard'
 import { getDeepestPool, getPoolPriceValue, getPoolTableRowsData } from './poolHelper'
 
 describe('helpers/poolHelper/', () => {
-  const pool1 = { status: GetPoolsStatusEnum.Staged, runeDepth: '1000' } as PoolDetail
-  const pool2 = { status: GetPoolsStatusEnum.Available, runeDepth: '2000' } as PoolDetail
-  const pool3 = { status: GetPoolsStatusEnum.Suspended, runeDepth: '0' } as PoolDetail
-  const pool4 = { status: GetPoolsStatusEnum.Staged, runeDepth: '4000' } as PoolDetail
+  const pool1 = { status: GetPoolsStatusEnum.Staged, runeDepth: '1000' } as PoolOverviewDetail
+  const pool2 = { status: GetPoolsStatusEnum.Available, runeDepth: '2000' } as PoolOverviewDetail
+  const pool3 = { status: GetPoolsStatusEnum.Suspended, runeDepth: '0' } as PoolOverviewDetail
+  const pool4 = { status: GetPoolsStatusEnum.Staged, runeDepth: '4000' } as PoolOverviewDetail
 
   describe('getDeepestPool', () => {
     it('returns deepest pool', () => {
@@ -24,7 +24,7 @@ describe('helpers/poolHelper/', () => {
     })
 
     it('does not return a deepest pool by given an empty list of pools', () => {
-      const pools: PoolDetails = []
+      const pools: PoolOverviewDetails = []
       const result = getDeepestPool(pools)
       expect(result).toBeNone()
     })
@@ -40,7 +40,7 @@ describe('helpers/poolHelper/', () => {
         asset: assetToString(ASSETS_TESTNET.FTM),
         status: GetPoolsStatusEnum.Available
       }
-    ] as PoolDetails
+    ] as PoolOverviewDetails
     const pendingPoolDetails = [
       {
         asset: assetToString(ASSETS_TESTNET.BOLT),
@@ -50,7 +50,7 @@ describe('helpers/poolHelper/', () => {
         asset: assetToString(ASSETS_TESTNET.FTM),
         status: GetPoolsStatusEnum.Staged
       }
-    ] as PoolDetails
+    ] as PoolOverviewDetails
 
     const pricePoolData: PoolData = {
       runeBalance: assetToBase(assetAmount(110)),
@@ -88,7 +88,7 @@ describe('helpers/poolHelper/', () => {
     const poolDetail = {
       assetDepth: '11000000000',
       runeDepth: '10000000000'
-    } as PoolDetail
+    } as PoolOverviewDetail
 
     it('transforms `PoolData', () => {
       const result = toPoolData(poolDetail)
@@ -98,7 +98,7 @@ describe('helpers/poolHelper/', () => {
   })
 
   describe('getPoolPriceValue', () => {
-    const poolDetails: PoolDetails = [
+    const poolDetails: PoolOverviewDetails = [
       {
         asset: assetToString(AssetBNB),
         assetDepth: '1000000000',

--- a/src/renderer/helpers/poolHelper.ts
+++ b/src/renderer/helpers/poolHelper.ts
@@ -10,8 +10,9 @@ import * as Ord from 'fp-ts/lib/Ord'
 
 import { Network } from '../../shared/api/types'
 import { ONE_RUNE_BASE_AMOUNT } from '../../shared/mock/amount'
-import { PoolAddress, PoolDetail, PoolDetails } from '../services/midgard/types'
+import { PoolAddress, PoolOverviewDetail, PoolOverviewDetails } from '../services/midgard/types'
 import { getPoolDetail, toPoolData } from '../services/midgard/utils'
+import { PoolDetail } from '../types/generated/midgard'
 import { PoolTableRowData, PoolTableRowsData, PricePool } from '../views/pools/Pools.types'
 import { getPoolTableRowData } from '../views/pools/Pools.utils'
 import { isRuneNativeAsset } from './assetHelper'
@@ -52,7 +53,7 @@ export const getPoolTableRowsData = ({
   pricePoolData,
   network
 }: {
-  poolDetails: PoolDetails
+  poolDetails: PoolOverviewDetails
   pricePoolData: PoolData
   network: Network
 }): PoolTableRowsData => {
@@ -68,7 +69,7 @@ export const getPoolTableRowsData = ({
   // Transform `PoolDetails` -> PoolRowType
   return FP.pipe(
     poolDetails,
-    A.mapWithIndex<PoolDetail, O.Option<PoolTableRowData>>((index, poolDetail) => {
+    A.mapWithIndex<PoolOverviewDetail, O.Option<PoolTableRowData>>((index, poolDetail) => {
       // get symbol of PoolDetail
       const oPoolDetailSymbol: O.Option<string> = FP.pipe(
         O.fromNullable(assetFromString(poolDetail.asset ?? '')),
@@ -108,8 +109,8 @@ export const getPoolTableRowsData = ({
 /**
  * Filters a pool out with hightest value of run
  */
-export const getDeepestPool = (pools: PoolDetails): O.Option<PoolDetail> =>
-  pools.reduce((acc: O.Option<PoolDetail>, pool: PoolDetail) => {
+export const getDeepestPool = (pools: PoolOverviewDetails): O.Option<PoolOverviewDetail> =>
+  pools.reduce((acc: O.Option<PoolOverviewDetail>, pool: PoolOverviewDetail) => {
     const runeDepth = bnOrZero(pool.runeDepth)
     const prev = O.toNullable(acc)
     return runeDepth.isGreaterThanOrEqualTo(bnOrZero(prev?.runeDepth)) ? O.some(pool) : acc
@@ -118,7 +119,7 @@ export const getDeepestPool = (pools: PoolDetails): O.Option<PoolDetail> =>
 /**
  * Converts Asset's pool price according to runePrice in selectedPriceAsset
  */
-export const getAssetPoolPrice = (runePrice: BigNumber) => (poolDetail: PoolDetail) =>
+export const getAssetPoolPrice = (runePrice: BigNumber) => (poolDetail: Pick<PoolDetail, 'assetPrice'>) =>
   bnOrZero(poolDetail.assetPrice).multipliedBy(runePrice)
 
 /**
@@ -126,7 +127,7 @@ export const getAssetPoolPrice = (runePrice: BigNumber) => (poolDetail: PoolDeta
  */
 export const getPoolPriceValue = (
   { asset, amount }: Balance,
-  poolDetails: PoolDetails,
+  poolDetails: PoolOverviewDetails,
   selectedPricePoolData: PoolData
 ): O.Option<BaseAmount> => {
   return FP.pipe(

--- a/src/renderer/helpers/poolShareHelper.ts
+++ b/src/renderer/helpers/poolShareHelper.ts
@@ -2,7 +2,7 @@ import { baseAmount, BaseAmount, bn, bnOrZero } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 
 import { ZERO_BN } from '../const'
-import { PoolDetail } from '../services/midgard/types'
+import { PoolDetail } from '../types/generated/midgard'
 import { convertBaseAmountDecimal, THORCHAIN_DECIMAL } from './assetHelper'
 
 /**

--- a/src/renderer/services/binance/utils.ts
+++ b/src/renderer/services/binance/utils.ts
@@ -7,7 +7,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { BNB_DECIMAL, isRuneNativeAsset } from '../../helpers/assetHelper'
-import { PoolDetails } from '../midgard/types'
+import { PoolOverviewDetails } from '../midgard/types'
 import { getPoolDetail, toPoolData } from '../midgard/utils'
 
 /**
@@ -15,7 +15,7 @@ import { getPoolDetail, toPoolData } from '../midgard/utils'
  */
 export const getPoolPriceValue = (
   { asset, amount }: Balance,
-  poolDetails: PoolDetails,
+  poolDetails: PoolOverviewDetails,
   selectedPricePoolData: PoolData
 ): O.Option<BaseAmount> => {
   return FP.pipe(

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -32,8 +32,7 @@ import {
   PoolAssetDetailsLD,
   PendingPoolsStateLD,
   PoolAssetsLD,
-  PoolDetailLD,
-  PoolDetailsLD,
+  PoolOverviewDetailsLD,
   PoolsService,
   PoolsStateLD,
   SelectedPricePoolAsset,
@@ -46,7 +45,8 @@ import {
   PoolStatsDetailLD,
   PoolLegacyDetailLD,
   PoolLiquidityHistoryLD,
-  PoolLiquidityHistoryParams
+  PoolLiquidityHistoryParams,
+  PoolDetailLD
 } from './types'
 import {
   getPoolAddressesByChain,
@@ -165,7 +165,10 @@ const createPoolsService = (
   /**
    * Data of enabled `Pools` from Midgard
    */
-  const apiGetPoolsEnabled$: PoolDetailsLD = apiGetPools$({ status: GetPoolsStatusEnum.Available }, reloadPools$)
+  const apiGetPoolsEnabled$: PoolOverviewDetailsLD = apiGetPools$(
+    { status: GetPoolsStatusEnum.Available },
+    reloadPools$
+  )
 
   // `TriggerStream` to reload data of pending pools
   const { stream$: reloadPendingPools$, trigger: reloadPendingPools } = triggerStream()
@@ -173,7 +176,10 @@ const createPoolsService = (
   /**
    * Data of pending `Pools` from Midgard
    */
-  const apiGetPoolsPending$: PoolDetailsLD = apiGetPools$({ status: GetPoolsStatusEnum.Staged }, reloadPendingPools$)
+  const apiGetPoolsPending$: PoolOverviewDetailsLD = apiGetPools$(
+    { status: GetPoolsStatusEnum.Staged },
+    reloadPendingPools$
+  )
 
   // `TriggerStream` to reload data of all pools
   const { stream$: reloadAllPools$, trigger: reloadAllPools } = triggerStream()
@@ -181,7 +187,7 @@ const createPoolsService = (
   /**
    * Data of all `Pools`
    */
-  const apiGetPoolsAll$: PoolDetailsLD = apiGetPools$({ status: undefined }, reloadAllPools$)
+  const apiGetPoolsAll$: PoolOverviewDetailsLD = apiGetPools$({ status: undefined }, reloadAllPools$)
 
   /**
    * Helper to get (same) stream of `PoolDetailsLD` by given status
@@ -224,9 +230,6 @@ const createPoolsService = (
       liveData.chain((api) => {
         return FP.pipe(
           api.getPool({ asset: assetToString(asset) }),
-          // Setting empty values, since we don't need those in pool detail atm
-          // TODO (@asdgdx-team: Do we still need `poolSlipAverage` + `swappingTxCount` in PoolDetail ??
-          RxOp.map((poolDetail) => ({ poolSlipAverage: '', swappingTxCount: '', ...poolDetail })),
           RxOp.map(RD.success),
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
@@ -238,10 +241,10 @@ const createPoolsService = (
   /**
    * `PoolDetails` data from Midgard
    */
-  const apiGetPoolsData$: (assetOrAssets: string | string[], status?: GetPoolsStatusEnum) => PoolDetailsLD = (
-    assetOrAssets,
-    status
-  ) => {
+  const apiGetPoolOverviewDetails$: (
+    assetOrAssets: string | string[],
+    status?: GetPoolsStatusEnum
+  ) => PoolOverviewDetailsLD = (assetOrAssets, status) => {
     const assets = Array.isArray(assetOrAssets) ? assetOrAssets : [assetOrAssets]
 
     return FP.pipe(
@@ -251,8 +254,8 @@ const createPoolsService = (
       liveData.chain(
         O.fold(
           // TODO (@thatStrangeGuy | @veado) Add i18n
-          (): PoolDetailsLD => Rx.of(RD.failure(new Error('No pools available'))),
-          (poolsDetails): PoolDetailsLD => Rx.of(RD.success(poolsDetails))
+          (): PoolOverviewDetailsLD => Rx.of(RD.failure(new Error('No pools available'))),
+          (poolsDetails): PoolOverviewDetailsLD => Rx.of(RD.success(poolsDetails))
         )
       ),
       RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
@@ -279,7 +282,7 @@ const createPoolsService = (
     )
 
   // Factory to create a stream to get data of `PoolDetails`
-  const getPoolDetails$: (poolAssets$: PoolAssetsLD, status?: GetPoolsStatusEnum) => PoolDetailsLD = (
+  const getPoolOverviewDetails$: (poolAssets$: PoolAssetsLD, status?: GetPoolsStatusEnum) => PoolOverviewDetailsLD = (
     poolAssets$,
     status
   ) =>
@@ -291,7 +294,7 @@ const createPoolsService = (
       liveData.chain(
         O.fold(
           () => liveData.of([]),
-          (assets) => apiGetPoolsData$(assets, status)
+          (assets) => apiGetPoolOverviewDetails$(assets, status)
         )
       ),
       RxOp.shareReplay(1)
@@ -300,7 +303,7 @@ const createPoolsService = (
   /**
    * Loading queue to get `PoolDetails` of all pools
    */
-  const loadAllPoolsDetails$ = (): PoolDetailsLD => {
+  const loadAllPoolOverviewDetails$ = (): PoolOverviewDetailsLD => {
     const poolAssets$: PoolAssetsLD = FP.pipe(
       apiGetPoolsAll$,
       // Filter out all unknown / invalid assets created from asset strings
@@ -311,7 +314,7 @@ const createPoolsService = (
     )
 
     return FP.pipe(
-      getPoolDetails$(poolAssets$),
+      getPoolOverviewDetails$(poolAssets$),
       RxOp.startWith(RD.pending),
       RxOp.catchError((error: Error) => Rx.of(RD.failure(error)))
     )
@@ -320,9 +323,9 @@ const createPoolsService = (
   /**
    * `PoolDetails` of all pools
    */
-  const allPoolDetails$: PoolDetailsLD = reloadPools$.pipe(
+  const allPoolOverviewDetails$: PoolOverviewDetailsLD = reloadPools$.pipe(
     // start loading queue
-    RxOp.switchMap(loadAllPoolsDetails$),
+    RxOp.switchMap(loadAllPoolOverviewDetails$),
     // cache it to avoid reloading data by every subscription
     RxOp.shareReplay(1)
   )
@@ -340,7 +343,7 @@ const createPoolsService = (
       RxOp.shareReplay(1)
     )
     const assetDetails$ = getAssetDetails$(poolAssets$, GetPoolsStatusEnum.Available)
-    const poolDetails$ = getPoolDetails$(poolAssets$, GetPoolsStatusEnum.Available)
+    const poolDetails$ = getPoolOverviewDetails$(poolAssets$, GetPoolsStatusEnum.Available)
 
     const pricePools$: LiveData<Error, O.Option<PricePools>> = poolDetails$.pipe(
       RxOp.map((poolDetailsRD) =>
@@ -399,7 +402,7 @@ const createPoolsService = (
       RxOp.shareReplay(1)
     )
     const assetDetails$ = getAssetDetails$(poolAssets$, GetPoolsStatusEnum.Staged)
-    const poolDetails$ = getPoolDetails$(poolAssets$, GetPoolsStatusEnum.Staged)
+    const poolDetails$ = getPoolOverviewDetails$(poolAssets$, GetPoolsStatusEnum.Staged)
 
     return FP.pipe(
       liveData.sequenceS({
@@ -692,7 +695,7 @@ const createPoolsService = (
   return {
     poolsState$,
     pendingPoolsState$,
-    allPoolDetails$,
+    allPoolOverviewDetails$,
     setSelectedPricePoolAsset,
     selectedPricePoolAsset$,
     selectedPricePool$,

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -13,7 +13,7 @@ import {
   Network as NetworkInfo,
   Constants as ThorchainConstants,
   LastblockItem,
-  PoolDetail as MidgardPoolDetail,
+  PoolDetail,
   Health,
   PoolStatsDetail,
   GetPoolStatsPeriodEnum,
@@ -41,16 +41,19 @@ export type PoolAssetDetail = {
 export type PoolAssetDetails = PoolAssetDetail[]
 export type PoolAssetDetailsLD = LiveData<Error, PoolAssetDetails>
 
-export type PoolDetail = MidgardPoolDetail & {
+export type PoolDetailRD = RD.RemoteData<Error, PoolDetail>
+export type PoolDetailLD = LiveData<Error, PoolDetail>
+
+export type PoolOverviewDetail = PoolDetail & {
   poolSlipAverage: string
   swappingTxCount: string
 }
 
-export type PoolDetailRD = RD.RemoteData<Error, PoolDetail>
-export type PoolDetailLD = LiveData<Error, PoolDetail>
+export type PoolOverviewDetailRD = RD.RemoteData<Error, PoolOverviewDetail>
+export type PoolOverviewDetailLD = LiveData<Error, PoolOverviewDetail>
 
-export type PoolDetails = PoolDetail[]
-export type PoolDetailsLD = LiveData<Error, PoolDetails>
+export type PoolOverviewDetails = PoolOverviewDetail[]
+export type PoolOverviewDetailsLD = LiveData<Error, PoolOverviewDetails>
 
 /**
  * Hash map for storing `PoolData` (key: string of asset)
@@ -64,7 +67,7 @@ export type PriceDataIndex = {
 export type PoolsState = {
   assetDetails: PoolAssetDetails
   poolAssets: PoolAssets
-  poolDetails: PoolDetails
+  poolDetails: PoolOverviewDetails
   pricePools: O.Option<PricePools>
 }
 export type PoolsStateRD = RD.RemoteData<Error, PoolsState>
@@ -73,7 +76,7 @@ export type PoolsStateLD = LiveData<Error, PoolsState>
 export type PendingPoolsState = {
   assetDetails: PoolAssetDetails
   poolAssets: PoolAssets
-  poolDetails: PoolDetails
+  poolDetails: PoolOverviewDetails
 }
 export type PendingPoolsStateRD = RD.RemoteData<Error, PendingPoolsState>
 export type PendingPoolsStateLD = LiveData<Error, PendingPoolsState>
@@ -142,7 +145,7 @@ export type HealthLD = LiveData<Error, Health>
 export type PoolsService = {
   poolsState$: LiveData<Error, PoolsState>
   pendingPoolsState$: LiveData<Error, PendingPoolsState>
-  allPoolDetails$: LiveData<Error, PoolDetails>
+  allPoolOverviewDetails$: LiveData<Error, PoolOverviewDetails>
   setSelectedPricePoolAsset: (asset: PricePoolAsset) => void
   selectedPricePoolAsset$: Rx.Observable<SelectedPricePoolAsset>
   selectedPricePool$: Rx.Observable<SelectedPricePool>

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -26,7 +26,15 @@ import { PRICE_POOLS_WHITELIST, AssetBUSDBAF, ZERO_BN } from '../../const'
 import { eqAsset, eqPoolShare, eqPoolShares } from '../../helpers/fp/eq'
 import { RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { PricePool, PricePools } from '../../views/pools/Pools.types'
-import { PoolAddress, PoolAssetDetail, PoolDetail, PoolShare, PoolShares, PoolsState, PoolsStateRD } from './types'
+import {
+  PoolAddress,
+  PoolAssetDetail,
+  PoolOverviewDetail,
+  PoolShare,
+  PoolShares,
+  PoolsState,
+  PoolsStateRD
+} from './types'
 import {
   getAssetDetail,
   getPricePools,
@@ -62,11 +70,11 @@ describe('services/midgard/utils/', () => {
   })
 
   describe('getPricePools', () => {
-    const tomob = { asset: 'BNB.TOMOB-1E1', assetDepth: '1', runeDepth: '11' } as PoolDetail
-    const eth = { asset: 'ETH.ETH', assetDepth: '2', runeDepth: '22' } as PoolDetail
-    const BUSDBAF = { asset: 'BNB.BUSD-BAF', assetDepth: '3', runeDepth: '33' } as PoolDetail
-    const btc = { asset: 'BTC.BTC', assetDepth: '4', runeDepth: '44' } as PoolDetail
-    const lok = { asset: 'BNB.LOK-3C0', assetDepth: '5', runeDepth: '5' } as PoolDetail
+    const tomob = { asset: 'BNB.TOMOB-1E1', assetDepth: '1', runeDepth: '11' } as PoolOverviewDetail
+    const eth = { asset: 'ETH.ETH', assetDepth: '2', runeDepth: '22' } as PoolOverviewDetail
+    const BUSDBAF = { asset: 'BNB.BUSD-BAF', assetDepth: '3', runeDepth: '33' } as PoolOverviewDetail
+    const btc = { asset: 'BTC.BTC', assetDepth: '4', runeDepth: '44' } as PoolOverviewDetail
+    const lok = { asset: 'BNB.LOK-3C0', assetDepth: '5', runeDepth: '5' } as PoolOverviewDetail
 
     it('returns list of price pools in a right order', () => {
       const result = getPricePools([tomob, eth, BUSDBAF, btc, lok], PRICE_POOLS_WHITELIST)
@@ -190,8 +198,8 @@ describe('services/midgard/utils/', () => {
   })
 
   describe('getPoolDetail', () => {
-    const runeDetail = { asset: assetToString(AssetRuneNative) } as PoolDetail
-    const bnbDetail = { asset: assetToString(AssetBNB) } as PoolDetail
+    const runeDetail = { asset: assetToString(AssetRuneNative) } as PoolOverviewDetail
+    const bnbDetail = { asset: assetToString(AssetBNB) } as PoolOverviewDetail
 
     it('returns details of RUNE pool', () => {
       const result = getPoolDetail([runeDetail, bnbDetail], AssetRuneNative)
@@ -205,8 +213,8 @@ describe('services/midgard/utils/', () => {
   })
 
   describe('getPoolDetailsHashMap', () => {
-    const runeDetail = { asset: assetToString(AssetRuneNative) } as PoolDetail
-    const bnbDetail = { asset: assetToString(AssetBNB) } as PoolDetail
+    const runeDetail = { asset: assetToString(AssetRuneNative) } as PoolOverviewDetail
+    const bnbDetail = { asset: assetToString(AssetBNB) } as PoolOverviewDetail
 
     it('returns hashMap of pool details', () => {
       const result = getPoolDetailsHashMap([runeDetail, bnbDetail], AssetRuneNative)

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -16,11 +16,11 @@ import { InboundAddressesItem } from '../../types/generated/midgard'
 import { PricePoolAssets, PricePools, PricePoolAsset, PricePool } from '../../views/pools/Pools.types'
 import {
   PoolAssetDetails as PoolAssetsDetail,
-  PoolDetails,
+  PoolOverviewDetails,
   PoolsStateRD,
   SelectedPricePoolAsset,
   PoolAssetDetail,
-  PoolDetail,
+  PoolOverviewDetail,
   PoolShares,
   PoolShare,
   PoolAddress,
@@ -34,13 +34,13 @@ export const getAssetDetail = (assets: PoolAssetsDetail, ticker: string): O.Opti
     A.findFirst(({ asset }: PoolAssetDetail) => asset.ticker === ticker)
   )
 
-export const getPricePools = (pools: PoolDetails, whitelist?: PricePoolAssets): PricePools => {
+export const getPricePools = (pools: PoolOverviewDetails, whitelist?: PricePoolAssets): PricePools => {
   const poolDetails = !whitelist
     ? pools
     : pools.filter((detail) => whitelist.find((asset) => detail?.asset === assetToString(asset)))
 
   const pricePools = poolDetails
-    .map((detail: PoolDetail) => {
+    .map((detail: PoolOverviewDetail) => {
       // Since we have filtered pools based on whitelist before ^,
       // we can type asset as `PricePoolAsset` now
       const asset = assetFromString(detail?.asset ?? '') as PricePoolAsset
@@ -91,9 +91,9 @@ export const pricePoolSelectorFromRD = (
  * Gets a `PoolDetail by given Asset
  * It returns `None` if no `PoolDetail` has been found
  */
-export const getPoolDetail = (details: PoolDetails, asset: Asset): O.Option<PoolDetail> =>
+export const getPoolDetail = (details: PoolOverviewDetails, asset: Asset): O.Option<PoolOverviewDetail> =>
   FP.pipe(
-    details.find((detail: PoolDetail) => {
+    details.find((detail: PoolOverviewDetail) => {
       const { asset: detailAsset = '' } = detail
       const detailTicker = assetFromString(detailAsset)
       return detailTicker && eqAsset.equals(detailTicker, asset)
@@ -105,7 +105,7 @@ export const getPoolDetail = (details: PoolDetails, asset: Asset): O.Option<Pool
  * Converts PoolDetails to the appropriate HashMap
  * Keys of the end HasMap is PoolDetails[i].asset
  */
-export const getPoolDetailsHashMap = (poolDetails: PoolDetails, runeAsset: Asset): PoolsDataMap => {
+export const getPoolDetailsHashMap = (poolDetails: PoolOverviewDetails, runeAsset: Asset): PoolsDataMap => {
   const res = poolDetails.reduce<PoolsDataMap>((acc, cur) => {
     if (!cur.asset) {
       return acc
@@ -126,7 +126,7 @@ export const getPoolDetailsHashMap = (poolDetails: PoolDetails, runeAsset: Asset
 /**
  * Transforms `PoolDetail` into `PoolData` (provided by `asgardex-util`)
  */
-export const toPoolData = (detail: Pick<PoolDetail, 'assetDepth' | 'runeDepth'>): PoolData => ({
+export const toPoolData = (detail: Pick<PoolOverviewDetail, 'assetDepth' | 'runeDepth'>): PoolData => ({
   assetBalance: baseAmount(bnOrZero(detail.assetDepth)),
   runeBalance: baseAmount(bnOrZero(detail.runeDepth))
 })
@@ -235,7 +235,7 @@ export const getSharesByAssetAndType = ({
 export const getPoolAssetDetail = ({
   asset: assetString,
   assetPrice
-}: Pick<PoolDetail, 'assetPrice' | 'asset'>): O.Option<PoolAssetDetail> =>
+}: Pick<PoolOverviewDetail, 'assetPrice' | 'asset'>): O.Option<PoolAssetDetail> =>
   FP.pipe(
     assetString,
     assetFromString,
@@ -246,6 +246,6 @@ export const getPoolAssetDetail = ({
     }))
   )
 
-export const getPoolAssetsDetail: (_: Array<Pick<PoolDetail, 'assetPrice' | 'asset'>>) => PoolAssetsDetail = (
+export const getPoolAssetsDetail: (_: Array<Pick<PoolOverviewDetail, 'assetPrice' | 'asset'>>) => PoolAssetsDetail = (
   poolDetails
 ) => FP.pipe(poolDetails, A.filterMap(getPoolAssetDetail))

--- a/src/renderer/views/deposit/share/ShareView.tsx
+++ b/src/renderer/views/deposit/share/ShareView.tsx
@@ -14,9 +14,10 @@ import { useMidgardContext } from '../../../contexts/MidgardContext'
 import { to1e8BaseAmount } from '../../../helpers/assetHelper'
 import { RUNE_PRICE_POOL } from '../../../helpers/poolHelper'
 import * as ShareHelpers from '../../../helpers/poolShareHelper'
-import { PoolDetailRD, PoolDetail, PoolShareRD, PoolShare } from '../../../services/midgard/types'
+import { PoolDetailRD, PoolShareRD, PoolShare } from '../../../services/midgard/types'
 import { toPoolData } from '../../../services/midgard/utils'
 import { AssetWithDecimal } from '../../../types/asgardex'
+import { PoolDetail } from '../../../types/generated/midgard'
 import * as Styled from './ShareView.styles'
 
 type Props = {

--- a/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
+++ b/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
@@ -19,9 +19,10 @@ import { useWalletContext } from '../../../contexts/WalletContext'
 import { getAssetPoolPrice } from '../../../helpers/poolHelper'
 import * as ShareHelpers from '../../../helpers/poolShareHelper'
 import { DEFAULT_NETWORK } from '../../../services/const'
-import { PoolDetailRD, PoolShareRD, PoolDetail, PoolShare } from '../../../services/midgard/types'
+import { PoolDetailRD, PoolShareRD, PoolShare } from '../../../services/midgard/types'
 import { getBalanceByAsset } from '../../../services/wallet/util'
 import { AssetWithDecimal } from '../../../types/asgardex'
+import { PoolDetail } from '../../../types/generated/midgard'
 
 type Props = {
   asset: AssetWithDecimal

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -12,20 +12,23 @@ import { PoolDetails, Props as PoolDetailProps } from '../../components/pool/Poo
 import { PoolStatus } from '../../components/uielements/poolStatus'
 import { ZERO_ASSET_AMOUNT, ONE_BN } from '../../const'
 import { useMidgardContext } from '../../contexts/MidgardContext'
-import { PoolDetail } from '../../services/midgard/types'
+import { PoolDetailRD } from '../../services/midgard/types'
+import { PoolDetail, SwapHistory } from '../../types/generated/midgard'
 
-const getDepth = (data: PoolDetail, priceRatio: BigNumber = bn(1)) =>
+// TODO (@asgdx-team) Extract follwing helpers into PoolDetailsView.helper + add tests
+
+const getDepth = (data: Pick<PoolDetail, 'runeDepth'>, priceRatio: BigNumber = bn(1)) =>
   baseToAsset(baseAmount(bnOrZero(data.runeDepth).multipliedBy(priceRatio)))
 
-const get24hrVolume = (data: PoolDetail, priceRatio: BigNumber = bn(1)) =>
+const get24hrVolume = (data: Pick<PoolDetail, 'volume24h'>, priceRatio: BigNumber = bn(1)) =>
   baseToAsset(baseAmount(bnOrZero(data.volume24h).multipliedBy(priceRatio)))
 
-const getAllTimeVolume = (data: PoolDetail, priceRatio: BigNumber = bn(1)) =>
+const getAllTimeVolume = (data: Pick<PoolDetail, 'poolAPY'>, priceRatio: BigNumber = bn(1)) =>
   baseToAsset(baseAmount(bnOrZero(/*data.poolVolume*/ 0).multipliedBy(priceRatio)))
 
-const getTotalSwaps = (data: PoolDetail) => Number(data.swappingTxCount)
+const _getTotalSwaps = ({ meta }: SwapHistory) => Number(meta.totalCount)
 
-const getTotalStakers = (_data: PoolDetail) => Number(/*data.stakersCount ||*/ 0)
+const _getTotalStakers = (/* _data: ??? */) => 0
 
 const defaultDetailsProps: PoolDetailProps = {
   depth: ZERO_ASSET_AMOUNT,
@@ -51,7 +54,7 @@ export const PoolDetailsView: React.FC = () => {
 
   const priceRatio = useObservableState(priceRatio$, ONE_BN)
 
-  const poolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
+  const poolDetailRD: PoolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
 
   return FP.pipe(
     poolDetailRD,
@@ -61,14 +64,14 @@ export const PoolDetailsView: React.FC = () => {
       (e: Error) => {
         return <PoolStatus label={intl.formatMessage({ id: 'common.error' })} displayValue={e.message} />
       },
-      (data) => {
+      (poolDetail) => {
         return (
           <PoolDetails
-            depth={getDepth(data, priceRatio)}
-            volume24hr={get24hrVolume(data, priceRatio)}
-            allTimeVolume={getAllTimeVolume(data, priceRatio)}
-            totalSwaps={getTotalSwaps(data)}
-            totalStakers={getTotalStakers(data)}
+            depth={getDepth(poolDetail, priceRatio)}
+            volume24hr={get24hrVolume(poolDetail, priceRatio)}
+            allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
+            totalSwaps={0 /* getTotalSwaps(history) */}
+            totalStakers={0 /* getTotalStakers(poolDetail) */}
             priceSymbol={O.toUndefined(priceSymbol)}
           />
         )

--- a/src/renderer/views/pools/Pools.util.test.ts
+++ b/src/renderer/views/pools/Pools.util.test.ts
@@ -16,7 +16,7 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET, ERC20_TESTNET } from '../../../shared/mock/assets'
-import { ThorchainLastblock, PoolDetail } from '../../services/midgard/types'
+import { ThorchainLastblock, PoolOverviewDetail } from '../../services/midgard/types'
 import { Constants as ThorchainConstants } from '../../types/generated/midgard'
 import { GetPoolsStatusEnum } from '../../types/generated/midgard'
 import { PoolTableRowData } from './Pools.types'
@@ -38,7 +38,7 @@ describe('views/pools/utils', () => {
       poolSlipAverage: '11',
       swappingTxCount: '123',
       status: GetPoolsStatusEnum.Staged
-    } as PoolDetail
+    } as PoolOverviewDetail
 
     const pricePoolData: PoolData = {
       runeBalance: assetToBase(assetAmount(10)),

--- a/src/renderer/views/pools/Pools.utils.ts
+++ b/src/renderer/views/pools/Pools.utils.ts
@@ -8,7 +8,7 @@ import { Network } from '../../../shared/api/types'
 import { ONE_RUNE_BASE_AMOUNT } from '../../../shared/mock/amount'
 import { ZERO_BASE_AMOUNT } from '../../const'
 import { isChainAsset, isUSDAsset } from '../../helpers/assetHelper'
-import { PoolDetail } from '../../services/midgard/types'
+import { PoolOverviewDetail } from '../../services/midgard/types'
 import { PoolFilter } from '../../services/midgard/types'
 import { toPoolData } from '../../services/midgard/utils'
 import { GetPoolsStatusEnum, Constants as ThorchainConstants, LastblockItem } from '../../types/generated/midgard'
@@ -33,7 +33,7 @@ export const getPoolTableRowData = ({
   pricePoolData,
   network
 }: {
-  poolDetail: PoolDetail
+  poolDetail: PoolOverviewDetail
   pricePoolData: PoolData
   network: Network
 }): O.Option<PoolTableRowData> => {

--- a/src/renderer/views/wallet/PoolShareView.helper.ts
+++ b/src/renderer/views/wallet/PoolShareView.helper.ts
@@ -5,12 +5,12 @@ import * as O from 'fp-ts/lib/Option'
 
 import { PoolShareTableData } from '../../components/PoolShares/PoolShares.types'
 import * as ShareHelpers from '../../helpers/poolShareHelper'
-import { PoolDetails, PoolShares } from '../../services/midgard/types'
+import { PoolOverviewDetails, PoolShares } from '../../services/midgard/types'
 import { getPoolDetail, toPoolData } from '../../services/midgard/utils'
 
 export const getPoolShareTableData = (
   shares: PoolShares,
-  poolDetails: PoolDetails,
+  poolDetails: PoolOverviewDetails,
   pricePoolData: PoolData
 ): PoolShareTableData =>
   FP.pipe(

--- a/src/renderer/views/wallet/PoolShareView.tsx
+++ b/src/renderer/views/wallet/PoolShareView.tsx
@@ -34,7 +34,9 @@ export const PoolShareView: React.FC = (): JSX.Element => {
 
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { allPoolDetails$, selectedPricePool$, selectedPricePoolAsset$, reloadAllPools },
+    // TODO (@asgardex-team) Improve loading of pool details - no need to load all data
+    // @see https://github.com/thorchain/asgardex-electron/issues/1205
+    pools: { allPoolOverviewDetails$: allPoolDetails$, selectedPricePool$, selectedPricePoolAsset$, reloadAllPools },
     reloadNetworkInfo,
     shares: { combineSharesByAddresses$ }
   } = midgardService


### PR DESCRIPTION
## TL;DR
Rename `PoolDetail` to `PoolOverviewDetail`

## Summary
To get data for pool overview we currently do requests to:
- `pools` to get `PoolDetails` for all pools
-  `v2/history/waps/` to get more data for each pool

We do need this way for pool overview only, but not for other places where we need data of `PoolDetail` as well. To keep the differences, we do need another type `PoolOverviewDetail` besides Midgards `PoolDetail`.