### PR TITLE
[Wallet] Undefined i18n 

### DIFF
--- a/src/renderer/components/wallet/phrase/ImportPhrase.tsx
+++ b/src/renderer/components/wallet/phrase/ImportPhrase.tsx
@@ -75,7 +75,7 @@ export const ImportPhrase: React.FC = (): JSX.Element => {
 
   const rules: Rule[] = useMemo(
     () => [
-      { required: true },
+      { required: true, message: intl.formatMessage({ id: 'wallet.validations.shouldNotBeEmpty' }) },
       ({ getFieldValue }) => ({
         validator(_, value) {
           if (!value || getFieldValue('password') === value) {

--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -43,7 +43,7 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Ele
 
   const rules: Rule[] = useMemo(
     () => [
-      { required: true },
+      { required: true, message: intl.formatMessage({ id: 'wallet.validations.shouldNotBeEmpty' }) },
       ({ getFieldValue }) => ({
         validator(_, value) {
           if (!value || getFieldValue('password') === value) {


### PR DESCRIPTION
`ImportPhrase`, `NewPhraseGenerate`: fixed custom validation message for password inputs

closes #1320 