### PR TITLE
Pool detail history

### DIFF
--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { assetAmount, AssetETH, bn } from '@xchainjs/xchain-util'
-import * as O from 'fp-ts/lib/Option'
 
 import { PoolDetails } from './PoolDetails'
 
@@ -18,7 +17,8 @@ export const PoolDetailsStory = () => {
       totalStakers={307}
       priceUSD={assetAmount(1)}
       priceSymbol={'R'}
-      asset={O.some(AssetETH)}
+      asset={AssetETH}
+      HistoryView={() => <>Actions History Here</>}
     />
   )
 }

--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { assetAmount, AssetETH, bn } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/Option'
 
 import { PoolDetails } from './PoolDetails'
 
@@ -17,7 +18,7 @@ export const PoolDetailsStory = () => {
       totalStakers={307}
       priceUSD={assetAmount(1)}
       priceSymbol={'R'}
-      asset={AssetETH}
+      asset={O.some(AssetETH)}
       HistoryView={() => <>Actions History Here</>}
     />
   )

--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { assetAmount, AssetETH, bn } from '@xchainjs/xchain-util'
-import * as O from 'fp-ts/Option'
 
 import { PoolDetails } from './PoolDetails'
 
@@ -18,7 +17,7 @@ export const PoolDetailsStory = () => {
       totalStakers={307}
       priceUSD={assetAmount(1)}
       priceSymbol={'R'}
-      asset={O.some(AssetETH)}
+      asset={AssetETH}
       HistoryView={() => <>Actions History Here</>}
     />
   )

--- a/src/renderer/components/pool/PoolDetails.style.tsx
+++ b/src/renderer/components/pool/PoolDetails.style.tsx
@@ -13,5 +13,6 @@ export const Container = styled(A.Row)`
 `
 
 export const TopContainer = styled(A.Row)`
+  width: 100%;
   margin-bottom: 10px;
 `

