### PR TITLE
[Wallet] History

### DIFF
--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.test.ts
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.test.ts
@@ -173,7 +173,8 @@ describe('PoolActionsHistory.helper', () => {
       ).toEqual('inId')
     })
 
-    it('should return default value in case there is no txId (`dateTimrStamp-action.type`)', () => {
+    it('should return default value in case there is no txId (`action.date-action.type`)', () => {
+      // Date(0) is a default date property value for defaultPoolAction
       expect(getRowKey(defaultPoolAction)).toEqual(`${new Date(0)}-SWAP`)
     })
   })

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.test.ts
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.test.ts
@@ -3,7 +3,7 @@ import * as O from 'fp-ts/Option'
 
 import { eqAssetsWithAmount } from '../../helpers/fp/eq'
 import { PoolAction, Tx } from '../../services/midgard/types'
-import { getTxId, getValues } from './PoolActionsHistory.helper'
+import { getTxId, getValues, getRowKey } from './PoolActionsHistory.helper'
 
 const defaultPoolAction: PoolAction = {
   date: new Date(0),
@@ -126,6 +126,55 @@ describe('PoolActionsHistory.helper', () => {
           { asset: AssetBNB, amount: baseAmount(100) }
         ])
       ).toBeTruthy()
+    })
+  })
+  describe('getRowKey', () => {
+    it('should return correct id if exists', () => {
+      expect(
+        getRowKey({
+          ...defaultPoolAction,
+          in: [
+            {
+              ...defaultTx,
+              txID: 'inId'
+            }
+          ]
+        })
+      ).toEqual('inId')
+
+      expect(
+        getRowKey({
+          ...defaultPoolAction,
+          out: [
+            {
+              ...defaultTx,
+              txID: 'outId'
+            }
+          ]
+        })
+      ).toEqual('outId')
+
+      expect(
+        getRowKey({
+          ...defaultPoolAction,
+          in: [
+            {
+              ...defaultTx,
+              txID: 'inId'
+            }
+          ],
+          out: [
+            {
+              ...defaultTx,
+              txID: 'outId'
+            }
+          ]
+        })
+      ).toEqual('inId')
+    })
+
+    it('should return default value in case there is no txId (`dateTimrStamp-action.type`)', () => {
+      expect(getRowKey(defaultPoolAction)).toEqual(`${new Date(0)}-SWAP`)
     })
   })
 })

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.tsx
@@ -15,7 +15,9 @@ export const getTxId = (action: PoolAction): O.Option<TxHash> => {
     action.in,
     A.head,
     O.alt(() => FP.pipe(action.out, A.head)),
-    O.map(({ txID }) => txID)
+    O.map(({ txID }) => txID),
+    // Filter out empty strings
+    O.filter((id) => !!id)
   )
 }
 

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.helper.tsx
@@ -36,4 +36,12 @@ export const renderDate = (date: Date) => (
   </Styled.DateContainer>
 )
 
