### PR TITLE
[DepositView] reduce redundant pool-details request

### DIFF
--- a/src/renderer/components/deposit/Deposit.stories.tsx
+++ b/src/renderer/components/deposit/Deposit.stories.tsx
@@ -15,6 +15,7 @@ import { Default as Withdraw } from './withdraw/Withdraw.stories'
 
 const defaultProps: DepositProps = {
   asset: { asset: AssetBNB, decimal: BNB_DECIMAL },
+  poolDetail: RD.initial,
   shares: RD.success([
     {
       units: bn('300000000'),

--- a/src/renderer/components/deposit/Deposit.tsx
+++ b/src/renderer/components/deposit/Deposit.tsx
@@ -7,7 +7,7 @@ import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
 
-import { PoolShareRD, PoolSharesRD } from '../../services/midgard/types'
+import { PoolDetailRD, PoolShareRD, PoolSharesRD } from '../../services/midgard/types'
 import { getSharesByAssetAndType, combineSharesByAsset } from '../../services/midgard/utils'
 import { KeystoreState } from '../../services/wallet/types'
 import { hasImportedKeystore, isLocked } from '../../services/wallet/util'
@@ -27,15 +27,17 @@ type Tab = {
 export type Props = {
   asset: AssetWithDecimal
   shares: PoolSharesRD
+  poolDetail: PoolDetailRD
   ShareContent: React.ComponentType<{
     asset: AssetWithDecimal
     poolShare: PoolShareRD
     smallWidth?: boolean
+    poolDetail: PoolDetailRD
   }>
-  AsymDepositContent: React.ComponentType<{ asset: Asset }>
-  SymDepositContent: React.ComponentType<{ asset: AssetWithDecimal }>
-  WidthdrawContent: React.ComponentType<{ asset: AssetWithDecimal; poolShare: PoolShareRD }>
-  AsymWidthdrawContent: React.ComponentType<{ asset: Asset; poolShare: PoolShareRD }>
+  AsymDepositContent: React.ComponentType<{ asset: Asset; poolDetail: PoolDetailRD }>
+  SymDepositContent: React.ComponentType<{ asset: AssetWithDecimal; poolDetail: PoolDetailRD }>
+  WidthdrawContent: React.ComponentType<{ asset: AssetWithDecimal; poolShare: PoolShareRD; poolDetail: PoolDetailRD }>
+  AsymWidthdrawContent: React.ComponentType<{ asset: Asset; poolShare: PoolShareRD; poolDetail: PoolDetailRD }>
   keystoreState: KeystoreState
 }
 
@@ -50,7 +52,8 @@ export const Deposit: React.FC<Props> = (props) => {
     // TODO (@Veado) Temporary disabled #827
     // AsymWidthdrawContent,
     keystoreState,
-    shares: poolSharesRD
+    shares: poolSharesRD,
+    poolDetail: poolDetailRD
   } = props
 
   const { asset } = assetWD
@@ -106,13 +109,13 @@ export const Deposit: React.FC<Props> = (props) => {
         key: 'deposit-sym',
         disabled: false,
         label: intl.formatMessage({ id: 'deposit.add.sym' }),
-        content: <SymDepositContent asset={assetWD} />
+        content: <SymDepositContent poolDetail={poolDetailRD} asset={assetWD} />
       },
       {
         key: 'withdraw-sym',
         disabled: !hasSymPoolShare,
         label: intl.formatMessage({ id: 'deposit.withdraw.sym' }),
-        content: <WidthdrawContent asset={assetWD} poolShare={combinedPoolShare} />
+        content: <WidthdrawContent poolDetail={poolDetailRD} asset={assetWD} poolShare={combinedPoolShare} />
       }
       // {
       //   key: 'withdraw-asym-asset',
@@ -121,7 +124,7 @@ export const Deposit: React.FC<Props> = (props) => {
       //   content: <AsymWidthdrawContent asset={asset} poolShare={asymPoolShareAsset} />
       // }
     ],
-    [intl, assetWD, SymDepositContent, hasSymPoolShare, WidthdrawContent, combinedPoolShare]
+    [intl, assetWD, SymDepositContent, hasSymPoolShare, WidthdrawContent, combinedPoolShare, poolDetailRD]
   )
 
   const alignTopShareContent: boolean = useMemo(
@@ -148,7 +151,12 @@ export const Deposit: React.FC<Props> = (props) => {
             </Styled.DepositContentCol>
             <Styled.ShareContentCol xs={24} xl={9}>
               <Styled.ShareContentWrapper alignTop={alignTopShareContent}>
-                <ShareContent asset={assetWD} poolShare={combinedPoolShare} smallWidth={!isDesktopView} />
+                <ShareContent
+                  poolDetail={poolDetailRD}
+                  asset={assetWD}
+                  poolShare={combinedPoolShare}
+                  smallWidth={!isDesktopView}
+                />
               </Styled.ShareContentWrapper>
             </Styled.ShareContentCol>
           </>

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -23,7 +23,7 @@ import { sequenceTOption } from '../../helpers/fpHelpers'
 import { DepositRouteParams } from '../../routes/pools/deposit'
 import { AssetWithDecimalRD } from '../../services/chain/types'
 import { DEFAULT_NETWORK } from '../../services/const'
-import { PoolSharesLD, PoolSharesRD } from '../../services/midgard/types'
+import { PoolDetailRD, PoolSharesLD, PoolSharesRD } from '../../services/midgard/types'
 import { AsymDepositView } from './add/AsymDepositView'
 import { SymDepositView } from './add/SymDepositView'
 import * as Styled from './DepositView.styles'
@@ -44,7 +44,7 @@ export const DepositView: React.FC<Props> = () => {
     service: {
       setSelectedPoolAsset,
       selectedPoolAsset$,
-      pools: { reloadSelectedPoolDetail },
+      pools: { reloadSelectedPoolDetail, selectedPoolDetail$ },
       shares: { shares$, reloadShares }
     }
   } = useMidgardContext()
@@ -141,6 +141,8 @@ export const DepositView: React.FC<Props> = () => {
   // before a check of `keystoreState` can be done
   const keystoreState = useObservableState(keystoreService.keystore$, undefined)
 
+  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
+
   // Special case: `keystoreState` is `undefined` in first render loop
   // (see comment at its definition using `useObservableState`)
   if (keystoreState === undefined) {
@@ -166,6 +168,7 @@ export const DepositView: React.FC<Props> = () => {
           ),
           (asset) => (
             <Deposit
+              poolDetail={poolDetailRD}
               asset={asset}
               shares={poolSharesRD}
               keystoreState={keystoreState}

--- a/src/renderer/views/deposit/add/AsymDepositView.tsx
+++ b/src/renderer/views/deposit/add/AsymDepositView.tsx
@@ -32,9 +32,10 @@ import { WalletBalances } from '../../../types/wallet'
 
 type Props = {
   asset: Asset
+  poolDetail: PoolDetailRD
 }
 
-export const AsymDepositView: React.FC<Props> = ({ asset }) => {
+export const AsymDepositView: React.FC<Props> = ({ asset, poolDetail: poolDetailRD }) => {
   const history = useHistory()
   const intl = useIntl()
 
@@ -50,7 +51,7 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
 
   const {
     service: {
-      pools: { availableAssets$, priceRatio$, selectedPricePoolAsset$, selectedPoolDetail$, selectedPoolAddress$ },
+      pools: { availableAssets$, priceRatio$, selectedPricePoolAsset$, selectedPoolAddress$ },
       shares: { reloadShares }
     }
   } = useMidgardContext()
@@ -87,8 +88,6 @@ export const AsymDepositView: React.FC<Props> = ({ asset }) => {
     reloadBalances()
     reloadShares(5000)
   }, [reloadBalances, reloadShares])
-
-  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const assetBalance: O.Option<BaseAmount> = useMemo(
     () =>

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -35,10 +35,11 @@ import { WalletBalances } from '../../../types/wallet'
 
 type Props = {
   asset: AssetWithDecimal
+  poolDetail: PoolDetailRD
 }
 
 export const SymDepositView: React.FC<Props> = (props) => {
-  const { asset: assetWD } = props
+  const { asset: assetWD, poolDetail: poolDetailRD } = props
   const { asset } = assetWD
   const history = useHistory()
   const intl = useIntl()
@@ -59,7 +60,6 @@ export const SymDepositView: React.FC<Props> = (props) => {
         availableAssets$,
         priceRatio$,
         selectedPricePoolAsset$,
-        selectedPoolDetail$,
         reloadSelectedPoolDetail,
         selectedPoolAddress$,
         reloadPoolAddresses
@@ -95,8 +95,6 @@ export const SymDepositView: React.FC<Props> = (props) => {
   const [selectedPricePoolAsset] = useObservableState(() => FP.pipe(selectedPricePoolAsset$, RxOp.map(O.toUndefined)))
 
   const { balances: walletBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
-
-  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const assetBalance: O.Option<BaseAmount> = useMemo(
     () =>

--- a/src/renderer/views/deposit/share/ShareView.tsx
+++ b/src/renderer/views/deposit/share/ShareView.tsx
@@ -23,18 +23,23 @@ import * as Styled from './ShareView.styles'
 type Props = {
   asset: AssetWithDecimal
   poolShare: PoolShareRD
+  poolDetail: PoolDetailRD
   smallWidth?: boolean
 }
 
-export const ShareView: React.FC<Props> = ({ asset: assetWD, poolShare: poolShareRD, smallWidth }) => {
+export const ShareView: React.FC<Props> = ({
+  asset: assetWD,
+  poolShare: poolShareRD,
+  smallWidth,
+  poolDetail: poolDetailRD
+}) => {
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { selectedPoolDetail$, selectedPricePoolAsset$, selectedPricePool$ }
+    pools: { selectedPricePoolAsset$, selectedPricePool$ }
   } = midgardService
 
   const intl = useIntl()
 
-  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
   const oPriceAsset = useObservableState<O.Option<Asset>>(selectedPricePoolAsset$, O.none)
 
   const { poolData: pricePoolData } = useObservableState(selectedPricePool$, RUNE_PRICE_POOL)

--- a/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
+++ b/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
@@ -25,13 +25,14 @@ import { getBalanceByAsset } from '../../../services/wallet/util'
 type Props = {
   asset: Asset
   poolShare: PoolShareRD
+  poolDetail: PoolDetailRD
 }
 
 export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
-  const { asset, poolShare: poolShareRD } = props
+  const { asset, poolShare: poolShareRD, poolDetail: poolDetailRD } = props
   const {
     service: {
-      pools: { selectedPoolDetail$, selectedPricePoolAsset$, priceRatio$, selectedPoolAddress$ }
+      pools: { selectedPricePoolAsset$, priceRatio$, selectedPoolAddress$ }
     }
   } = useMidgardContext()
 
@@ -40,8 +41,6 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
   const runePrice = useObservableState(priceRatio$, bn(1))
 
   const oPoolAddress: O.Option<PoolAddress> = useObservableState(selectedPoolAddress$, O.none)
-
-  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const [selectedPriceAssetRD]: [RD.RemoteData<Error, Asset>, unknown] = useObservableState(
     () =>

--- a/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
+++ b/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
@@ -27,14 +27,15 @@ import { PoolDetail } from '../../../types/generated/midgard'
 type Props = {
   asset: AssetWithDecimal
   poolShare: PoolShareRD
+  poolDetail: PoolDetailRD
 }
 
 export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
-  const { asset: assetWD, poolShare: poolShareRD } = props
+  const { asset: assetWD, poolShare: poolShareRD, poolDetail: poolDetailRD } = props
   const { decimal: assetDecimal } = assetWD
   const {
     service: {
-      pools: { selectedPoolDetail$, selectedPricePoolAsset$, priceRatio$ },
+      pools: { selectedPricePoolAsset$, priceRatio$ },
       shares: { reloadShares }
     }
   } = useMidgardContext()
@@ -42,8 +43,6 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
   const { withdrawFee$, reloadWithdrawFees, symWithdraw$, getExplorerUrlByAsset$ } = useChainContext()
 
   const runePrice = useObservableState(priceRatio$, bn(1))
-
-  const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 
   const [selectedPriceAssetRD]: [RD.RemoteData<Error, Asset>, unknown] = useObservableState(
     () =>


### PR DESCRIPTION
Issue description:
`DepositView` is a composition view which render `ShareView` and `Sym/Asym-Deposit` / `Sym/Asym-Withdraw` views. Both of rendered views (`ShareView` + any of listed) are subscribing `selectedPoolDetail$` ([ShareView](https://github.com/thorchain/asgardex-electron/blob/develop/src/renderer/views/deposit/share/ShareView.tsx#L37),  [WithdrawView](https://github.com/thorchain/asgardex-electron/blob/develop/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx#L46) and etc.). so this leads to duplicated requests.

Solution:
- moved loading of `poolDetails` to the top-level at the `DepositView`

closes #1286 