### PR TITLE
[PoolDetail] Few improvements (architecture) 

### DIFF
--- a/src/renderer/components/pool/PoolCards.tsx
+++ b/src/renderer/components/pool/PoolCards.tsx
@@ -1,50 +1,45 @@
 import React, { useMemo } from 'react'
 
-import { AssetAmount, baseAmount, baseToAsset, bn, bnOrZero, formatAssetAmount } from '@xchainjs/xchain-util'
+import { formatAssetAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
 
 import { abbreviateNumber } from '../../helpers/numberHelper'
-import { PoolDetail } from '../../types/generated/midgard/models'
+import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
 import { PoolStatus } from '../uielements/poolStatus'
 import * as Styled from './PoolCards.style'
+import * as H from './PoolDetails.helpers'
 
 export type Props = {
   poolDetail: PoolDetail
-  earnings: AssetAmount
-  fees: AssetAmount
-  totalTx: BigNumber
-  totalSwaps: BigNumber
-  members: BigNumber
+  poolStatsDetail: PoolStatsDetail
+  earningsHistory: O.Option<EarningsHistoryItemPool>
   priceSymbol?: string
   isLoading?: boolean
   priceRatio: BigNumber
 }
 
-const getDepth = (data: Pick<PoolDetail, 'runeDepth'>, priceRatio: BigNumber = bn(1)) =>
-  baseToAsset(baseAmount(bnOrZero(data.runeDepth).multipliedBy(priceRatio)))
-
-const getVolume = (data: Pick<PoolDetail, 'volume24h'>, priceRatio: BigNumber = bn(1)) =>
-  baseToAsset(baseAmount(bnOrZero(data.volume24h).multipliedBy(priceRatio)))
-
-const getAPY = (data: Pick<PoolDetail, 'poolAPY'>) => bn(data.poolAPY).plus(1).multipliedBy(100)
-
 export const PoolCards: React.FC<Props> = ({
-  earnings,
-  fees,
-  totalTx,
-  totalSwaps,
-  members,
+  poolStatsDetail,
   priceSymbol = '',
   poolDetail,
+  earningsHistory,
   priceRatio,
   isLoading
 }) => {
   const intl = useIntl()
 
-  const liquidity = useMemo(() => getDepth(poolDetail, priceRatio), [poolDetail, priceRatio])
-  const volume = useMemo(() => getVolume(poolDetail, priceRatio), [poolDetail, priceRatio])
-  const apy = useMemo(() => getAPY(poolDetail), [poolDetail])
+  const liquidity = useMemo(() => H.getDepth(poolDetail, priceRatio), [poolDetail, priceRatio])
+  const volume = useMemo(() => H.getVolume(poolDetail, priceRatio), [poolDetail, priceRatio])
+  const apy = useMemo(() => H.getAPY(poolDetail), [poolDetail])
+
+  const fees = useMemo(() => H.getFees(poolStatsDetail, priceRatio), [poolStatsDetail, priceRatio])
+  const totalTx = useMemo(() => H.getTotalTx(poolStatsDetail), [poolStatsDetail])
+  const totalSwaps = useMemo(() => H.getTotalSwaps(poolStatsDetail), [poolStatsDetail])
+  const members = useMemo(() => H.getMembers(poolStatsDetail), [poolStatsDetail])
+
+  const earnings = useMemo(() => H.getEarnings(earningsHistory), [earningsHistory])
 
   return (
     <Styled.Container>

--- a/src/renderer/components/pool/PoolDetails.helpers.test.ts
+++ b/src/renderer/components/pool/PoolDetails.helpers.test.ts
@@ -1,0 +1,273 @@
+import { assetAmount, assetToBase, bn } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/Option'
+
+import { ZERO_ASSET_AMOUNT, ZERO_BN } from '../../const'
+import { eqAssetAmount, eqBigNumber } from '../../helpers/fp/eq'
+import {
+  getDepth,
+  getVolume,
+  getAPY,
+  getPrice,
+  getTotalSwaps,
+  getTotalTx,
+  getMembers,
+  getFees,
+  getEarnings
+} from './PoolDetails.helpers'
+
+describe('PoolDetails.helpers', () => {
+  describe('getDepth', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqAssetAmount.equals(getDepth({ runeDepth: '' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+      expect(eqAssetAmount.equals(getDepth({ runeDepth: 'asdasd' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+    it('should get depth correctly for default price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getDepth({ runeDepth: assetToBase(assetAmount(123)).amount().toString() }),
+          assetAmount(123)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getDepth({ runeDepth: assetToBase(assetAmount(123.123123)).amount().toString() }),
+          assetAmount(123.123123)
+        )
+      ).toBeTruthy()
+    })
+
+    it('should get depth correctly for provided price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getDepth({ runeDepth: assetToBase(assetAmount(123)).amount().toString() }, bn(2)),
+          assetAmount(246)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getDepth({ runeDepth: assetToBase(assetAmount(100)).amount().toString() }, bn(2.5)),
+          assetAmount(250)
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  describe('getVolume', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqAssetAmount.equals(getVolume({ volume24h: '' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+      expect(eqAssetAmount.equals(getVolume({ volume24h: 'asdasd' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+    it('should get volume correctly for default price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getVolume({ volume24h: assetToBase(assetAmount(123)).amount().toString() }),
+          assetAmount(123)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getVolume({ volume24h: assetToBase(assetAmount(123.123123)).amount().toString() }),
+          assetAmount(123.123123)
+        )
+      ).toBeTruthy()
+    })
+
+    it('should get volume correctly for provided price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getVolume({ volume24h: assetToBase(assetAmount(123)).amount().toString() }, bn(2)),
+          assetAmount(246)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getVolume({ volume24h: assetToBase(assetAmount(100)).amount().toString() }, bn(2.5)),
+          assetAmount(250)
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  describe('getAPY', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqBigNumber.equals(getAPY({ poolAPY: '' }), ZERO_BN)).toBeTruthy()
+      expect(eqBigNumber.equals(getAPY({ poolAPY: 'asdasd' }), ZERO_BN)).toBeTruthy()
+    })
+    it('should get APY correctly', () => {
+      expect(eqBigNumber.equals(getAPY({ poolAPY: '0.2120' }), bn(21.2))).toBeTruthy()
+      expect(eqBigNumber.equals(getAPY({ poolAPY: '0.0123' }), bn(1.23))).toBeTruthy()
+    })
+  })
+
+  describe('getPrice', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: '' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: 'asdasd' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+
+    it('should get price correctly for default price ratio', () => {
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: '123' }), assetAmount(123))).toBeTruthy()
+
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: '123.123' }), assetAmount(123.123))).toBeTruthy()
+    })
+
+    it('should get price correctly for provided price ratio', () => {
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: '123' }, bn(2)), assetAmount(246))).toBeTruthy()
+
+      expect(eqAssetAmount.equals(getPrice({ assetPrice: '100' }, bn(2.5)), assetAmount(250))).toBeTruthy()
+    })
+  })
+
+  describe('getTotalSwaps', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqBigNumber.equals(getTotalSwaps({ swapCount: '' }), ZERO_BN)).toBeTruthy()
+      expect(eqBigNumber.equals(getTotalSwaps({ swapCount: 'asdasd' }), ZERO_BN)).toBeTruthy()
+    })
+    it('should return total swaps amount correctly', () => {
+      expect(eqBigNumber.equals(getTotalSwaps({ swapCount: '2120' }), bn(2120))).toBeTruthy()
+      expect(eqBigNumber.equals(getTotalSwaps({ swapCount: '0123' }), bn(123))).toBeTruthy()
+    })
+  })
+
+  describe('getTotalTx', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(
+        eqBigNumber.equals(
+          getTotalTx({
+            addLiquidityCount: 'asdfa',
+            withdrawCount: 'saa',
+            swapCount: 'asda'
+          }),
+          ZERO_BN
+        )
+      ).toBeTruthy()
+      expect(
+        eqBigNumber.equals(
+          getTotalTx({
+            addLiquidityCount: '',
+            withdrawCount: '',
+            swapCount: ''
+          }),
+          ZERO_BN
+        )
+      ).toBeTruthy()
+    })
+
+    it('should total swaps amount correctly', () => {
+      expect(
+        eqBigNumber.equals(
+          getTotalTx({
+            addLiquidityCount: '10',
+            withdrawCount: '20',
+            swapCount: '30'
+          }),
+          bn(60)
+        )
+      ).toBeTruthy()
+      expect(
+        eqBigNumber.equals(
+          getTotalTx({
+            addLiquidityCount: 'qwqwd',
+            withdrawCount: 'safda',
+            swapCount: '0123'
+          }),
+          bn(123)
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  describe('getMembers', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqBigNumber.equals(getMembers({ uniqueMemberCount: '' }), ZERO_BN)).toBeTruthy()
+      expect(eqBigNumber.equals(getMembers({ uniqueMemberCount: 'asdasd' }), ZERO_BN)).toBeTruthy()
+    })
+    it('should return ьуьиукы amount correctly', () => {
+      expect(eqBigNumber.equals(getMembers({ uniqueMemberCount: '2120' }), bn(2120))).toBeTruthy()
+      expect(eqBigNumber.equals(getMembers({ uniqueMemberCount: '0123' }), bn(123))).toBeTruthy()
+    })
+  })
+
+  describe('getFees', () => {
+    it('should return zero value for incorrect data', () => {
+      expect(eqAssetAmount.equals(getFees({ totalFees: '' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+      expect(eqAssetAmount.equals(getFees({ totalFees: 'asdasd' }), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+    it('should get fees correctly for default price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getFees({ totalFees: assetToBase(assetAmount(123)).amount().toString() }),
+          assetAmount(123)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getFees({ totalFees: assetToBase(assetAmount(123.123123)).amount().toString() }),
+          assetAmount(123.123123)
+        )
+      ).toBeTruthy()
+    })
+
+    it('should get fees correctly for provided price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getFees({ totalFees: assetToBase(assetAmount(123)).amount().toString() }, bn(2)),
+          assetAmount(246)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getFees({ totalFees: assetToBase(assetAmount(100)).amount().toString() }, bn(2.5)),
+          assetAmount(250)
+        )
+      ).toBeTruthy()
+    })
+  })
+
+  describe('getEarnings', () => {
+    it('should return zero value for O.none', () => {
+      expect(eqAssetAmount.equals(getEarnings(O.none), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+    it('should return zero value for incorrect data', () => {
+      expect(eqAssetAmount.equals(getEarnings(O.some({ earnings: '' })), ZERO_ASSET_AMOUNT)).toBeTruthy()
+      expect(eqAssetAmount.equals(getEarnings(O.some({ earnings: 'asdasd' })), ZERO_ASSET_AMOUNT)).toBeTruthy()
+    })
+    it('should get earnings correctly for default price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getEarnings(O.some({ earnings: assetToBase(assetAmount(123)).amount().toString() })),
+          assetAmount(123)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getEarnings(O.some({ earnings: assetToBase(assetAmount(123.123123)).amount().toString() })),
+          assetAmount(123.123123)
+        )
+      ).toBeTruthy()
+    })
+
+    it('should get earnings correctly for provided price ratio', () => {
+      expect(
+        eqAssetAmount.equals(
+          getEarnings(O.some({ earnings: assetToBase(assetAmount(123)).amount().toString() }), bn(2)),
+          assetAmount(246)
+        )
+      ).toBeTruthy()
+
+      expect(
+        eqAssetAmount.equals(
+          getEarnings(O.some({ earnings: assetToBase(assetAmount(100)).amount().toString() }), bn(2.5)),
+          assetAmount(250)
+        )
+      ).toBeTruthy()
+    })
+  })
+})

--- a/src/renderer/components/pool/PoolDetails.helpers.ts
+++ b/src/renderer/components/pool/PoolDetails.helpers.ts
@@ -12,22 +12,25 @@ export const getDepth = (data: Pick<PoolDetail, 'runeDepth'>, priceRatio: BigNum
 export const getVolume = (data: Pick<PoolDetail, 'volume24h'>, priceRatio: BigNumber = bn(1)) =>
   baseToAsset(baseAmount(bnOrZero(data.volume24h).multipliedBy(priceRatio)))
 
-export const getAPY = (data: Pick<PoolDetail, 'poolAPY'>) => bn(data.poolAPY).plus(1).multipliedBy(100)
+export const getAPY = (data: Pick<PoolDetail, 'poolAPY'>) => bnOrZero(data.poolAPY).multipliedBy(100)
 
 export const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)) =>
   assetAmount(bnOrZero(data.assetPrice).multipliedBy(priceRatio))
 
