### PR TITLE
Fix reload of balances

### DIFF
--- a/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
@@ -4,7 +4,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { BaseStory } from '@storybook/addons'
 import { assetAmount, AssetBNB, AssetRune67C, AssetRuneNative, assetToBase } from '@xchainjs/xchain-util'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
-import * as O from 'fp-ts/lib/Option'
 
 import { ZERO_BASE_AMOUNT } from '../../../const'
 import { WalletBalance, WalletBalances } from '../../../types/wallet'
@@ -34,17 +33,17 @@ const getBalances = (balances: WalletBalances) => NEA.fromArray<WalletBalance>(b
 const balances = getBalances([bnbBalance, runeBnbBalance, runeNativeBalance])
 
 export const StoryBNB: BaseStory<never, JSX.Element> = () => (
-  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={O.some(AssetBNB)} network="testnet" />
+  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={AssetBNB} network="testnet" />
 )
 StoryBNB.storyName = 'BNB'
 
 export const StoryRuneTxSuccess: BaseStory<never, JSX.Element> = () => (
-  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={O.some(AssetRune67C)} network="testnet" />
+  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={AssetRune67C} network="testnet" />
 )
 StoryRuneTxSuccess.storyName = 'RUNE - tx success'
 
 export const StoryRuneTxError: BaseStory<never, JSX.Element> = () => (
-  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={O.some(AssetRune67C)} network="testnet" />
+  <AssetDetails txsPageRD={RD.initial} balances={balances} asset={AssetRune67C} network="testnet" />
 )
 StoryRuneTxError.storyName = 'RUNE - tx error'
 
@@ -52,7 +51,7 @@ export const StoryRuneNoBalances: BaseStory<never, JSX.Element> = () => (
   <AssetDetails
     txsPageRD={RD.initial}
     balances={getBalances([runeBalanceEmpty, bnbBalance])}
-    asset={O.some(AssetRune67C)}
+    asset={AssetRune67C}
     network="testnet"
   />
 )
@@ -62,7 +61,7 @@ export const StoryRuneFeeNotCovered: BaseStory<never, JSX.Element> = () => (
   <AssetDetails
     txsPageRD={RD.initial}
     balances={getBalances([runeBnbBalance, bnbBalanceEmpty])}
-    asset={O.some(AssetRune67C)}
+    asset={AssetRune67C}
     network="mainnet"
   />
 )

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -7,7 +7,7 @@ import {
   reloadBalances,
   balancesState$,
   chainBalances$,
-  reloadBalances$,
+  reloadBalancesByChain,
   keystoreService,
   selectedAsset$,
   loadTxs,
@@ -23,7 +23,7 @@ type WalletContextValue = {
   balancesState$: typeof balancesState$
   chainBalances$: typeof chainBalances$
   loadTxs: typeof loadTxs
-  reloadBalances$: typeof reloadBalances$
+  reloadBalancesByChain: typeof reloadBalancesByChain
   getExplorerTxUrl$: typeof getExplorerTxUrl$
   selectedAsset$: typeof selectedAsset$
   getTxs$: typeof getTxs$
@@ -34,7 +34,7 @@ type WalletContextValue = {
 const initialContext: WalletContextValue = {
   keystoreService,
   reloadBalances,
-  reloadBalances$,
+  reloadBalancesByChain,
   loadTxs,
   balancesState$,
   chainBalances$,

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -21,7 +21,6 @@ import { WalletBalancesRD } from '../clients'
 import * as ETH from '../ethereum'
 import * as LTC from '../litecoin'
 import * as THOR from '../thorchain'
-// import { selectedAsset$ } from './common'
 import { INITIAL_BALANCES_STATE } from './const'
 import { BalancesState, ChainBalances$, ChainBalance$, ChainBalance } from './types'
 import { sortBalances } from './util'
@@ -36,7 +35,6 @@ export const reloadBalances: FP.Lazy<void> = () => {
 }
 
 export const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
-  console.log('reloadBalancesByChain:', chain)
   switch (chain) {
     case 'BNB':
       return BNB.reloadBalances
@@ -54,10 +52,6 @@ export const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) =>
       return () => {}
   }
 }
-
-// export const reloadBalances$: Rx.Observable<O.Option<LoadBalancesHandler>> = selectedAsset$.pipe(
-//   RxOp.map(O.map(({ chain }) => reloadBalancesByChain(chain)))
-// )
 
 /**
  * Transforms THOR balances into `ChainBalances`

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -21,9 +21,9 @@ import { WalletBalancesRD } from '../clients'
 import * as ETH from '../ethereum'
 import * as LTC from '../litecoin'
 import * as THOR from '../thorchain'
-import { selectedAsset$ } from './common'
+// import { selectedAsset$ } from './common'
 import { INITIAL_BALANCES_STATE } from './const'
-import { BalancesState, LoadBalancesHandler, ChainBalances$, ChainBalance$, ChainBalance } from './types'
+import { BalancesState, ChainBalances$, ChainBalance$, ChainBalance } from './types'
 import { sortBalances } from './util'
 
 export const reloadBalances: FP.Lazy<void> = () => {
@@ -35,7 +35,8 @@ export const reloadBalances: FP.Lazy<void> = () => {
   BCH.reloadBalances()
 }
 
-const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
+export const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
+  console.log('reloadBalancesByChain:', chain)
   switch (chain) {
     case 'BNB':
       return BNB.reloadBalances
@@ -54,9 +55,9 @@ const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
   }
 }
 
-export const reloadBalances$: Rx.Observable<O.Option<LoadBalancesHandler>> = selectedAsset$.pipe(
-  RxOp.map(O.map(({ chain }) => reloadBalancesByChain(chain)))
-)
+// export const reloadBalances$: Rx.Observable<O.Option<LoadBalancesHandler>> = selectedAsset$.pipe(
+//   RxOp.map(O.map(({ chain }) => reloadBalancesByChain(chain)))
+// )
 
 /**
  * Transforms THOR balances into `ChainBalances`

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -1,4 +1,4 @@
-import { reloadBalances, reloadBalances$, balancesState$, chainBalances$ } from './balances'
+import { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } from './balances'
 import { setSelectedAsset, selectedAsset$ } from './common'
 import { keystoreService, removeKeystore } from './keystore'
 import { getTxs$, loadTxs, explorerUrl$, getExplorerTxUrl$, resetTxsPage } from './transaction'
@@ -17,7 +17,7 @@ export {
   getExplorerTxUrl$,
   getTxs$,
   reloadBalances,
-  reloadBalances$,
+  reloadBalancesByChain,
   balancesState$,
   chainBalances$
 }

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -80,9 +80,9 @@ export type BalancesState = {
 }
 
 export type LoadTxsHandler = (props: LoadTxsParams) => void
-export type ResetTxsPageHandler = () => void
+export type ResetTxsPageHandler = FP.Lazy<void>
 
-export type LoadBalancesHandler = () => void
+export type LoadBalancesHandler = FP.Lazy<void>
 
 export enum ErrorId {
   GET_BALANCES = 'GET_BALANCES',

--- a/src/renderer/views/wallet/UpgradeView.tsx
+++ b/src/renderer/views/wallet/UpgradeView.tsx
@@ -44,7 +44,7 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
     balancesState$,
     getExplorerTxUrl$,
     keystoreService: { validatePassword$ },
-    reloadBalances
+    reloadBalancesByChain
   } = useWalletContext()
   const { balances: oBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 
@@ -150,7 +150,7 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
               fee={upgradeFeeRD}
               balances={oBalances}
               successActionHandler={successActionHandler}
-              reloadBalancesHandler={reloadBalances}
+              reloadBalancesHandler={reloadBalancesByChain(runeBnbAsset.chain)}
               network={network}
             />
           </>


### PR DESCRIPTION
- [x] Remove `reloadBalances$` (for using `reloadBalancesByChain` only)
- [x] `UpgradeView`: Fix reload of balances by  using `reloadBalancesByChain`
- [x] `AssetDetail`: Fix reload of balances by  using `reloadBalancesByChain`
- [x] `AssetDetail`: `asset: Option<Asset>` -> `asset: Asset`  
- [x] `AssetDetail`: Show `ErrorView` in case of invalid asset in route


Fix #1209 
Fix #1232 