### PR TITLE
Reload `inbound_addresses` on a regular basis

### DIFF
--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -499,8 +499,7 @@ const createPoolsService = (
   // Trigger to reload pool addresses (`inbound_addresses`)
   const { stream$: reloadPoolAddresses$, trigger: reloadPoolAddresses } = triggerStream()
 
-  // const poolAddressesInterval$ = Rx.timer(0 /* no delay for first value */, 5 * 60 * 1000 /* delay of 5 min  */)
-  const poolAddressesInterval$ = Rx.timer(0 /* no delay for first value */, 5 * 1000 /* delay of 5 min  */)
+  const poolAddressesInterval$ = Rx.timer(0 /* no delay for first value */, 5 * 60 * 1000 /* delay of 5 min  */)
   const poolAddresses$: PoolAddressesLD = Rx.combineLatest([reloadPoolAddresses$, poolAddressesInterval$]).pipe(
     RxOp.switchMap((_) => loadInboundAddresses$())
   )

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -160,6 +160,7 @@ export type PoolsService = {
   reloadAllPools: FP.Lazy<void>
   selectedPoolAddress$: PoolAddress$
   poolAddressesByChain$: (chain: Chain) => PoolAddressLD
+  reloadPoolAddresses: FP.Lazy<void>
   selectedPoolDetail$: PoolDetailLD
   reloadSelectedPoolDetail: (delay?: number) => void
   reloadPoolStatsDetail: FP.Lazy<void>

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Asset, AssetRuneNative, assetToString, BaseAmount, bn } from '@xchainjs/xchain-util'
@@ -61,7 +61,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
         selectedPricePoolAsset$,
         selectedPoolDetail$,
         reloadSelectedPoolDetail,
-        selectedPoolAddress$
+        selectedPoolAddress$,
+        reloadPoolAddresses
       },
       shares: { reloadShares }
     }
@@ -84,6 +85,11 @@ export const SymDepositView: React.FC<Props> = (props) => {
   } = useWalletContext()
 
   const { approveERC20Token$, isApprovedERC20Token$ } = useEthereumContext()
+
+  // reload inbound addresses at `onMount` to get always latest `pool address`
+  useEffect(() => {
+    reloadPoolAddresses()
+  }, [reloadPoolAddresses])
 
   const runPrice = useObservableState(priceRatio$, bn(1))
   const [selectedPricePoolAsset] = useObservableState(() => FP.pipe(selectedPricePoolAsset$, RxOp.map(O.toUndefined)))

--- a/src/renderer/views/wallet/UpgradeView.tsx
+++ b/src/renderer/views/wallet/UpgradeView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { assetFromString, BNBChain, THORChain } from '@xchainjs/xchain-util'
@@ -55,9 +55,14 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
 
   const {
     service: {
-      pools: { poolAddressesByChain$ }
+      pools: { poolAddressesByChain$, reloadPoolAddresses }
     }
   } = useMidgardContext()
+
+  // reload inbound addresses at `onMount` to get always latest `pool address`
+  useEffect(() => {
+    reloadPoolAddresses()
+  }, [reloadPoolAddresses])
 
   const [upgradeFeeRD] = useObservableState(
     () =>


### PR DESCRIPTION
- [x] Reload inbound_addresses every 5min
- [x] And by entering Swap, Deposit, Upgrade views
- [x] Swap: Fix `chainFeeRD` by introducing callback for `useObservableState`
 
Fix #1210 