+export const getRowKey = (action: PoolAction) =>
+  FP.pipe(
+    action,
+    getTxId,
+    O.map(FP.identity),
+    O.getOrElse(() => `${action.date.toString()}-${action.type}`)
+  )
+
 export const emptyData: PoolActionsHistoryPage = { total: 0, actions: [] as PoolActions }

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
@@ -142,6 +142,7 @@ export const History: Story<{ dataStatus: RDStatus }> = ({ dataStatus }) => {
   const [filter, setFilter] = useState<Filter>('ALL')
   return (
     <PoolActionsHistory
+      availableFilters={['ALL', 'SWITCH', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']}
       currentFilter={filter}
       setFilter={setFilter}
       goToTx={console.log}

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.stories.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.stories.tsx
@@ -7,7 +7,13 @@ import { Filter as FilterType } from './types'
 
 export const Filter: Story = () => {
   const [filter, setFilter] = useState<FilterType>('ALL')
-  return <PoolActionsHistoryFilter currentFilter={filter} onFilterChanged={setFilter} />
+  return (
+    <PoolActionsHistoryFilter
+      currentFilter={filter}
+      onFilterChanged={setFilter}
+      availableFilters={['ALL', 'SWITCH', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']}
+    />
+  )
 }
 
 export default {

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.tsx
@@ -15,16 +15,21 @@ type Props = {
   currentFilter: Filter
   onFilterChanged: (targetFilter: Filter) => void
   disabled?: boolean
+  availableFilters: Filter[]
 }
 
-const FILTER_ITEMS: Filter[] = ['ALL', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']
-
-export const PoolActionsHistoryFilter: React.FC<Props> = ({ currentFilter, onFilterChanged, className, disabled }) => {
+export const PoolActionsHistoryFilter: React.FC<Props> = ({
+  currentFilter,
+  onFilterChanged,
+  className,
+  disabled,
+  availableFilters
+}) => {
   const intl = useIntl()
   const activeFilterIndex = useMemo(() => {
-    const index = FILTER_ITEMS.indexOf(currentFilter)
+    const index = availableFilters.indexOf(currentFilter)
     return index > -1 ? index : 0
-  }, [currentFilter])
+  }, [currentFilter, availableFilters])
 
   const allItemContent = useMemo(
     () => (
@@ -37,9 +42,9 @@ export const PoolActionsHistoryFilter: React.FC<Props> = ({ currentFilter, onFil
 
   const menu = useMemo(() => {
     return (
-      <Styled.Menu selectedKeys={[FILTER_ITEMS[activeFilterIndex]]}>
+      <Styled.Menu selectedKeys={[availableFilters[activeFilterIndex]]}>
         {FP.pipe(
-          FILTER_ITEMS,
+          availableFilters,
           A.map((filter) => {
             const content = filter === 'ALL' ? allItemContent : <TxType type={filter} />
             return (
@@ -51,7 +56,7 @@ export const PoolActionsHistoryFilter: React.FC<Props> = ({ currentFilter, onFil
         )}
       </Styled.Menu>
     )
-  }, [activeFilterIndex, onFilterChanged, allItemContent])
+  }, [activeFilterIndex, onFilterChanged, allItemContent, availableFilters])
 
   return (
     <Dropdown overlay={menu} trigger={['click']} disabled={disabled}>

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
@@ -16,13 +16,12 @@ import { Props } from './types'
 const renderItem = (goToTx: (txId: string) => void) => (action: PoolAction) => {
   const date = H.renderDate(action.date)
 
-  const oTxId = H.getTxId(action)
-
   const titleExtra = (
     <>
       {date}
       {FP.pipe(
-        oTxId,
+        action,
+        H.getTxId,
         O.map((id) => (
           <Styled.GoToButton key="go" onClick={() => goToTx(id)}>
             <Styled.InfoArrow />
@@ -33,14 +32,8 @@ const renderItem = (goToTx: (txId: string) => void) => (action: PoolAction) => {
     </>
   )
 
-  const rowKey = FP.pipe(
-    oTxId,
-    O.map(FP.identity),
-    O.getOrElse(() => `${action.date.toString()}-${Math.random()}`)
-  )
-
   return (
-    <Styled.ListItem key={rowKey}>
+    <Styled.ListItem key={H.getRowKey(action)}>
       <Styled.Card title={<Styled.TxType type={action.type} />} extra={titleExtra}>
         <TxDetail type={action.type} date={date} incomes={H.getValues(action.in)} outgos={H.getValues(action.out)} />
       </Styled.Card>

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
@@ -56,7 +56,8 @@ export const PoolActionsHistoryList: React.FC<Props> = ({
   currentPage,
   currentFilter,
   setFilter,
-  className
+  className,
+  availableFilters
 }) => {
   const renderListItem = useMemo(() => renderItem(goToTx), [goToTx])
   const renderList = useCallback(
@@ -82,6 +83,7 @@ export const PoolActionsHistoryList: React.FC<Props> = ({
   return (
     <div className={className}>
       <Styled.ActionsFilter
+        availableFilters={availableFilters}
         currentFilter={currentFilter}
         onFilterChanged={setFilter}
         disabled={!RD.isSuccess(actionsPageRD)}

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
@@ -114,18 +114,11 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
     linkColumn
   ])
 
-  const rowKey = (action: PoolAction) =>
-    FP.pipe(
-      H.getTxId(action),
-      O.map(FP.identity),
-      O.getOrElse(() => `${action.date.toString()}-${action.type}`)
-    )
-
   const renderTable = useCallback(
     ({ total, actions }: PoolActionsHistoryPage, loading = false) => {
       return (
         <>
-          <Styled.Table columns={columns} dataSource={actions} loading={loading} rowKey={rowKey} />
+          <Styled.Table columns={columns} dataSource={actions} loading={loading} rowKey={H.getRowKey} />
           {total > 0 && (
             <Pagination
               current={currentPage}

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { ColumnsType, ColumnType } from 'antd/lib/table'
-import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
@@ -25,7 +24,8 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
   prevActionsPage = O.none,
   currentPage,
   currentFilter,
-  setFilter
+  setFilter,
+  availableFilters
 }) => {
   const intl = useIntl()
 
@@ -34,12 +34,18 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
   const actionTypeColumn: ColumnType<PoolAction> = useMemo(
     () => ({
       key: 'txType',
-      title: <Styled.ActionsFilter currentFilter={currentFilter} onFilterChanged={setFilter} />,
+      title: (
+        <Styled.ActionsFilter
+          availableFilters={availableFilters}
+          currentFilter={currentFilter}
+          onFilterChanged={setFilter}
+        />
+      ),
       align: 'left',
       width: 180,
       render: renderActionTypeColumn
     }),
-    [renderActionTypeColumn, setFilter, currentFilter]
+    [renderActionTypeColumn, setFilter, currentFilter, availableFilters]
   )
 
   const renderDateColumn = useCallback((_, { date }: PoolAction) => H.renderDate(date), [])
@@ -58,10 +64,9 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
   const renderLinkColumn = useCallback(
     (action: PoolAction) =>
       FP.pipe(
-        action.in,
-        A.head,
-        O.alt(() => A.head(action.out)),
-        O.map(({ txID }) => <CommonStyled.ExternalLinkIcon key="external link" onClick={() => goToTx(txID)} />),
+        action,
+        H.getTxId,
+        O.map((txID) => <CommonStyled.ExternalLinkIcon key="external link" onClick={() => goToTx(txID)} />),
         O.getOrElse(() => <></>)
       ),
     [goToTx]
@@ -113,7 +118,7 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
     FP.pipe(
       H.getTxId(action),
       O.map(FP.identity),
-      O.getOrElse(() => `${action.date.toString()}-${Math.random()}`)
+      O.getOrElse(() => `${action.date.toString()}-${action.type}`)
     )
 
   const renderTable = useCallback(

--- a/src/renderer/components/poolActionsHistory/types.ts
+++ b/src/renderer/components/poolActionsHistory/types.ts
@@ -13,4 +13,5 @@ export type Props = {
   currentFilter: Filter
   setFilter: (filter: Filter) => void
   className?: string
+  availableFilters: Filter[]
 }

--- a/src/renderer/components/uielements/txType/TxType.styles.ts
+++ b/src/renderer/components/uielements/txType/TxType.styles.ts
@@ -1,3 +1,4 @@
+import { UpCircleOutlined } from '@ant-design/icons/lib'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
@@ -23,7 +24,15 @@ export const IconContainer = styled.span`
   width: 30px;
   height: 30px;
 
-  > svg {
+  svg {
     stroke: ${palette('primary', 0)};
+    fill: ${palette('primary', 0)};
+  }
+`
+
+export const UpgradeIcon = styled(UpCircleOutlined)`
+  svg {
+    width: 20px;
+    height: 20px;
   }
 `

--- a/src/renderer/components/uielements/txType/TxType.styles.ts
+++ b/src/renderer/components/uielements/txType/TxType.styles.ts
@@ -26,7 +26,6 @@ export const IconContainer = styled.span`
 
   svg {
     stroke: ${palette('primary', 0)};
-    fill: ${palette('primary', 0)};
   }
 `
 
@@ -34,5 +33,6 @@ export const UpgradeIcon = styled(UpCircleOutlined)`
   svg {
     width: 20px;
     height: 20px;
+    fill: ${palette('primary', 0)};
   }
 `

--- a/src/renderer/components/uielements/txType/TxType.tsx
+++ b/src/renderer/components/uielements/txType/TxType.tsx
@@ -45,6 +45,8 @@ const getTypeI18nKey = (type: MidgardTxType): CommonMessageKey | undefined => {
       return 'common.tx.type.donate'
     case 'REFUND':
       return 'common.tx.type.refund'
+    case 'SWITCH':
+      return 'common.tx.type.upgrade'
   }
 }
 export const TxType: React.FC<Props> = ({ type, className }) => {

--- a/src/renderer/components/uielements/txType/TxType.tsx
+++ b/src/renderer/components/uielements/txType/TxType.tsx
@@ -28,6 +28,8 @@ const getIcon = (type: MidgardTxType) => {
       return <DonateIcon />
     case 'REFUND':
       return <RefundIcon />
+    case 'SWITCH':
+      return <Styled.UpgradeIcon />
     default:
       return <></>
   }

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -67,7 +67,7 @@ const common: CommonMessages = {
   'common.tx.type.refund': 'Erstatten',
   'common.tx.type.deposit': 'Einzahlen',
   'common.tx.type.withdraw': 'Auszahlen',
-  'common.tx.type.upgrade': 'Upgrade - DE',
+  'common.tx.type.upgrade': 'Upgrade',
   'common.detail': 'Detail',
   'common.filter': 'Filter',
   'common.all': 'Alle',

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -67,6 +67,7 @@ const common: CommonMessages = {
   'common.tx.type.refund': 'Erstatten',
   'common.tx.type.deposit': 'Einzahlen',
   'common.tx.type.withdraw': 'Auszahlen',
+  'common.tx.type.upgrade': 'Upgrade - DE',
   'common.detail': 'Detail',
   'common.filter': 'Filter',
   'common.all': 'Alle',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -67,6 +67,7 @@ const common: CommonMessages = {
   'common.tx.type.refund': 'Refund',
   'common.tx.type.deposit': 'Deposit',
   'common.tx.type.withdraw': 'Withdraw',
+  'common.tx.type.upgrade': 'Upgrade',
   'common.detail': 'Detail',
   'common.filter': 'Filter',
   'common.all': 'All',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -68,6 +68,7 @@ const common: CommonMessages = {
   'common.tx.type.deposit': 'Dépôt',
   'common.tx.type.withdraw': 'Retrait',
   'common.detail': 'Détail',
+  'common.tx.type.upgrade': 'Upgrade - FR',
   'common.filter': 'Filtre',
   'common.all': 'Tout',
   'common.time.week': 'Semaine',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -67,6 +67,7 @@ const common: CommonMessages = {
   'common.tx.type.refund': 'Возврат',
   'common.tx.type.deposit': 'Вклад',
   'common.tx.type.withdraw': 'Изъятие',
+  'common.tx.type.upgrade': 'Обновление',
   'common.detail': 'Детали',
   'common.filter': 'Фильтр',
   'common.all': 'Все',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -70,6 +70,7 @@ export type CommonMessageKey =
   | 'common.tx.type.donate'
   | 'common.tx.type.deposit'
   | 'common.tx.type.withdraw'
+  | 'common.tx.type.upgrade'
   | 'common.time.week'
   | 'common.time.all'
 

--- a/src/renderer/services/midgard/poolActionsHistory.utils.ts
+++ b/src/renderer/services/midgard/poolActionsHistory.utils.ts
@@ -15,6 +15,7 @@ export const getTxType = (apiString: string): TxType => {
     case 'WITHDRAW':
     case 'DONATE':
     case 'REFUND':
+    case 'SWITCH':
       return type
     case 'ADDLIQUIDITY':
       return 'DEPOSIT'
@@ -30,6 +31,7 @@ export const getRequestType = (type?: TxType | 'ALL'): string | undefined => {
     case 'DEPOSIT': {
       return 'addLiquidity'
     }
+    case 'SWITCH':
     case 'SWAP':
     case 'WITHDRAW':
     case 'DONATE':

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -233,6 +233,7 @@ export type TxType =
   | 'WITHDRAW'
   | 'DONATE'
   | 'REFUND'
+  | 'SWITCH'
   // in case asgardex does not know about any other action type we will display
   // 'unknown' tx type to avoid filtering out any tx
   | 'UNKNOWN'

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -28,6 +28,8 @@ const DEFAULT_REQUEST_PARAMS = {
   itemsPerPage: 5
 }
 
+const HISTORY_FILTERS: Filter[] = ['ALL', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']
+
 export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
   const {
     service: {
@@ -124,6 +126,7 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
       goToTx={goToTx}
       changePaginationHandler={setCurrentPage}
       currentFilter={requestParams.type || 'ALL'}
+      availableFilters={HISTORY_FILTERS}
       setFilter={setFilter}
     />
   )

--- a/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
+++ b/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
@@ -19,6 +19,8 @@ import { ENABLED_CHAINS } from '../../../services/const'
 import { DEFAULT_ACTIONS_HISTORY_REQUEST_PARAMS } from '../../../services/midgard/poolActionsHistory'
 import { PoolActionsHistoryPage } from '../../../services/midgard/types'
 
+const HISTORY_FILTERS: Filter[] = ['ALL', 'SWITCH', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']
+
 export const PoolActionsHistoryView: React.FC<{ className?: string }> = ({ className }) => {
   const {
     service: {
@@ -118,6 +120,7 @@ export const PoolActionsHistoryView: React.FC<{ className?: string }> = ({ class
       changePaginationHandler={setCurrentPage}
       currentFilter={requestParams.type || 'ALL'}
       setFilter={setFilter}
+      availableFilters={HISTORY_FILTERS}
     />
   )
 }


### PR DESCRIPTION
- added `SWITCH` TxType;
- `PoolActionsHistory` (and related):
- -  added `availableFilters` prop (`upgrade` filter does not make sense for `PoolDetails` page)
- - fixed non-unique keys for history action (moved to separate `getRowKey` helper + testes)
- - fixed filtering empty `txId`
- `TxType`: added Upgrade icon

closes #1321 