### PR TITLE
[UI] fix wrong failed-validation password input styles

### DIFF
--- a/src/renderer/components/uielements/input/Input.style.tsx
+++ b/src/renderer/components/uielements/input/Input.style.tsx
@@ -77,6 +77,10 @@ const inputStyle = css<InputProps>`
   .ant-form-item-has-error {
     border-color: ${({ typevalue = 'normal' }) => (typevalue === 'ghost' ? 'transparent' : colors['error'])} !important;
   }
+
+  .ant-input {
+    background-color: inherit !important;
+  }
 `
 
 export const Input = styled(A.Input)<InputProps>`


### PR DESCRIPTION
`Input.style.tsx`: added inheriting of background for inputs

closes #1323 