### PR TITLE
Fix route handling in case of network switch

### DIFF
--- a/src/renderer/components/PoolShares/PoolShares.tsx
+++ b/src/renderer/components/PoolShares/PoolShares.tsx
@@ -10,6 +10,7 @@ import {
 } from '@xchainjs/xchain-util'
 import { Grid, Row } from 'antd'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
+import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../shared/api/types'
@@ -25,7 +26,7 @@ export type Props = {
   loading: boolean
   priceAsset: Asset | undefined
   network: Network
-  goToStakeInfo: () => void
+  goToStakeInfo: FP.Lazy<void>
 }
 
 export const PoolShares: React.FC<Props> = ({ data, priceAsset, goToStakeInfo, loading, network }) => {

--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -60,7 +60,7 @@ export const Header: React.FC = (): JSX.Element => {
     O.map((_) => poolsRoutes.base.path())
   )
 
-  // Check pool sub-routes and return url to re-direct in case of matching
+  // Check wallet sub-routes and return url to re-direct in case of matching
   const oWalletRedirectPath: O.Option<string> = FP.pipe(
     useRouteMatch([
       walletRoutes.send.template,
@@ -98,7 +98,7 @@ export const Header: React.FC = (): JSX.Element => {
       changeNetwork(network)
 
       const M = O.getFirstMonoid<string>()
-      // Handle first "some" value within a list of possible url to re-direct
+      // Handle first "some" value within a list of possible urls to re-direct
       FP.pipe(M.concat(oPoolRedirectPath, oWalletRedirectPath), O.map(history.replace))
     },
     [changeNetwork, history.replace, oPoolRedirectPath, oWalletRedirectPath]

--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -52,19 +52,18 @@ export const Header: React.FC = (): JSX.Element => {
 
   const history = useHistory()
 
-  // Pool sub routes needed to re-direct in case of network switch
+  // Pool sub-routes needed to re-direct in case of network switch
   const isPoolSubRoute = useRouteMatch([
     poolsRoutes.deposit.template,
     poolsRoutes.detail.template,
     poolsRoutes.swap.template
   ])
 
-  // Check wallet sub routes  needed to re-direct in case of network switch
+  // Wallet sub-routes  needed to re-direct in case of network switch
   const isWalletSubRoute = useRouteMatch([
     walletRoutes.send.template,
     walletRoutes.upgradeBnbRune.template,
     walletRoutes.assetDetail.template,
-    walletRoutes.bonds.template,
     walletRoutes.bonds.template,
     walletRoutes.deposit.template
   ])
@@ -77,26 +76,30 @@ export const Header: React.FC = (): JSX.Element => {
    * You might have following questions:
    *
    * (1) Why not handling this at service layer?
+   * --------------------------------------------
    * We can't handle this at service layer, because it's recommended by React Router to handle route states on view layer only.
    * Quote: "Our recommendation is not to keep your routes in your Redux store at all."
    * ^ @see https://reactrouter.com/web/guides/deep-redux-integration
    *
    * (2) Why don't  we handle re-directing in views, where we defined our routes (such as `PoolsView` or `WalletView`)?
+   * ------------------------------------------------------------------------------------------------------------------
    * Since we have to subscribe to `network$` to get changes by using `useSubscription` or something,
    * we get state of network after first rendering, but not before. With this, components are still trying to render data,
    * which might be deprecated based on network changes.
    *
    */
-
   const changeNetworkHandler = useCallback(
     (network: Network) => {
       changeNetwork(network)
-      // handle re-directs for pools
-      if (isPoolSubRoute) history.replace(poolsRoutes.base.path())
-      // handle re-directs for wallet
-      else if (isWalletSubRoute) history.replace(walletRoutes.base.path())
-      else {
-        /* do nothing */
+      // check pool sub-routes to re-direct
+      if (isPoolSubRoute) {
+        history.replace(poolsRoutes.base.path())
+      }
+      // check wallet sub-routes to re-direct
+      else if (isWalletSubRoute) {
+        history.replace(walletRoutes.base.path())
+      } else {
+        /* nothing to do */
       }
     },
     [changeNetwork, history, isPoolSubRoute, isWalletSubRoute]

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -29,7 +29,7 @@ import { HeaderContainer, TabLink, HeaderDrawer, HeaderDrawerItem } from './Head
 import { HeaderLang } from './lang'
 import { HeaderLock } from './lock/'
 import { HeaderNetStatus } from './netstatus'
-import { HeaderNetwork } from './network'
+import { HeaderNetworkSelector } from './network'
 import { HeaderPriceSelector } from './price'
 import { HeaderSettings } from './settings'
 import { HeaderTheme } from './theme'
@@ -246,7 +246,11 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
 
   const renderHeaderNetwork = useMemo(
     () => (
-      <HeaderNetwork isDesktopView={isDesktopView} selectedNetwork={selectedNetwork} changeNetwork={changeNetwork} />
+      <HeaderNetworkSelector
+        isDesktopView={isDesktopView}
+        selectedNetwork={selectedNetwork}
+        changeNetwork={changeNetwork}
+      />
     ),
     [selectedNetwork, changeNetwork, isDesktopView]
   )

--- a/src/renderer/components/header/network/HeaderNetworkSelector.stories.tsx
+++ b/src/renderer/components/header/network/HeaderNetworkSelector.stories.tsx
@@ -1,14 +1,14 @@
 import { Meta, Story } from '@storybook/react'
 import { Network } from '@xchainjs/xchain-client'
 
-import { HeaderNetwork } from './HeaderNetworkSelector'
+import { HeaderNetworkSelector } from './HeaderNetworkSelector'
 
 export const Default: Story<{
   network: Network
   isDesktopView: boolean
   changeNetwork: () => void
 }> = ({ network, isDesktopView, changeNetwork }) => {
-  return <HeaderNetwork selectedNetwork={network} changeNetwork={changeNetwork} isDesktopView={isDesktopView} />
+  return <HeaderNetworkSelector selectedNetwork={network} changeNetwork={changeNetwork} isDesktopView={isDesktopView} />
 }
 
 Default.args = { network: 'mainnet', isDesktopView: false }

--- a/src/renderer/components/header/network/HeaderNetworkSelector.tsx
+++ b/src/renderer/components/header/network/HeaderNetworkSelector.tsx
@@ -24,7 +24,11 @@ type Props = {
   changeNetwork: (network: Network) => void
 }
 
-export const HeaderNetwork: React.FC<Props> = ({ isDesktopView, changeNetwork = FP.constVoid, selectedNetwork }) => {
+export const HeaderNetworkSelector: React.FC<Props> = ({
+  isDesktopView,
+  changeNetwork = FP.constVoid,
+  selectedNetwork
+}) => {
   const intl = useIntl()
 
   const changeNetworkHandler: MenuProps['onClick'] = useCallback(

--- a/src/renderer/routes/wallet/wallet.ts
+++ b/src/renderer/routes/wallet/wallet.ts
@@ -5,8 +5,10 @@ import * as O from 'fp-ts/lib/Option'
 import { isRuneBnbAsset } from '../../helpers/assetHelper'
 import { sequenceTOption } from '../../helpers/fpHelpers'
 import { Route } from '../types'
-import * as createRoutes from './create'
-import * as importRoutes from './imports'
+
+export * as imports from './imports'
+
+export * as create from './create'
 
 type RedirectUrl = string
 
@@ -24,8 +26,6 @@ export const noWallet: Route<void> = {
   }
 }
 
-export const imports = importRoutes
-
 export const REDIRECT_PARAMETER_NAME = 'redirectUrl'
 
 export const locked: Route<RedirectUrl | void> = {
@@ -34,8 +34,6 @@ export const locked: Route<RedirectUrl | void> = {
     return redirectUrl ? `${this.template}?${REDIRECT_PARAMETER_NAME}=${redirectUrl}` : this.template
   }
 }
-
-export const create = createRoutes
 
 export const settings: Route<void> = {
   template: `${base.template}/settings`,

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -191,8 +191,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      }),
-      RxOp.shareReplay(1)
+      })
     )
 
   /**
@@ -557,8 +556,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
 
   const poolStatsDetail$: PoolStatsDetailLD = Rx.combineLatest([selectedPoolAsset$, reloadSelectedPoolDetail$]).pipe(
@@ -590,8 +588,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
 
   const poolLegacyDetail$: PoolLegacyDetailLD = Rx.combineLatest([selectedPoolAsset$, reloadSelectedPoolDetail$]).pipe(
@@ -608,8 +605,7 @@ const createPoolsService = (
         )
       )
     }),
-    RxOp.startWith(RD.pending),
-    RxOp.shareReplay(1)
+    RxOp.startWith(RD.pending)
   )
 
   // Factory to get earning history
@@ -623,8 +619,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
 
   const poolEarningHistory$: PoolEarningHistoryLD = Rx.combineLatest([
@@ -637,7 +632,6 @@ const createPoolsService = (
         RxOp.switchMap(() => Rx.of(oSelectedPoolAsset))
       )
     ),
-    RxOp.filter(O.isSome),
     RxOp.switchMap((selectedPoolAsset) => {
       return FP.pipe(
         selectedPoolAsset,
@@ -669,13 +663,11 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
 
   const poolLiquidityHistory$ = (params: PoolLiquidityHistoryParams): PoolLiquidityHistoryLD =>
     selectedPoolAsset$.pipe(
-      RxOp.filter(O.isSome),
       RxOp.switchMap((selectedPoolAsset) =>
         FP.pipe(
           selectedPoolAsset,
@@ -689,8 +681,7 @@ const createPoolsService = (
           )
         )
       ),
-      RxOp.startWith(RD.pending),
-      RxOp.shareReplay(1)
+      RxOp.startWith(RD.pending)
     )
 
   // Factory to get swap history from Midgard
@@ -705,8 +696,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
   }
 
@@ -745,8 +735,7 @@ const createPoolsService = (
           RxOp.startWith(RD.pending),
           RxOp.catchError((e: Error) => Rx.of(RD.failure(e)))
         )
-      ),
-      RxOp.shareReplay(1)
+      )
     )
   }
 

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -60,6 +60,7 @@ export const PoolDetailsView: React.FC = () => {
     setSelectedPoolAsset(oRouteAsset)
     // Reset selectedPoolAsset on view's unmount to avoid effects with depending streams
     return () => {
+      console.log('PoolDetailsView: onLeave')
       setSelectedPoolAsset(O.none)
     }
   }, [oRouteAsset, setSelectedPoolAsset])

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -60,7 +60,6 @@ export const PoolDetailsView: React.FC = () => {
     setSelectedPoolAsset(oRouteAsset)
     // Reset selectedPoolAsset on view's unmount to avoid effects with depending streams
     return () => {
-      console.log('PoolDetailsView: onLeave')
       setSelectedPoolAsset(O.none)
     }
   }, [oRouteAsset, setSelectedPoolAsset])

--- a/src/renderer/views/pools/PoolsView.tsx
+++ b/src/renderer/views/pools/PoolsView.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import { useSubscription } from 'observable-hooks'
-import { Route, Switch, useHistory } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 
-import { useAppContext } from '../../contexts/AppContext'
 import * as poolsRoutes from '../../routes/pools'
 import { DepositView } from '../deposit/DepositView'
 import { PoolDetailsView } from '../pool/PoolDetailsView'
@@ -11,21 +9,6 @@ import { SwapView } from '../swap/SwapView'
 import { PoolsOverview } from './PoolsOverview'
 
 export const PoolsView: React.FC = (): JSX.Element => {
-  const { network$ } = useAppContext()
-  const history = useHistory()
-
-  /**
-   * All of inner routes are Pool dependent.
-   * After network switched there might be
-   * a situation when there is no such pool
-   * as previously selected for previous network.
-   * For this reason for every network change
-   * we redirect to the top-level route
-   */
-  useSubscription(network$, () => {
-    history.replace(poolsRoutes.base.path())
-  })
-
   return (
     <Switch>
       <Route path={poolsRoutes.base.template} exact>

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -2,12 +2,11 @@ import React, { useCallback, useMemo } from 'react'
 
 import { Row } from 'antd'
 import * as H from 'history'
-import { useObservableState, useSubscription } from 'observable-hooks'
-import { Switch, Route, Redirect, useHistory, useRouteMatch } from 'react-router-dom'
+import { useObservableState } from 'observable-hooks'
+import { Switch, Route, Redirect } from 'react-router-dom'
 
 import { RefreshButton } from '../../components/uielements/button/'
 import { AssetsNav } from '../../components/wallet/assets'
-import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
@@ -54,32 +53,6 @@ export const WalletView: React.FC = (): JSX.Element => {
     ),
     []
   )
-
-  const { network$ } = useAppContext()
-  const history = useHistory()
-
-  const isSendRoute = useRouteMatch(walletRoutes.send.template)
-  const isUpgradeBnbRuneRoute = useRouteMatch(walletRoutes.upgradeBnbRune.template)
-  const isAssetDetailRoute = useRouteMatch(walletRoutes.assetDetail.template)
-
-  const isPoolDependantRoute = useMemo(() => isSendRoute || isUpgradeBnbRuneRoute || isAssetDetailRoute, [
-    isSendRoute,
-    isUpgradeBnbRuneRoute,
-    isAssetDetailRoute
-  ])
-
-  /**
-   * After network was switched there might be
-   * a situation when there is no such pool
-   * as previously selected for previous network.
-   * For this reason for every poolDependent route and
-   * network change we redirect to the top-level route
-   */
-  useSubscription(network$, () => {
-    if (isPoolDependantRoute) {
-      history.replace(walletRoutes.base.path())
-    }
-  })
 
   // Following routes are accessable only,
   // if an user has a phrase imported and wallet has not been locked


### PR DESCRIPTION
- [x] Fixes #1294 
- [x] Extract handling of re-directs from `PoolsView` and  `WalletView` into `Header` ([this comment explains](https://github.com/thorchain/asgardex-electron/pull/1298/files#diff-f561f8ec69c35b3156218582c4199bbcdb136e713a29e4bfcda6f322b66bd1efR77-R87) why this change was needed)
- [x] Remove `shareReply` + `O.filter` from misc. pool services to fix memory (requests) leaks  to get data for PoolsDetailViews while switching `network`
- [x] Rename `HeaderNetwork` -> `HeaderNetworkSelector`