-export const getTotalSwaps = (data: Pick<PoolStatsDetail, 'swapCount'>) => bn(data.swapCount)
+export const getTotalSwaps = (data: Pick<PoolStatsDetail, 'swapCount'>) => bnOrZero(data.swapCount)
 
-export const getTotalTx = (data: PoolStatsDetail) =>
-  bn(data.swapCount).plus(data.addLiquidityCount).plus(data.withdrawCount)
+export const getTotalTx = (data: Pick<PoolStatsDetail, 'swapCount' | 'addLiquidityCount' | 'withdrawCount'>) =>
+  bnOrZero(data.swapCount).plus(bnOrZero(data.addLiquidityCount)).plus(bnOrZero(data.withdrawCount))
 
-export const getMembers = (data: Pick<PoolStatsDetail, 'uniqueMemberCount'>) => bn(data.uniqueMemberCount)
+export const getMembers = (data: Pick<PoolStatsDetail, 'uniqueMemberCount'>) => bnOrZero(data.uniqueMemberCount)
 
 export const getFees = (data: Pick<PoolStatsDetail, 'totalFees'>, priceRatio: BigNumber = bn(1)) =>
   baseToAsset(baseAmount(bnOrZero(data.totalFees).multipliedBy(priceRatio)))
 
-export const getEarnings = (oData: O.Option<EarningsHistoryItemPool>, priceRatio: BigNumber = bn(1)) =>
+export const getEarnings = (
+  oData: O.Option<Pick<EarningsHistoryItemPool, 'earnings'>>,
+  priceRatio: BigNumber = bn(1)
+) =>
   FP.pipe(
     oData,
     O.fold(

--- a/src/renderer/components/pool/PoolDetails.helpers.ts
+++ b/src/renderer/components/pool/PoolDetails.helpers.ts
@@ -1,0 +1,37 @@
+import { assetAmount, baseAmount, baseToAsset, bn, bnOrZero } from '@xchainjs/xchain-util'
+import BigNumber from 'bignumber.js'
+import * as O from 'fp-ts/Option'
+import * as FP from 'fp-ts/pipeable'
+
+import { ZERO_ASSET_AMOUNT } from '../../const'
+import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
+
+export const getDepth = (data: Pick<PoolDetail, 'runeDepth'>, priceRatio: BigNumber = bn(1)) =>
+  baseToAsset(baseAmount(bnOrZero(data.runeDepth).multipliedBy(priceRatio)))
+
+export const getVolume = (data: Pick<PoolDetail, 'volume24h'>, priceRatio: BigNumber = bn(1)) =>
+  baseToAsset(baseAmount(bnOrZero(data.volume24h).multipliedBy(priceRatio)))
+
+export const getAPY = (data: Pick<PoolDetail, 'poolAPY'>) => bn(data.poolAPY).plus(1).multipliedBy(100)
+
+export const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)) =>
+  assetAmount(bnOrZero(data.assetPrice).multipliedBy(priceRatio))
+
+export const getTotalSwaps = (data: Pick<PoolStatsDetail, 'swapCount'>) => bn(data.swapCount)
+
+export const getTotalTx = (data: PoolStatsDetail) =>
+  bn(data.swapCount).plus(data.addLiquidityCount).plus(data.withdrawCount)
+
+export const getMembers = (data: Pick<PoolStatsDetail, 'uniqueMemberCount'>) => bn(data.uniqueMemberCount)
+
+export const getFees = (data: Pick<PoolStatsDetail, 'totalFees'>, priceRatio: BigNumber = bn(1)) =>
+  baseToAsset(baseAmount(bnOrZero(data.totalFees).multipliedBy(priceRatio)))
+
+export const getEarnings = (oData: O.Option<EarningsHistoryItemPool>, priceRatio: BigNumber = bn(1)) =>
+  FP.pipe(
+    oData,
+    O.fold(
+      () => ZERO_ASSET_AMOUNT,
+      (data) => baseToAsset(baseAmount(bnOrZero(data.earnings).multipliedBy(priceRatio)))
+    )
+  )

