### PR TITLE
[Routes] Add re-directs in case of switching network

### DIFF
--- a/src/renderer/views/pools/PoolsView.tsx
+++ b/src/renderer/views/pools/PoolsView.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
-import { Route, Switch } from 'react-router-dom'
+import { useSubscription } from 'observable-hooks'
+import { Route, Switch, useHistory } from 'react-router-dom'
 
+import { useAppContext } from '../../contexts/AppContext'
 import * as poolsRoutes from '../../routes/pools'
 import { DepositView } from '../deposit/DepositView'
 import { PoolDetailsView } from '../pool/PoolDetailsView'
@@ -9,6 +11,21 @@ import { SwapView } from '../swap/SwapView'
 import { PoolsOverview } from './PoolsOverview'
 
 export const PoolsView: React.FC = (): JSX.Element => {
+  const { network$ } = useAppContext()
+  const history = useHistory()
+
+  /**
+   * All of inner routes are Pool dependent.
+   * After network switched there might be
+   * a situation when there is no such pool
+   * as previously selected for previous network.
+   * For this reason for every network change
+   * we redirect to the top-level route
+   */
+  useSubscription(network$, () => {
+    history.replace(poolsRoutes.base.path())
+  })
+
   return (
     <Switch>
       <Route path={poolsRoutes.base.template} exact>

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -89,7 +89,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
           title={intl.formatMessage(
             { id: 'routes.invalid.asset' },
             {
-              routeAsset
+              asset: routeAsset
             }
           )}
         />

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -2,11 +2,12 @@ import React, { useCallback, useMemo } from 'react'
 
 import { Row } from 'antd'
 import * as H from 'history'
-import { useObservableState } from 'observable-hooks'
-import { Switch, Route, Redirect } from 'react-router-dom'
+import { useObservableState, useSubscription } from 'observable-hooks'
+import { Switch, Route, Redirect, useHistory, useRouteMatch } from 'react-router-dom'
 
 import { RefreshButton } from '../../components/uielements/button/'
 import { AssetsNav } from '../../components/wallet/assets'
+import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
@@ -53,6 +54,32 @@ export const WalletView: React.FC = (): JSX.Element => {
     ),
     []
   )
+
+  const { network$ } = useAppContext()
+  const history = useHistory()
+
+  const isSendRoute = useRouteMatch(walletRoutes.send.template)
+  const isUpgradeBnbRuneRoute = useRouteMatch(walletRoutes.upgradeBnbRune.template)
+  const isAssetDetailRoute = useRouteMatch(walletRoutes.assetDetail.template)
+
+  const isPoolDependantRoute = useMemo(() => isSendRoute || isUpgradeBnbRuneRoute || isAssetDetailRoute, [
+    isSendRoute,
+    isUpgradeBnbRuneRoute,
+    isAssetDetailRoute
+  ])
+
+  /**
+   * After network was switched there might be
+   * a situation when there is no such pool
+   * as previously selected for previous network.
+   * For this reason for every poolDependent route and
+   * network change we redirect to the top-level route
+   */
+  useSubscription(network$, () => {
+    if (isPoolDependantRoute) {
+      history.replace(walletRoutes.base.path())
+    }
+  })
 
   // Following routes are accessable only,
   // if an user has a phrase imported and wallet has not been locked


### PR DESCRIPTION
- `AssetDetailsView`: fixed wrong values passing to the intl.formatMessage
- `PoolsView`: added redirecting to the `poolsRoutes.base` path in case network was changed
- `WalletView`:  added redirecting to the walletRoutes.base path in case network was changed

closes #1281 