--- a/src/renderer/components/pool/PoolDetails.style.tsx
+++ b/src/renderer/components/pool/PoolDetails.style.tsx
@@ -11,3 +11,7 @@ export const Container = styled(A.Row)`
     padding: 0;
   `}
 `
+
+export const TopContainer = styled(A.Row)`
+  margin-bottom: 10px;
+`

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -60,28 +60,30 @@ export const PoolDetails: React.FC<Props> = ({
   )
   return (
     <Styled.Container>
-      <A.Col span={24}>
-        <PoolTitle asset={asset} priceUSD={priceUSD} isLoading={isLoading} />
-      </A.Col>
-      <A.Col xs={24} md={8}>
-        <PoolCards
-          depth={depth}
-          volume24hr={volume24hr}
-          allTimeVolume={allTimeVolume}
-          totalStakers={totalStakers}
-          totalSwaps={totalSwaps}
-          priceSymbol={priceSymbol}
-          depthTrend={depthTrend}
-          volume24hrTrend={volume24hrTrend}
-          allTimeVolumeTrend={allTimeVolumeTrend}
-          totalSwapsTrend={totalSwapsTrend}
-          totalStakersTrend={totalStakersTrend}
-          isLoading={isLoading}
-        />
-      </A.Col>
-      <A.Col xs={24} md={16}>
-        <PoolChart isLoading={isLoading} />
-      </A.Col>
+      <Styled.TopContainer>
+        <A.Col span={24}>
+          <PoolTitle asset={asset} priceUSD={priceUSD} isLoading={isLoading} />
+        </A.Col>
+        <A.Col xs={24} md={8}>
+          <PoolCards
+            depth={depth}
+            volume24hr={volume24hr}
+            allTimeVolume={allTimeVolume}
+            totalStakers={totalStakers}
+            totalSwaps={totalSwaps}
+            priceSymbol={priceSymbol}
+            depthTrend={depthTrend}
+            volume24hrTrend={volume24hrTrend}
+            allTimeVolumeTrend={allTimeVolumeTrend}
+            totalSwapsTrend={totalSwapsTrend}
+            totalStakersTrend={totalStakersTrend}
+            isLoading={isLoading}
+          />
+        </A.Col>
+        <A.Col xs={24} md={16}>
+          <PoolChart isLoading={isLoading} />
+        </A.Col>
+      </Styled.TopContainer>
       <A.Col span={24}>{renderHistoryView}</A.Col>
     </Styled.Container>
   )

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -8,11 +8,10 @@ import * as O from 'fp-ts/lib/Option'
 import { PoolCards } from './PoolCards'
 import { PoolChart } from './PoolChart'
 import * as Styled from './PoolDetails.style'
-import { PoolHistory } from './PoolHistory'
 import { PoolTitle } from './PoolTitle'
 
 export type Props = {
-  asset: O.Option<Asset>
+  asset: Asset
   depth: AssetAmount
   depthTrend?: BigNumber
   volume24hr: AssetAmount
@@ -27,6 +26,7 @@ export type Props = {
   priceUSD: AssetAmount
   priceSymbol?: string
   isLoading?: boolean
+  HistoryView: React.ComponentType<{ poolAsset: Asset }>
 }
 
 export const PoolDetails: React.FC<Props> = ({
@@ -43,12 +43,13 @@ export const PoolDetails: React.FC<Props> = ({
   allTimeVolumeTrend,
   totalSwapsTrend,
   totalStakersTrend,
-  isLoading
+  isLoading,
+  HistoryView
 }) => {
   return (
     <Styled.Container>
       <A.Col span={24}>
-        <PoolTitle asset={asset} priceUSD={priceUSD} isLoading={isLoading} />
+        <PoolTitle asset={O.some(asset)} priceUSD={priceUSD} isLoading={isLoading} />
       </A.Col>
       <A.Col xs={24} md={8}>
         <PoolCards
@@ -70,7 +71,7 @@ export const PoolDetails: React.FC<Props> = ({
         <PoolChart isLoading={isLoading} />
       </A.Col>
       <A.Col span={24}>
-        <PoolHistory isLoading={isLoading} />
+        <HistoryView poolAsset={asset} />
       </A.Col>
     </Styled.Container>
   )

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { Asset, AssetAmount } from '@xchainjs/xchain-util'
 import * as A from 'antd'
 import BigNumber from 'bignumber.js'
-import * as O from 'fp-ts/lib/Option'
+import * as FP from 'fp-ts/function'
+import * as O from 'fp-ts/Option'
 
 import { PoolCards } from './PoolCards'
 import { PoolChart } from './PoolChart'
@@ -11,7 +12,7 @@ import * as Styled from './PoolDetails.style'
 import { PoolTitle } from './PoolTitle'
 
 export type Props = {
-  asset: Asset
+  asset: O.Option<Asset>
   depth: AssetAmount
   depthTrend?: BigNumber
   volume24hr: AssetAmount
@@ -46,10 +47,21 @@ export const PoolDetails: React.FC<Props> = ({
   isLoading,
   HistoryView
 }) => {
+  const renderHistoryView = useMemo(
+    () =>
+      FP.pipe(
+        asset,
+        O.fold(
+          () => <></>,
+          (asset) => <HistoryView poolAsset={asset} />
+        )
+      ),
+    [asset, HistoryView]
+  )
   return (
     <Styled.Container>
       <A.Col span={24}>
-        <PoolTitle asset={O.some(asset)} priceUSD={priceUSD} isLoading={isLoading} />
+        <PoolTitle asset={asset} priceUSD={priceUSD} isLoading={isLoading} />
       </A.Col>
       <A.Col xs={24} md={8}>
         <PoolCards
@@ -70,9 +82,7 @@ export const PoolDetails: React.FC<Props> = ({
       <A.Col xs={24} md={16}>
         <PoolChart isLoading={isLoading} />
       </A.Col>
-      <A.Col span={24}>
-        <HistoryView poolAsset={asset} />
-      </A.Col>
+      <A.Col span={24}>{renderHistoryView}</A.Col>
     </Styled.Container>
   )
 }

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { Asset, AssetAmount } from '@xchainjs/xchain-util'
 import * as A from 'antd'
 import BigNumber from 'bignumber.js'
-import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 
 import { PoolCards } from './PoolCards'
@@ -12,7 +11,7 @@ import * as Styled from './PoolDetails.style'
 import { PoolTitle } from './PoolTitle'
 
 export type Props = {
-  asset: O.Option<Asset>
+  asset: Asset
   depth: AssetAmount
   depthTrend?: BigNumber
   volume24hr: AssetAmount
@@ -47,22 +46,11 @@ export const PoolDetails: React.FC<Props> = ({
   isLoading,
   HistoryView
 }) => {
-  const renderHistoryView = useMemo(
-    () =>
-      FP.pipe(
-        asset,
-        O.fold(
-          () => <></>,
-          (asset) => <HistoryView poolAsset={asset} />
-        )
-      ),
-    [asset, HistoryView]
-  )
   return (
     <Styled.Container>
       <Styled.TopContainer>
         <A.Col span={24}>
-          <PoolTitle asset={asset} priceUSD={priceUSD} isLoading={isLoading} />
+          <PoolTitle asset={O.some(asset)} priceUSD={priceUSD} isLoading={isLoading} />
         </A.Col>
         <A.Col xs={24} md={8}>
           <PoolCards
@@ -84,7 +72,9 @@ export const PoolDetails: React.FC<Props> = ({
           <PoolChart isLoading={isLoading} />
         </A.Col>
       </Styled.TopContainer>
-      <A.Col span={24}>{renderHistoryView}</A.Col>
+      <A.Col span={24}>
+        <HistoryView poolAsset={asset} />
+      </A.Col>
     </Styled.Container>
   )
 }

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
@@ -148,7 +148,6 @@ export const History: Story<{ dataStatus: RDStatus }> = ({ dataStatus }) => {
       actionsPageRD={res}
       changePaginationHandler={setCurrentPage}
       currentPage={currentPage}
-      clickTxLinkHandler={console.log}
     />
   )
 }

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
@@ -19,7 +19,7 @@ import * as Styled from './PoolActionsHistoryTable.styles'
 import { Props } from './types'
 
 export const PoolActionsHistoryTable: React.FC<Props> = ({
-  clickTxLinkHandler,
+  goToTx,
   changePaginationHandler,
   actionsPageRD,
   prevActionsPage = O.none,
@@ -61,12 +61,10 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
         action.in,
         A.head,
         O.alt(() => A.head(action.out)),
-        O.map(({ txID }) => (
-          <CommonStyled.ExternalLinkIcon key="external link" onClick={() => clickTxLinkHandler(txID)} />
-        )),
+        O.map(({ txID }) => <CommonStyled.ExternalLinkIcon key="external link" onClick={() => goToTx(txID)} />),
         O.getOrElse(() => <></>)
       ),
-    [clickTxLinkHandler]
+    [goToTx]
   )
 
   const linkColumn: ColumnType<PoolAction> = useMemo(

--- a/src/renderer/components/poolActionsHistory/types.ts
+++ b/src/renderer/components/poolActionsHistory/types.ts
@@ -10,7 +10,6 @@ export type Props = {
   prevActionsPage?: O.Option<PoolActionsHistoryPage>
   goToTx: (txHash: string) => void
   changePaginationHandler: (page: number) => void
-  clickTxLinkHandler: (txHash: string) => void
   currentFilter: Filter
   setFilter: (filter: Filter) => void
   className?: string

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -389,7 +389,6 @@ const createPoolsService = (
         RxOp.switchMap(() => Rx.of(oSelectedPoolAsset))
       )
     ),
-    RxOp.filter(O.isSome),
     RxOp.switchMap((selectedPoolAsset) => {
       return FP.pipe(
         selectedPoolAsset,

--- a/src/renderer/views/pool/PoolDetailsView.styles.ts
+++ b/src/renderer/views/pool/PoolDetailsView.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+import { BackLink as BackLinkUI } from '../../components/uielements/backLink'
+
+export const ControlsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+export const BackLink = styled(BackLinkUI)`
+  margin: 0 !important;
+`

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -56,7 +56,7 @@ export const PoolDetailsView: React.FC = () => {
   const {
     service: {
       pools: { selectedPoolDetail$, priceRatio$, selectedPricePoolAssetSymbol$, reloadSelectedPoolDetail },
-      poolActionsHistory: { reloadActionsHistory },
+      poolActionsHistory: { reloadActionsHistory, isHistoryLoading$ },
       setSelectedPoolAsset
     }
   } = useMidgardContext()
@@ -86,6 +86,8 @@ export const PoolDetailsView: React.FC = () => {
 
   const priceRatio = useObservableState(priceRatio$, ONE_BN)
 
+  const isHistoryLoading = useObservableState(isHistoryLoading$, false)
+
   const poolDetailRD: PoolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
 
   const onRefreshData = useCallback(() => {
@@ -93,13 +95,17 @@ export const PoolDetailsView: React.FC = () => {
     reloadActionsHistory()
   }, [reloadSelectedPoolDetail, reloadActionsHistory])
 
+  const refreshButtonDisabled = useMemo(() => {
+    return isHistoryLoading || FP.pipe(poolDetailRD, RD.isPending)
+  }, [isHistoryLoading, poolDetailRD])
+
   const prev = useRef<React.ReactElement>()
 
   return (
     <>
       <Styled.ControlsContainer>
         <Styled.BackLink />
-        <RefreshButton clickHandler={onRefreshData} />
+        <RefreshButton clickHandler={onRefreshData} disabled={refreshButtonDisabled} />
       </Styled.ControlsContainer>
       {FP.pipe(
         RD.combine(routeAssetRD, poolDetailRD),

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -49,7 +49,6 @@ const defaultDetailsProps: PoolDetailProps = {
   HistoryView: PoolHistory
 }
 
-const renderPendingView = () => <PoolDetails {...defaultDetailsProps} isLoading={true} />
 const renderInitialView = () => <PoolDetails {...defaultDetailsProps} />
 
 export const PoolDetailsView: React.FC = () => {
@@ -99,7 +98,7 @@ export const PoolDetailsView: React.FC = () => {
     return isHistoryLoading || FP.pipe(poolDetailRD, RD.isPending)
   }, [isHistoryLoading, poolDetailRD])
 
-  const prev = useRef<React.ReactElement>()
+  const prevProps = useRef<PoolDetailProps>(defaultDetailsProps)
 
   return (
     <>
@@ -111,24 +110,24 @@ export const PoolDetailsView: React.FC = () => {
         RD.combine(routeAssetRD, poolDetailRD),
         RD.fold(
           renderInitialView,
-          () => prev.current || renderPendingView(),
+          () => <PoolDetails {...prevProps.current} isLoading />,
           (e: Error) => {
             return <PoolStatus label={intl.formatMessage({ id: 'common.error' })} displayValue={e.message} />
           },
           ([asset, poolDetail]) => {
-            return (prev.current = (
-              <PoolDetails
-                asset={O.some(asset)}
-                depth={getDepth(poolDetail, priceRatio)}
-                volume24hr={get24hrVolume(poolDetail, priceRatio)}
-                allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
-                totalSwaps={0 /* getTotalSwaps(history) */}
-                totalStakers={0 /* getTotalStakers(poolDetail) */}
-                priceUSD={getPriceUSD(poolDetail, priceRatio)}
-                priceSymbol={O.toUndefined(priceSymbol)}
-                HistoryView={PoolHistory}
-              />
-            ))
+            prevProps.current = {
+              asset: O.some(asset),
+              depth: getDepth(poolDetail, priceRatio),
+              volume24hr: get24hrVolume(poolDetail, priceRatio),
+              allTimeVolume: getAllTimeVolume(poolDetail, priceRatio),
+              totalSwaps: 0 /* getTotalSwaps(history) */,
+              totalStakers: 0 /* getTotalStakers(poolDetail) */,
+              priceUSD: getPriceUSD(poolDetail, priceRatio),
+              priceSymbol: O.toUndefined(priceSymbol),
+              HistoryView: PoolHistory
+            }
+
+            return <PoolDetails {...prevProps.current} />
           }
         )
       )}

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -10,8 +10,8 @@ import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
 
 import { PoolDetails, Props as PoolDetailProps } from '../../components/pool/PoolDetails'
+import { ErrorView } from '../../components/shared/error'
 import { RefreshButton } from '../../components/uielements/button'
-import { PoolStatus } from '../../components/uielements/poolStatus'
 import { ZERO_ASSET_AMOUNT, ONE_BN } from '../../const'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { PoolDetailRouteParams } from '../../routes/pools/detail'
@@ -103,20 +103,15 @@ export const PoolDetailsView: React.FC = () => {
       {FP.pipe(
         oRouteAsset,
         O.fold(
-          () => (
-            <PoolStatus
-              label={intl.formatMessage({ id: 'common.error' })}
-              displayValue={intl.formatMessage({ id: 'routes.invalid.asset' }, { asset })}
-            />
-          ),
+          () => <ErrorView title={intl.formatMessage({ id: 'routes.invalid.asset' }, { asset })} />,
           (asset) =>
             FP.pipe(
               poolDetailRD,
               RD.fold(
                 () => <PoolDetails asset={asset} {...defaultDetailsProps} />,
                 () => <PoolDetails asset={asset} {...prevProps.current} isLoading />,
-                (e: Error) => {
-                  return <PoolStatus label={intl.formatMessage({ id: 'common.error' })} displayValue={e.message} />
+                ({ message }: Error) => {
+                  return <ErrorView title={message} />
                 },
                 (poolDetail) => {
                   prevProps.current = {

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -10,6 +10,7 @@ import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
 
 import { PoolDetails, Props as PoolDetailProps } from '../../components/pool/PoolDetails'
+import { BackLink } from '../../components/uielements/backLink'
 import { PoolStatus } from '../../components/uielements/poolStatus'
 import { ZERO_ASSET_AMOUNT, ONE_BN } from '../../const'
 import { useMidgardContext } from '../../contexts/MidgardContext'
@@ -92,16 +93,19 @@ export const PoolDetailsView: React.FC = () => {
       },
       ([asset, poolDetail]) => {
         return (
-          <PoolDetails
-            asset={O.some(asset)}
-            depth={getDepth(poolDetail, priceRatio)}
-            volume24hr={get24hrVolume(poolDetail, priceRatio)}
-            allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
-            totalSwaps={0 /* getTotalSwaps(history) */}
-            totalStakers={0 /* getTotalStakers(poolDetail) */}
-            priceUSD={getPriceUSD(poolDetail, priceRatio)}
-            priceSymbol={O.toUndefined(priceSymbol)}
-          />
+          <>
+            <BackLink />
+            <PoolDetails
+              asset={O.some(asset)}
+              depth={getDepth(poolDetail, priceRatio)}
+              volume24hr={get24hrVolume(poolDetail, priceRatio)}
+              allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
+              totalSwaps={0 /* getTotalSwaps(history) */}
+              totalStakers={0 /* getTotalStakers(poolDetail) */}
+              priceUSD={getPriceUSD(poolDetail, priceRatio)}
+              priceSymbol={O.toUndefined(priceSymbol)}
+            />
+          </>
         )
       }
     )

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { assetAmount, assetFromString, baseAmount, baseToAsset, bn, bnOrZero } from '@xchainjs/xchain-util'
+import { Asset, assetAmount, assetFromString, baseAmount, baseToAsset, bn, bnOrZero } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
-import * as O from 'fp-ts/lib/Option'
+import * as O from 'fp-ts/Option'
 import * as FP from 'fp-ts/pipeable'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
@@ -17,6 +17,7 @@ import { useMidgardContext } from '../../contexts/MidgardContext'
 import { PoolDetailRouteParams } from '../../routes/pools/detail'
 import { PoolDetailRD } from '../../services/midgard/types'
 import { PoolDetail, SwapHistory } from '../../types/generated/midgard'
+import { PoolHistory } from './PoolHistoryView'
 
 // TODO (@asgdx-team) Extract follwing helpers into PoolDetailsView.helper + add tests
 
@@ -36,18 +37,20 @@ const _getTotalSwaps = ({ meta }: SwapHistory) => Number(meta.totalCount)
 
 const _getTotalStakers = (/* _data: ??? */) => 0
 
-const defaultDetailsProps: PoolDetailProps = {
-  asset: O.none,
+const defaultDetailsProps: Omit<PoolDetailProps, 'asset'> = {
   depth: ZERO_ASSET_AMOUNT,
   volume24hr: ZERO_ASSET_AMOUNT,
   allTimeVolume: ZERO_ASSET_AMOUNT,
   totalSwaps: 0,
   totalStakers: 0,
-  priceUSD: ZERO_ASSET_AMOUNT
+  priceUSD: ZERO_ASSET_AMOUNT,
+  HistoryView: PoolHistory
 }
 
-const renderPendingView = () => <PoolDetails {...defaultDetailsProps} isLoading={true} />
-const renderInitialView = () => <PoolDetails {...defaultDetailsProps} />
+const renderPendingView = (asset: Asset) => () => (
+  <PoolDetails asset={asset} {...defaultDetailsProps} isLoading={true} />
+)
+const renderInitialView = (asset: Asset) => () => <PoolDetails asset={asset} {...defaultDetailsProps} />
 
 export const PoolDetailsView: React.FC = () => {
   const {
@@ -73,10 +76,6 @@ export const PoolDetailsView: React.FC = () => {
     }
   }, [oRouteAsset, setSelectedPoolAsset])
 
-  const routeAssetRD = RD.fromOption(oRouteAsset, () =>
-    Error(intl.formatMessage({ id: 'routes.invalid.asset' }, { asset }))
-  )
-
   const priceSymbol = useObservableState(selectedPricePoolAssetSymbol$, O.none)
 
   const priceRatio = useObservableState(priceRatio$, ONE_BN)
@@ -84,30 +83,41 @@ export const PoolDetailsView: React.FC = () => {
   const poolDetailRD: PoolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
 
   return FP.pipe(
-    RD.combine(routeAssetRD, poolDetailRD),
-    RD.fold(
-      renderInitialView,
-      renderPendingView,
-      (e: Error) => {
-        return <PoolStatus label={intl.formatMessage({ id: 'common.error' })} displayValue={e.message} />
-      },
-      ([asset, poolDetail]) => {
-        return (
-          <>
-            <BackLink />
-            <PoolDetails
-              asset={O.some(asset)}
-              depth={getDepth(poolDetail, priceRatio)}
-              volume24hr={get24hrVolume(poolDetail, priceRatio)}
-              allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
-              totalSwaps={0 /* getTotalSwaps(history) */}
-              totalStakers={0 /* getTotalStakers(poolDetail) */}
-              priceUSD={getPriceUSD(poolDetail, priceRatio)}
-              priceSymbol={O.toUndefined(priceSymbol)}
-            />
-          </>
+    oRouteAsset,
+    O.fold(
+      () => (
+        <PoolStatus
+          label={intl.formatMessage({ id: 'common.error' })}
+          displayValue={intl.formatMessage({ id: 'routes.invalid.asset' }, { asset })}
+        />
+      ),
+      (asset) =>
+        FP.pipe(
+          poolDetailRD,
+          RD.fold(
+            renderInitialView(asset),
+            renderPendingView(asset),
+            (e) => <PoolStatus label={intl.formatMessage({ id: 'common.error' })} displayValue={e.message} />,
+            (poolDetail) => {
+              return (
+                <>
+                  <BackLink />
+                  <PoolDetails
+                    asset={asset}
+                    depth={getDepth(poolDetail, priceRatio)}
+                    volume24hr={get24hrVolume(poolDetail, priceRatio)}
+                    allTimeVolume={getAllTimeVolume(poolDetail, priceRatio)}
+                    totalSwaps={0 /* getTotalSwaps(history) */}
+                    totalStakers={0 /* getTotalStakers(poolDetail) */}
+                    priceUSD={getPriceUSD(poolDetail, priceRatio)}
+                    priceSymbol={O.toUndefined(priceSymbol)}
+                    HistoryView={PoolHistory}
+                  />
+                </>
+              )
+            }
+          )
         )
-      }
     )
   )
 }

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import { Asset } from '@xchainjs/xchain-util'
+
+type Props = {
+  poolAsset: Asset
+}
+export const PoolHistory: React.FC<Props> = () => {
+  return <>pool history</>
+}

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -102,7 +102,6 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
       prevActionsPage={prevActionsPage.current}
       goToTx={goToTx}
       changePaginationHandler={setCurrentPage}
-      clickTxLinkHandler={goToTx}
       currentFilter={requestParams.current.type || 'ALL'}
       setFilter={setFilter}
     />

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -1,10 +1,110 @@
-import React from 'react'
+import React, { useCallback, useRef } from 'react'
 
-import { Asset } from '@xchainjs/xchain-util'
+import * as RD from '@devexperts/remote-data-ts'
+import { Asset, assetToString } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/function'
+import * as O from 'fp-ts/Option'
+import { useObservableState } from 'observable-hooks'
+import * as RxOp from 'rxjs/operators'
+
+import { PoolActionsHistory } from '../../components/poolActionsHistory'
+import { Filter } from '../../components/poolActionsHistory/types'
+import { useMidgardContext } from '../../contexts/MidgardContext'
+import { useThorchainContext } from '../../contexts/ThorchainContext'
+import { liveData } from '../../helpers/rx/liveData'
+import { DEFAULT_ACTIONS_HISTORY_REQUEST_PARAMS, LoadActionsParams } from '../../services/midgard/poolActionsHistory'
+import { PoolActionsHistoryPage, PoolActionsHistoryPageRD } from '../../services/midgard/types'
 
 type Props = {
   poolAsset: Asset
+  className?: string
 }
-export const PoolHistory: React.FC<Props> = () => {
-  return <>pool history</>
+
+const DEFAULT_REQUEST_PARAMS = {
+  ...DEFAULT_ACTIONS_HISTORY_REQUEST_PARAMS,
+  itemsPerPage: 5
+}
+
+export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
+  const {
+    service: { poolActionsHistory }
+  } = useMidgardContext()
+
+  const { getExplorerTxUrl$ } = useThorchainContext()
+
+  const prevActionsPage = useRef<O.Option<PoolActionsHistoryPage>>(O.none)
+
+  const requestParams = useRef(DEFAULT_REQUEST_PARAMS)
+
+  const [historyPage, setHistoryPageParams] = useObservableState<PoolActionsHistoryPageRD, Partial<LoadActionsParams>>(
+    (params$) =>
+      FP.pipe(
+        params$,
+        RxOp.startWith(DEFAULT_REQUEST_PARAMS),
+        RxOp.map((params) => {
+          const res = {
+            ...requestParams.current,
+            asset: assetToString(poolAsset),
+            ...params
+          }
+          requestParams.current = res
+          return res
+        }),
+        RxOp.switchMap(poolActionsHistory.actions$),
+        liveData.map((page) => {
+          prevActionsPage.current = O.some(page)
+          return page
+        })
+      ),
+    RD.initial
+  )
+
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      setHistoryPageParams({ page: page - 1 })
+    },
+    [setHistoryPageParams]
+  )
+
+  const setFilter = useCallback(
+    (filter: Filter) => {
+      setHistoryPageParams({
+        ...DEFAULT_REQUEST_PARAMS,
+        type: filter
+      })
+    },
+    [setHistoryPageParams]
+  )
+
+  const oExplorerUrl = useObservableState(getExplorerTxUrl$, O.none)
+
+  const goToTx = useCallback(
+    (txId: string) => {
+      FP.pipe(
+        oExplorerUrl,
+        /**
+         * todo @asgardexTeam use appropriate independent method from xchain-thorchain
+         * after https://github.com/xchainjs/xchainjs-lib/issues/287 is resolved
+         */
+        O.alt(() => O.some((txId: string) => `https://testnet.thorchain.net/#/txs/${txId}`)),
+        O.ap(O.some(txId)),
+        O.map(window.apiUrl.openExternal)
+      )
+    },
+    [oExplorerUrl]
+  )
+
+  return (
+    <PoolActionsHistory
+      className={className}
+      currentPage={requestParams.current.page + 1}
+      actionsPageRD={historyPage}
+      prevActionsPage={prevActionsPage.current}
+      goToTx={goToTx}
+      changePaginationHandler={setCurrentPage}
+      clickTxLinkHandler={goToTx}
+      currentFilter={requestParams.current.type || 'ALL'}
+      setFilter={setFilter}
+    />
+  )
 }

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -36,6 +36,11 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
 
   const requestParams = useRef(DEFAULT_REQUEST_PARAMS)
 