--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -3,20 +3,29 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { assetAmount, AssetETH, bn } from '@xchainjs/xchain-util'
 
+import { ZERO_BN } from '../../const'
 import { PoolDetails } from './PoolDetails'
 
 export const PoolDetailsStory = () => {
   return (
     <PoolDetails
-      liquidity={assetAmount(1)}
-      volumn={assetAmount(1)}
+      poolDetail={{
+        asset: 'asset',
+        assetDepth: '0',
+        assetPrice: '0',
+        assetPriceUSD: '0',
+        poolAPY: '0',
+        runeDepth: '0',
+        status: '',
+        units: '0',
+        volume24h: ''
+      }}
+      priceRatio={ZERO_BN}
       earnings={assetAmount(1)}
       fees={assetAmount(1)}
       totalTx={bn(10)}
       totalSwaps={bn(20)}
       members={bn(30)}
-      apy={bn(120)}
-      price={assetAmount(1)}
       priceSymbol={'R'}
       asset={AssetETH}
       HistoryView={() => <>Actions History Here</>}

--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -1,31 +1,20 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { assetAmount, AssetETH, bn } from '@xchainjs/xchain-util'
+import { AssetETH } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/Option'
 
+import { poolDetailMock, poolStatsDetailMock } from '../../../shared/mock/pool'
 import { ZERO_BN } from '../../const'
 import { PoolDetails } from './PoolDetails'
 
 export const PoolDetailsStory = () => {
   return (
     <PoolDetails
-      poolDetail={{
-        asset: 'asset',
-        assetDepth: '0',
-        assetPrice: '0',
-        assetPriceUSD: '0',
-        poolAPY: '0',
-        runeDepth: '0',
-        status: '',
-        units: '0',
-        volume24h: ''
-      }}
+      poolDetail={poolDetailMock}
+      poolStatsDetail={poolStatsDetailMock}
       priceRatio={ZERO_BN}
-      earnings={assetAmount(1)}
-      fees={assetAmount(1)}
-      totalTx={bn(10)}
-      totalSwaps={bn(20)}
-      members={bn(30)}
+      earningsHistory={O.none}
       priceSymbol={'R'}
       asset={AssetETH}
       HistoryView={() => <>Actions History Here</>}

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -1,29 +1,24 @@
 import React, { useMemo } from 'react'
 
-import { Asset, assetAmount, AssetAmount, bn, bnOrZero } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 import * as A from 'antd'
 import BigNumber from 'bignumber.js'
 import * as O from 'fp-ts/Option'
 
-import { PoolDetail } from '../../types/generated/midgard/models'
+import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
 import { PoolCards } from './PoolCards'
 import { PoolChart } from './PoolChart'
+import * as H from './PoolDetails.helpers'
 import * as Styled from './PoolDetails.style'
 import { PoolTitle } from './PoolTitle'
 
-const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)) =>
-  assetAmount(bnOrZero(data.assetPrice).multipliedBy(priceRatio))
-
 export type Props = {
   asset: Asset
+  poolStatsDetail: PoolStatsDetail
   poolDetail: PoolDetail
   priceRatio: BigNumber
   priceSymbol?: string
-  earnings: AssetAmount
-  fees: AssetAmount
-  totalTx: BigNumber
-  totalSwaps: BigNumber
-  members: BigNumber
+  earningsHistory: O.Option<EarningsHistoryItemPool>
   isLoading?: boolean
   HistoryView: React.ComponentType<{ poolAsset: Asset }>
 }
@@ -31,18 +26,14 @@ export type Props = {
 export const PoolDetails: React.FC<Props> = ({
   asset,
   priceSymbol = '',
-  earnings,
-  fees,
-  totalTx,
-  totalSwaps,
-  members,
+  earningsHistory,
   priceRatio,
   poolDetail,
+  poolStatsDetail,
   isLoading,
   HistoryView
 }) => {
-  const price = useMemo(() => getPrice(poolDetail, priceRatio), [poolDetail, priceRatio])
-
+  const price = useMemo(() => H.getPrice(poolDetail, priceRatio), [poolDetail, priceRatio])
   return (
     <Styled.Container>
       <Styled.TopContainer>
@@ -51,13 +42,10 @@ export const PoolDetails: React.FC<Props> = ({
         </A.Col>
         <A.Col xs={24} md={8}>
           <PoolCards
+            poolStatsDetail={poolStatsDetail}
             priceRatio={priceRatio}
             poolDetail={poolDetail}
-            earnings={earnings}
-            fees={fees}
-            totalTx={totalTx}
-            totalSwaps={totalSwaps}
-            members={members}
+            earningsHistory={earningsHistory}
             priceSymbol={priceSymbol}
             isLoading={isLoading}
           />

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -1,46 +1,48 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
-import { Asset, AssetAmount } from '@xchainjs/xchain-util'
+import { Asset, assetAmount, AssetAmount, bn, bnOrZero } from '@xchainjs/xchain-util'
 import * as A from 'antd'
 import BigNumber from 'bignumber.js'
 import * as O from 'fp-ts/Option'
 
+import { PoolDetail } from '../../types/generated/midgard/models'
 import { PoolCards } from './PoolCards'
 import { PoolChart } from './PoolChart'
 import * as Styled from './PoolDetails.style'
 import { PoolTitle } from './PoolTitle'
 
+const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)) =>
+  assetAmount(bnOrZero(data.assetPrice).multipliedBy(priceRatio))
+
 export type Props = {
   asset: Asset
-  price: AssetAmount
+  poolDetail: PoolDetail
+  priceRatio: BigNumber
   priceSymbol?: string
-  liquidity: AssetAmount
-  volumn: AssetAmount
   earnings: AssetAmount
   fees: AssetAmount
   totalTx: BigNumber
   totalSwaps: BigNumber
   members: BigNumber
-  apy: BigNumber
   isLoading?: boolean
   HistoryView: React.ComponentType<{ poolAsset: Asset }>
 }
 
 export const PoolDetails: React.FC<Props> = ({
   asset,
-  price,
   priceSymbol = '',
-  liquidity,
-  volumn,
   earnings,
   fees,
   totalTx,
   totalSwaps,
   members,
-  apy,
+  priceRatio,
+  poolDetail,
   isLoading,
   HistoryView
 }) => {
+  const price = useMemo(() => getPrice(poolDetail, priceRatio), [poolDetail, priceRatio])
+
   return (
     <Styled.Container>
       <Styled.TopContainer>
@@ -49,14 +51,13 @@ export const PoolDetails: React.FC<Props> = ({
         </A.Col>
         <A.Col xs={24} md={8}>
           <PoolCards
-            liquidity={liquidity}
-            volumn={volumn}
+            priceRatio={priceRatio}
+            poolDetail={poolDetail}
             earnings={earnings}
             fees={fees}
             totalTx={totalTx}
             totalSwaps={totalSwaps}
             members={members}
-            apy={apy}
             priceSymbol={priceSymbol}
             isLoading={isLoading}
           />

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -8,6 +8,7 @@ import * as FP from 'fp-ts/pipeable'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
+import * as RxOp from 'rxjs/operators'
 
 import { PoolDetails, Props as PoolDetailProps } from '../../components/pool/PoolDetails'
 import { ErrorView } from '../../components/shared/error'
@@ -77,7 +78,7 @@ export const PoolDetailsView: React.FC = () => {
         poolEarningHistory$,
         reloadSelectedPoolDetail
       },
-      poolActionsHistory: { reloadActionsHistory, isHistoryLoading$ },
+      poolActionsHistory: { reloadActionsHistory, actions$ },
       setSelectedPoolAsset
     }
   } = useMidgardContext()
@@ -102,7 +103,7 @@ export const PoolDetailsView: React.FC = () => {
 
   const priceRatio = useObservableState(priceRatio$, ONE_BN)
 
-  const isHistoryLoading = useObservableState(isHistoryLoading$, false)
+  const [isHistoryLoading] = useObservableState(() => FP.pipe(actions$, RxOp.map(RD.isPending)), false)
 
   const poolDetailRD: PoolDetailRD = useObservableState(selectedPoolDetail$, RD.initial)
 

--- a/src/shared/mock/pool.ts
+++ b/src/shared/mock/pool.ts
@@ -1,0 +1,55 @@
+import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../renderer/types/generated/midgard/models'
+
+export const poolDetailMock: PoolDetail = {
+  asset: 'asset',
+  assetDepth: '0',
+  assetPrice: '0',
+  assetPriceUSD: '0',
+  poolAPY: '0',
+  runeDepth: '0',
+  status: '',
+  units: '0',
+  volume24h: ''
+}
+
+export const poolStatsDetailMock: PoolStatsDetail = {
+  addAssetLiquidityVolume: '0',
+  addLiquidityCount: '0',
+  addLiquidityVolume: '0',
+  addRuneLiquidityVolume: '0',
+  asset: 'asset',
+  assetDepth: '0',
+  assetPrice: '0',
+  assetPriceUSD: '0',
+  averageSlip: '0',
+  poolAPY: '0',
+  runeDepth: '0',
+  status: 'Staged',
+  swapCount: '0',
+  swapVolume: '0',
+  toAssetAverageSlip: '0',
+  toAssetCount: '0',
+  toAssetFees: '0',
+  toAssetVolume: '0',
+  toRuneAverageSlip: '0',
+  toRuneCount: '0',
+  toRuneFees: '0',
+  toRuneVolume: '0',
+  totalFees: '0',
+  uniqueMemberCount: '0',
+  uniqueSwapperCount: '0',
+  units: '0',
+  withdrawAssetVolume: '0',
+  withdrawCount: '0',
+  withdrawRuneVolume: '0',
+  withdrawVolume: '0'
+}
+
+export const earningsHistoryItemPoolMock: EarningsHistoryItemPool = {
+  assetLiquidityFees: '0',
+  earnings: '0',
+  pool: 'BNB.BNB',
+  rewards: '0',
+  runeLiquidityFees: '0',
+  totalLiquidityFeesRune: '0'
+}


### PR DESCRIPTION
- `poolActionsHistory`: refactored service to have a single shared `actions$` data stream
- `PoolDetails`: 
- - refactored props to receive pool's common data
- - moved helpers to the separate file `PoolDetails.helpers`
- `PoolDetails.helpers`:  fixed, added tests for them

closes #1254 