### PR TITLE
Fix handling of explorer url

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@xchainjs/xchain-crypto": "^0.2.3",
     "@xchainjs/xchain-ethereum": "^0.18.0",
     "@xchainjs/xchain-litecoin": "^0.4.1",
-    "@xchainjs/xchain-thorchain": "^0.13.2",
+    "@xchainjs/xchain-thorchain": "^0.13.3",
     "@xchainjs/xchain-util": "^0.2.6",
     "antd": "^4.15.0",
     "axios": "^0.21.0",

--- a/src/main/api/ledger/binance.ts
+++ b/src/main/api/ledger/binance.ts
@@ -35,7 +35,7 @@
 // ): Promise<E.Either<LedgerErrorId, string>> => {
 //   try {
 //     const { sender, recipient, asset, amount, memo } = txInfo
-//     const client = new Client({ network: network === 'testnet' ? 'testnet' : 'mainnet' })
+//     const client = new Client({ network: getClientNetwork(network)})
 //     const app = new AppBNB(transport)
 //     const derive_path = getDerivePath(0)
 //     const hpr = network === 'testnet' ? 'tbnb' : 'bnb' // This will be replaced later with "const hpr = client.getPrefix()"

--- a/src/main/api/ledger/bitcoin.ts
+++ b/src/main/api/ledger/bitcoin.ts
@@ -32,7 +32,7 @@
 //     const derive_path = getDerivePath(0)
 //     const { utxos, newTxHex } = await createTxInfo({
 //       ...txInfo,
-//       network: network === 'testnet' ? 'testnet' : 'mainnet'
+//       network: getClientNetwork(network)
 //     })
 //     const txs = utxos.map((utxo) => {
 //       return {

--- a/src/renderer/contexts/AppContext.tsx
+++ b/src/renderer/contexts/AppContext.tsx
@@ -1,16 +1,18 @@
 import React, { createContext, useContext } from 'react'
 
-import { onlineStatus$, network$, changeNetwork } from '../services/app/service'
+import { onlineStatus$, network$, changeNetwork, clientNetwork$ } from '../services/app/service'
 
 type AppContextValue = {
   onlineStatus$: typeof onlineStatus$
   network$: typeof network$
   changeNetwork: typeof changeNetwork
+  clientNetwork$: typeof clientNetwork$
 }
 const initialContext: AppContextValue = {
   onlineStatus$,
   network$,
-  changeNetwork
+  changeNetwork,
+  clientNetwork$
 }
 
 const AppContext = createContext<AppContextValue | null>(null)

--- a/src/renderer/services/app/service.ts
+++ b/src/renderer/services/app/service.ts
@@ -1,3 +1,4 @@
+import * as Client from '@xchainjs/xchain-client'
 import * as Rx from 'rxjs'
 import { startWith, mapTo, distinctUntilChanged } from 'rxjs/operators'
 import * as RxOp from 'rxjs/operators'
@@ -23,8 +24,8 @@ const { get$: getNetwork$, set: changeNetwork, get: getCurrentNetworkState } = o
 // Since `network$` based on `observableState` and it takes an initial value,
 // it might emit same values, we don't interested in.
 // So we do need a simple "dirty check" to provide "real" changes of selected network
-const network$ = getNetwork$.pipe(distinctUntilChanged())
+const network$: Rx.Observable<Network> = getNetwork$.pipe(distinctUntilChanged())
 
-const clientNetwork$ = network$.pipe(RxOp.map(getClientNetwork))
+const clientNetwork$: Rx.Observable<Client.Network> = network$.pipe(RxOp.map(getClientNetwork))
 
 export { onlineStatus$, network$, changeNetwork, getCurrentNetworkState, clientNetwork$ }

--- a/src/renderer/services/app/service.ts
+++ b/src/renderer/services/app/service.ts
@@ -1,8 +1,10 @@
 import * as Rx from 'rxjs'
 import { startWith, mapTo, distinctUntilChanged } from 'rxjs/operators'
+import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../shared/api/types'
 import { observableState } from '../../helpers/stateHelper'
+import { getClientNetwork } from '../clients'
 import { DEFAULT_NETWORK } from '../const'
 import { OnlineStatus } from './types'
 
@@ -23,4 +25,6 @@ const { get$: getNetwork$, set: changeNetwork, get: getCurrentNetworkState } = o
 // So we do need a simple "dirty check" to provide "real" changes of selected network
 const network$ = getNetwork$.pipe(distinctUntilChanged())
 
-export { onlineStatus$, network$, changeNetwork, getCurrentNetworkState }
+const clientNetwork$ = network$.pipe(RxOp.map(getClientNetwork))
+
+export { onlineStatus$, network$, changeNetwork, getCurrentNetworkState, clientNetwork$ }

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -1,5 +1,4 @@
 import { Client as BitcoinClient } from '@xchainjs/xchain-bitcoin'
-import { Network as ClientNetwork } from '@xchainjs/xchain-client'
 import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