+  /**
+   * setHistoryPageParams receives Partial parameters to have an opportunity to
+   * change request parameters only by small parts (not all in one). e.g setCurrentPage.
+   * To store previously chosen request parameters that should not be changed `requestParams` ref is used.
+   */
   const [historyPage, setHistoryPageParams] = useObservableState<PoolActionsHistoryPageRD, Partial<LoadActionsParams>>(
     (params$) =>
       FP.pipe(
@@ -43,6 +48,7 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
         RxOp.startWith(DEFAULT_REQUEST_PARAMS),
         RxOp.map((params) => {
           const res = {
+            // Merge previously saved request parameters with a new Partial parameters
             ...requestParams.current,
             asset: assetToString(poolAsset),
             ...params
@@ -69,6 +75,7 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
   const setFilter = useCallback(
     (filter: Filter) => {
       setHistoryPageParams({
+        // For every new filter reset all parameters to default and pass a filter
         ...DEFAULT_REQUEST_PARAMS,
         type: filter
       })

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -176,18 +176,18 @@ export const ActivePools: React.FC = (): JSX.Element => {
             loading={loading}
             rowKey="key"
             // TODO(@asgdx-team): Uncomment when pool detail is ready
-            // onRow={({ pool }: PoolTableRowData) => {
-            //   return {
-            //     onClick: () => {
-            //       history.push(poolsRoutes.detail.path({ asset: assetToString(pool.target) }))
-            //     }
-            //   }
-            // }}
+            onRow={({ pool }: PoolTableRowData) => {
+              return {
+                onClick: () => {
+                  history.push(poolsRoutes.detail.path({ asset: assetToString(pool.target) }))
+                }
+              }
+            }}
           />
         </>
       )
     },
-    [isDesktopView, desktopPoolsColumns, mobilePoolsColumns, poolFilter, setFilter]
+    [isDesktopView, desktopPoolsColumns, mobilePoolsColumns, poolFilter, setFilter, history]
   )
 
   return (

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -175,7 +175,6 @@ export const ActivePools: React.FC = (): JSX.Element => {
             dataSource={FP.pipe(tableData, filterTableData(poolFilter))}
             loading={loading}
             rowKey="key"
-            // TODO(@asgdx-team): Uncomment when pool detail is ready
             onRow={({ pool }: PoolTableRowData) => {
               return {
                 onClick: () => {

--- a/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
+++ b/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
@@ -111,7 +111,6 @@ export const PoolActionsHistoryView: React.FC<{ className?: string }> = ({ class
       prevActionsPage={prevActionsPage.current}
       goToTx={goToTx}
       changePaginationHandler={setCurrentPage}
-      clickTxLinkHandler={goToTx}
       currentFilter={requestParams.current.type || 'ALL'}
       setFilter={setFilter}
     />


### PR DESCRIPTION
`ActivePools`: enabled onCLick for a pool-row

`midgard/pools`: removed filtering out `O.none` values from `selectedPoolDetail$` as it leaded to the wrong caching results

`PoolHistoryView`: added business logic for history loading;

`PoolDetailsView`:
  - added `BackLink` and `RefreshButton`
  - added caching prev results;

`midgard/poolActionsHistory`: added `isHistoryLoading$` data;

as a part of #1161 