@@ -7,24 +6,12 @@ import * as Rx from 'rxjs'
 import { Observable, Observer } from 'rxjs'
 import { map, mergeMap, shareReplay } from 'rxjs/operators'
 
-import { network$ } from '../app/service'
+import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { GetExplorerAddressUrl$ } from '../clients'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState } from './types'
-
-/**
- * Bitcoin network depending on selected `Network`
- */
-const bitcoinNetwork$: Observable<ClientNetwork> = network$.pipe(
-  map((network) => {
-    // In case of 'chaosnet' + 'mainnet` we stick on `mainnet`
-    if (network === 'chaosnet') return 'mainnet'
-
-    return network
-  })
-)
 
 /**
  * Stream to create an observable BitcoinClient depending on existing phrase in keystore
@@ -33,16 +20,16 @@ const bitcoinNetwork$: Observable<ClientNetwork> = network$.pipe(
  * By the other hand: Whenever a phrase has been removed, the client is set to `none`
  * A BitcoinClient will never be created as long as no phrase is available
  */
-const clientState$ = Rx.combineLatest([keystoreService.keystore$, bitcoinNetwork$]).pipe(
+const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
   mergeMap(
-    ([keystore, bitcoinNetwork]) =>
+    ([keystore, network]) =>
       new Observable((observer: Observer<ClientState>) => {
         const client: ClientState = FP.pipe(
           getPhrase(keystore),
           O.chain((phrase) => {
             try {
               const client = new BitcoinClient({
-                network: bitcoinNetwork,
+                network,
                 phrase
               })
               return O.some(right(client))

--- a/src/renderer/services/chain/decimal.ts
+++ b/src/renderer/services/chain/decimal.ts
@@ -20,7 +20,6 @@ import * as RxOp from 'rxjs/operators'
 import { Network } from '../../../shared/api/types'
 import { BNB_DECIMAL, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { getERC20Decimal } from '../ethereum/common'
-import { toThorNetwork } from '../thorchain/common'
 import { AssetWithDecimalLD } from './types'
 
 const getDecimal = (asset: Asset, network: Network): Promise<number> => {
@@ -34,7 +33,6 @@ const getDecimal = (asset: Asset, network: Network): Promise<number> => {
     case THORChain:
       return Promise.resolve(THORCHAIN_DECIMAL)
     case PolkadotChain: {
-      const _thorNetwork = toThorNetwork(network)
       // return Promise.resolve(getDecimalDot(thorNetwork))
       return Promise.reject('Polkadot is not supported yet')
     }

--- a/src/renderer/services/chain/transaction/transaction.helper.ts
+++ b/src/renderer/services/chain/transaction/transaction.helper.ts
@@ -28,7 +28,7 @@ export const smallestAmountToSent = (chain: Chain, _network: Network): BaseAmoun
     case 'GAIA':
       return baseAmount(1, COSMOS_DECIMAL)
     case 'POLKA':
-      // return baseAmount(1, getDecimalDot(network === 'mainnet' ? 'mainnet' : 'testnet'))
+      // return baseAmount(1, getDecimalDot(getClientNetwork(network))
       throw Error('Polkadot is not supported yet')
     case 'BCH':
       // 1000 satoshi

--- a/src/renderer/services/clients/utils.test.ts
+++ b/src/renderer/services/clients/utils.test.ts
@@ -3,7 +3,7 @@ import * as E from 'fp-ts/lib/Either'
 import * as O from 'fp-ts/lib/Option'
 
 import { ClientState } from '../clients/types'
-import { getClient, hasClient, getClientStateForViews } from './utils'
+import { getClient, hasClient, getClientStateForViews, getClientNetwork } from './utils'
 
 // Mocking non default class exports
 // https://jestjs.io/docs/en/es6-class-mocks#mocking-non-default-class-exports
@@ -70,6 +70,18 @@ describe('services/utils/', () => {
       const state: ClientState<Client> = O.some(E.left(new Error('any error')))
       const result = getClientStateForViews(state)
       expect(result).toEqual('error')
+    })
+  })
+
+  describe('getClientNetwork', () => {
+    it('for testnet', () => {
+      expect(getClientNetwork('testnet')).toEqual('testnet')
+    })
+    it('for mainnent', () => {
+      expect(getClientNetwork('mainnet')).toEqual('mainnet')
+    })
+    it('returns mainnet for chaosnet', () => {
+      expect(getClientNetwork('chaosnet')).toEqual('mainnet')
     })
   })
 })

--- a/src/renderer/services/clients/utils.ts
+++ b/src/renderer/services/clients/utils.ts
@@ -1,7 +1,9 @@
+import * as Client from '@xchainjs/xchain-client'
 import * as E from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
+import { Network } from '../../../shared/api/types'
 import { ClientStateM, ClientStateForViews, ClientState } from './types'
 
 export const getClient = <C>(clientState: ClientState<C>): O.Option<C> =>
@@ -26,3 +28,9 @@ export const getClientStateForViews = <C>(clientState: ClientState<C>): ClientSt
       )
     )
   )
+
+/**
+ * Helper to transform `Network` (ASGDX) -> `Client.Network` (xchain-client)
+ * Note In case of 'chaosnet' + 'mainnet` we stick on `mainnet`
+ */
+export const getClientNetwork = (network: Network): Client.Network => (network === 'testnet' ? 'testnet' : 'mainnet')

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -1,9 +1,11 @@
+import * as Client from '@xchainjs/xchain-client'
 import { isChain, Chain } from '@xchainjs/xchain-util'
 
 import { Network } from '../../shared/api/types'
 import { envOrDefault } from '../helpers/envHelper'
 
 export const DEFAULT_NETWORK: Network = 'chaosnet'
+export const DEFAULT_CLIENT_NETWORK: Client.Network = 'mainnet'
 export const AVAILABLE_NETWORKS: Network[] = ['testnet', 'chaosnet'] // ['testnet', 'chaosnet', 'mainnet']
 export const ENABLED_CHAINS: Chain[] = envOrDefault(process.env.REACT_APP_CHAINS_ENABLED, 'THOR,BNB,BTC,LTC,BCH,ETH')
   .replace(/\s/g, '')

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
+import * as Client from '@xchainjs/xchain-client'
 import { getDefaultExplorerTxUrl } from '@xchainjs/xchain-thorchain'
 import { Asset, assetToString } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
@@ -8,15 +9,13 @@ import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
-import { Network } from '../../../shared/api/types'
 import { PoolActionsHistory } from '../../components/poolActionsHistory'
 import { Filter } from '../../components/poolActionsHistory/types'
 import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { liveData } from '../../helpers/rx/liveData'
-import { getClientNetwork } from '../../services/clients'
-import { DEFAULT_NETWORK } from '../../services/const'
+import { DEFAULT_CLIENT_NETWORK } from '../../services/const'
 import { DEFAULT_ACTIONS_HISTORY_REQUEST_PARAMS, LoadActionsParams } from '../../services/midgard/poolActionsHistory'
 import { PoolActionsHistoryPage, PoolActionsHistoryPageRD } from '../../services/midgard/types'
 
@@ -39,8 +38,8 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
 
   const { getExplorerTxUrl$ } = useThorchainContext()
 
-  const { network$ } = useAppContext()
-  const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
+  const { clientNetwork$ } = useAppContext()
+  const clientNetwork = useObservableState<Client.Network>(clientNetwork$, DEFAULT_CLIENT_NETWORK)
 
   const prevActionsPage = useRef<O.Option<PoolActionsHistoryPage>>(O.none)
 
@@ -99,17 +98,12 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
     (txId: string) => {
       FP.pipe(
         oExplorerUrl,
-        O.alt(() =>
-          O.some((txId: string) => {
-            const clientNetwork = getClientNetwork(network)
-            return getDefaultExplorerTxUrl(clientNetwork, txId)
-          })
-        ),
+        O.alt(() => O.some((txId: string) => getDefaultExplorerTxUrl(clientNetwork, txId))),
         O.ap(O.some(txId)),
         O.map(window.apiUrl.openExternal)
       )
     },
-    [oExplorerUrl, network]
+    [oExplorerUrl, clientNetwork]
   )
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,10 +4423,10 @@
   resolved "https://registry.yarnpkg.com/@xchainjs/xchain-litecoin/-/xchain-litecoin-0.4.1.tgz#7945853b4cd3afb0fc42bc6df841f35b4b2eb058"
   integrity sha512-8NxvTKtuaghJFzequbyTjTKzXaahvJ0/irbIFWvoLFGSH8LVjS57L9IVE0IozE6XD4IarJYNbJEzoIBtYLiSwg==
 
-"@xchainjs/xchain-thorchain@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-thorchain/-/xchain-thorchain-0.13.2.tgz#0a35b7a6d83c1f3306f8d7c428fe5b29a3ddd424"
-  integrity sha512-AqdkWV5fn0ZGZOyPi/+PtdGu2nvkeGGg9JZMoMQpGtC5RVgcdXh+iCRo2wyKZaZwsyOwHD6APWCJOz5/IHQ2wg==
+"@xchainjs/xchain-thorchain@^0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-thorchain/-/xchain-thorchain-0.13.3.tgz#d4dbee9c634ed38efd9ce9f315770e22e8c29d70"
+  integrity sha512-MmhK8m2mX9hwo+RsvqTDBX6YcqPhEPCn+3ITkn+HosJ43Gz8ycT6eOHNC47+WUbb5wxuyoGb0yQ85zOq3h8gjA==
 
 "@xchainjs/xchain-util@^0.2.6":
   version "0.2.6"


### PR DESCRIPTION
- [x] Fix handling of explorer url in `PoolHistoryView.tsx` + `PoolActionsHistoryView`
- [x] Introduce `getClientNetwork` (+ few tests) 
- [x] Introduce `clientNetwork$` (to remove all duplicated `toXYZNetwork` helper function in misc. client streams)
- [x] Use latest `xchain-thorchain@0.13.3`


Close #1310 