### PR TITLE
Reset balances while switching to another wallet

### DIFF
--- a/src/renderer/services/app/service.ts
+++ b/src/renderer/services/app/service.ts
@@ -7,7 +7,7 @@ import { Network } from '../../../shared/api/types'
 import { observableState } from '../../helpers/stateHelper'
 import { getClientNetwork } from '../clients'
 import { DEFAULT_NETWORK } from '../const'
-import { OnlineStatus } from './types'
+import { Network$, OnlineStatus } from './types'
 
 // Check online status
 // https://www.electronjs.org/docs/tutorial/online-offline-events
@@ -24,7 +24,7 @@ const { get$: getNetwork$, set: changeNetwork, get: getCurrentNetworkState } = o
 // Since `network$` based on `observableState` and it takes an initial value,
 // it might emit same values, we don't interested in.
 // So we do need a simple "dirty check" to provide "real" changes of selected network
-const network$: Rx.Observable<Network> = getNetwork$.pipe(distinctUntilChanged())
+const network$: Network$ = getNetwork$.pipe(distinctUntilChanged())
 
 const clientNetwork$: Rx.Observable<Client.Network> = network$.pipe(RxOp.map(getClientNetwork))
 

--- a/src/renderer/services/app/types.ts
+++ b/src/renderer/services/app/types.ts
@@ -1,4 +1,10 @@
+import * as Rx from 'rxjs'
+
+import { Network } from '../../../shared/api/types'
+
 export enum OnlineStatus {
   ON,
   OFF
 }
+
+export type Network$ = Rx.Observable<Network>

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -5,7 +5,6 @@ import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { ETHAssets } from '../../const'
@@ -14,7 +13,7 @@ import { filterEnabledChains } from '../../helpers/chainHelper'
 import { eqBalancesRD } from '../../helpers/fp/eq'
 import { sequenceTOptionFromArray } from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
-import { network$ } from '../app/service'
+import { Network$ } from '../app/types'
 import * as BNB from '../binance'
 import * as BTC from '../bitcoin'
 import * as BCH from '../bitcoincash'
@@ -23,298 +22,334 @@ import * as ETH from '../ethereum'
 import * as LTC from '../litecoin'
 import * as THOR from '../thorchain'
 import { INITIAL_BALANCES_STATE } from './const'
-import { BalancesState, ChainBalances$, ChainBalance$, ChainBalance } from './types'
+import {
+  ChainBalances$,
+  ChainBalance$,
+  ChainBalance,
+  BalancesService,
+  ChainBalancesService,
+  BalancesState$,
+  KeystoreState$,
+  KeystoreState
+} from './types'
 import { sortBalances } from './util'
+import { hasImportedKeystore } from './util'
 
-export const reloadBalances: FP.Lazy<void> = () => {
-  BTC.reloadBalances()
-  BNB.reloadBalances()
-  ETH.reloadBalances()
-  THOR.reloadBalances()
-  LTC.reloadBalances()
-  BCH.reloadBalances()
-}
+export const createBalancesService = ({
+  keystore$,
+  network$
+}: {
+  keystore$: KeystoreState$
+  network$: Network$
+}): BalancesService => {
+  const reloadBalances: FP.Lazy<void> = () => {
+    BTC.reloadBalances()
+    BNB.reloadBalances()
+    ETH.reloadBalances()
+    THOR.reloadBalances()
+    LTC.reloadBalances()
+    BCH.reloadBalances()
+  }
 
-type ChainService = {
-  reloadBalances: FP.Lazy<void>
-  resetReloadBalances: FP.Lazy<void>
-  reloadBalances$: Rx.Observable<boolean>
-  balances$: WalletBalancesLD
-}
+  const getServiceByChain = (chain: Chain): ChainBalancesService => {
+    switch (chain) {
+      case BNBChain:
+        return {
+          reloadBalances: BNB.reloadBalances,
+          resetReloadBalances: BNB.resetReloadBalances,
+          balances$: BNB.balances$,
+          reloadBalances$: BNB.reloadBalances$
+        }
+      case BTCChain:
+        return {
+          reloadBalances: BTC.reloadBalances,
+          resetReloadBalances: BTC.resetReloadBalances,
+          balances$: BTC.balances$,
+          reloadBalances$: BTC.reloadBalances$
+        }
+      case BCHChain:
+        return {
+          reloadBalances: BCH.reloadBalances,
+          resetReloadBalances: BCH.resetReloadBalances,
+          balances$: BCH.balances$,
+          reloadBalances$: BCH.reloadBalances$
+        }
+      case ETHChain:
+        return {
+          reloadBalances: ETH.reloadBalances,
+          resetReloadBalances: ETH.resetReloadBalances,
+          balances$: FP.pipe(
+            network$,
+            RxOp.switchMap((network) => ETH.balances$(network === 'testnet' ? ETHAssets : undefined))
+          ),
+          reloadBalances$: ETH.reloadBalances$
+        }
+      case THORChain:
+        return {
+          reloadBalances: THOR.reloadBalances,
+          resetReloadBalances: THOR.resetReloadBalances,
+          balances$: THOR.balances$,
+          reloadBalances$: THOR.reloadBalances$
+        }
+      case LTCChain:
+        return {
+          reloadBalances: LTC.reloadBalances,
+          resetReloadBalances: LTC.resetReloadBalances,
+          balances$: LTC.balances$,
+          reloadBalances$: LTC.reloadBalances$
+        }
+      default:
+        return {
+          reloadBalances: FP.constVoid,
+          resetReloadBalances: FP.constVoid,
+          balances$: Rx.EMPTY,
+          reloadBalances$: Rx.EMPTY
+        }
+    }
+  }
 
-const getServiceByChain = (chain: Chain): ChainService => {
-  switch (chain) {
-    case BNBChain:
-      return {
-        reloadBalances: BNB.reloadBalances,
-        resetReloadBalances: BNB.resetReloadBalances,
-        balances$: BNB.balances$,
-        reloadBalances$: BNB.reloadBalances$
-      }
-    case BTCChain:
-      return {
-        reloadBalances: BTC.reloadBalances,
-        resetReloadBalances: BTC.resetReloadBalances,
-        balances$: BTC.balances$,
-        reloadBalances$: BTC.reloadBalances$
-      }
-    case BCHChain:
-      return {
-        reloadBalances: BCH.reloadBalances,
-        resetReloadBalances: BCH.resetReloadBalances,
-        balances$: BCH.balances$,
-        reloadBalances$: BCH.reloadBalances$
-      }
-    case ETHChain:
-      return {
-        reloadBalances: ETH.reloadBalances,
-        resetReloadBalances: ETH.resetReloadBalances,
-        balances$: FP.pipe(
-          network$,
-          RxOp.switchMap((network) => ETH.balances$(network === 'testnet' ? ETHAssets : undefined))
+  const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
+    return getServiceByChain(chain).reloadBalances
+  }
+
+  /**
+   * Store previously successfully loaded results at the runtime-memory
+   * to give to the user last balances he loaded without re-requesting
+   * balances data which might be very expensive.
+   */
+  let walletBalancesState: Partial<Record<Chain, WalletBalancesRD>> = {}
+
+  // Whenever network is changed, reset stored balances
+  const networkSub = network$.subscribe(() => {
+    walletBalancesState = {}
+  })
+
+  // Whenever keystore has been removed, reset stored balances
+  const keystoreSub = keystore$.subscribe((keystoreState: KeystoreState) => {
+    if (!hasImportedKeystore(keystoreState)) {
+      walletBalancesState = {}
+    }
+  })
+
+  const getChainBalance$ = (chain: Chain): WalletBalancesLD => {
+    const chainService = getServiceByChain(chain)
+    const reload$ = FP.pipe(
+      chainService.reloadBalances$,
+      RxOp.finalize(() => {
+        // on finish a stream reset reload-trigger
+        // unsubscribe will be initiated on any View unmount
+        chainService.resetReloadBalances()
+      })
+    )
+
+    return FP.pipe(
+      reload$,
+      RxOp.switchMap((shouldReloadData) => {
+        const savedResult = walletBalancesState[chain]
+        // For every new simple subscription return cached results if they exist
+        if (!shouldReloadData && savedResult) {
+          return Rx.of(savedResult)
+        }
+        // If there is no cached data for appropriate chain request for it
+        // Re-request data ONLY for manual calling update trigger with `trigger`
+        // value inside of trigger$ stream
+        return FP.pipe(
+          chainService.balances$,
+          // For every successful load save results to the memory-based cache
+          // to avoid unwanted data re-requesting.
+          liveData.map((balances) => {
+            walletBalancesState[chain] = RD.success(balances)
+            return balances
+          }),
+          RxOp.startWith(savedResult || RD.initial)
+        )
+      })
+    )
+  }
+
+  /**
+   * Transforms THOR balances into `ChainBalances`
+   */
+  const thorChainBalance$: ChainBalance$ = Rx.combineLatest([THOR.addressUI$, getChainBalance$('THOR')]).pipe(
+    RxOp.map(([walletAddress, balances]) => ({
+      walletType: 'keystore',
+      chain: THORChain,
+      walletAddress,
+      balances
+    }))
+  )
+
+  /**
+   * Transforms LTC balances into `ChainBalances`
+   */
+  const litecoinBalance$: ChainBalance$ = Rx.combineLatest([LTC.addressUI$, getChainBalance$('LTC')]).pipe(
+    RxOp.map(([walletAddress, balances]) => ({
+      walletType: 'keystore',
+      chain: LTCChain,
+      walletAddress,
+      balances
+    }))
+  )
+
+  /**
+   * Transforms BCH balances into `ChainBalances`
+   */
+  const bchChainBalance$: ChainBalance$ = Rx.combineLatest([BCH.addressUI$, getChainBalance$('BCH')]).pipe(
+    RxOp.map(([walletAddress, balances]) => ({
+      walletType: 'keystore',
+      chain: BCHChain,
+      walletAddress,
+      balances
+    }))
+  )
+
+  /**
+   * Transforms BNB balances into `ChainBalances`
+   */
+  const bnbChainBalance$: ChainBalance$ = Rx.combineLatest([BNB.addressUI$, getChainBalance$('BNB'), network$]).pipe(
+    RxOp.map(([walletAddress, balances, network]) => ({
+      walletType: 'keystore',
+      chain: BNBChain,
+      walletAddress,
+      balances: FP.pipe(
+        balances,
+        RD.map((assets) => sortBalances(assets, [AssetBNB.ticker, getBnbRuneAsset(network).ticker]))
+      )
+    }))
+  )
+
+  /**
+   * Transforms BTC balances into `ChainBalance`
+   */
+  const btcChainBalance$: ChainBalance$ = Rx.combineLatest([BTC.addressUI$, getChainBalance$('BTC')]).pipe(
+    RxOp.map(([walletAddress, balances]) => ({
+      walletType: 'keystore',
+      chain: BTCChain,
+      walletAddress,
+      balances
+    }))
+  )
+
+  const btcLedgerChainBalance$: ChainBalance$ = FP.pipe(
+    BTC.ledgerAddress$,
+    RxOp.switchMap((addressRd) =>
+      FP.pipe(
+        addressRd,
+        RD.map((address) => BTC.getBalanceByAddress$(address, 'ledger')),
+        RD.map(
+          RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
+            walletType: 'ledger',
+            chain: BTCChain,
+            walletAddress: FP.pipe(addressRd, RD.toOption),
+            balances
+          }))
         ),
-        reloadBalances$: ETH.reloadBalances$
-      }
-    case THORChain:
-      return {
-        reloadBalances: THOR.reloadBalances,
-        resetReloadBalances: THOR.resetReloadBalances,
-        balances$: THOR.balances$,
-        reloadBalances$: THOR.reloadBalances$
-      }
-    case LTCChain:
-      return {
-        reloadBalances: LTC.reloadBalances,
-        resetReloadBalances: LTC.resetReloadBalances,
-        balances$: LTC.balances$,
-        reloadBalances$: LTC.reloadBalances$
-      }
-    default:
-      return {
-        reloadBalances: FP.constVoid,
-        resetReloadBalances: FP.constVoid,
-        balances$: Rx.EMPTY,
-        reloadBalances$: Rx.EMPTY
-      }
+        RD.getOrElse(() =>
+          Rx.of<ChainBalance>({
+            walletType: 'ledger',
+            chain: BTCChain,
+            walletAddress: O.none,
+            balances: RD.initial
+          })
+        )
+      )
+    ),
+    RxOp.shareReplay(1)
+  )
+
+  const btcLedgerBalance$ = FP.pipe(
+    btcLedgerChainBalance$,
+    RxOp.map((ledgerBalances) => ledgerBalances.balances)
+  )
+
+  const ethBalances$ = getChainBalance$('ETH')
+
+  /**
+   * Transforms ETH data (address + `WalletBalance`) into `ChainBalance`
+   */
+  const ethChainBalance$: ChainBalance$ = Rx.combineLatest([ETH.addressUI$, ethBalances$]).pipe(
+    RxOp.map(([walletAddress, balances]) => ({
+      walletType: 'keystore',
+      chain: ETHChain,
+      walletAddress,
+      balances
+    }))
+  )
+
+  /**
+   * List of `ChainBalances` for all available chains (order is important)
+   */
+  const chainBalances$: ChainBalances$ = Rx.combineLatest(
+    filterEnabledChains({
+      THOR: [thorChainBalance$],
+      BTC: [btcChainBalance$, btcLedgerChainBalance$],
+      BCH: [bchChainBalance$],
+      ETH: [ethChainBalance$],
+      BNB: [bnbChainBalance$],
+      LTC: [litecoinBalance$]
+    })
+  ).pipe(
+    // we ignore all `ChainBalances` with state of `initial` balances
+    // (e.g. a not connected Ledger )
+    RxOp.map(A.filter(({ balances }) => !RD.isInitial(balances)))
+  )
+
+  /**
+   * Transform a list of BalancesLD
+   * into a "single" state of `BalancesState`
+   * to provide loading / error / data states in a single "state" object
+   *
+   * Note: Empty list of balances won't be included in `BalancesState`!!
+   */
+  const balancesState$: BalancesState$ = Rx.combineLatest(
+    filterEnabledChains({
+      THOR: [getChainBalance$(THORChain)],
+      BTC: [getChainBalance$(BTCChain), btcLedgerBalance$],
+      BCH: [getChainBalance$(BCHChain)],
+      ETH: [ethBalances$],
+      BNB: [getChainBalance$(BNBChain)],
+      LTC: [getChainBalance$(LTCChain)]
+    })
+  ).pipe(
+    RxOp.map((balancesList) => ({
+      balances: FP.pipe(
+        balancesList,
+        // filter results out
+        // Transformation: RD<ApiError, WalletBalances>[]`-> `WalletBalances[]`
+        A.filterMap(RD.toOption),
+        A.flatten,
+        NEA.fromArray
+      ),
+      loading: FP.pipe(balancesList, A.elem(eqBalancesRD)(RD.pending)),
+      errors: FP.pipe(
+        balancesList,
+        // filter errors out
+        A.filter(RD.isFailure),
+        // Transformation to get Errors out of RD:
+        // `RemoteData<Error, never>[]` -> `RemoteData<never, Error>[]` -> `O.some(Error)[]`
+        A.map(FP.flow(RD.recover(O.some), RD.toOption)),
+        // Transformation: `O.some(Error)[]` -> `O.some(Error[])`
+        sequenceTOptionFromArray,
+        O.chain(NEA.fromArray)
+      )
+    })),
+    RxOp.startWith(INITIAL_BALANCES_STATE)
+  )
+
+  /**
+   * Dispose references / subscriptions (if needed)
+   */
+  const dispose = () => {
+    networkSub.unsubscribe()
+    keystoreSub.unsubscribe()
+    walletBalancesState = {}
+  }
+
+  return {
+    reloadBalances,
+    reloadBalancesByChain,
+    chainBalances$,
+    balancesState$,
+    dispose
   }
 }
-
-export const reloadBalancesByChain: (chain: Chain) => FP.Lazy<void> = (chain) => {
-  return getServiceByChain(chain).reloadBalances
-}
-
-/**
- * Store previously successfully loaded results at the runtime-memory
- * to give to the user last balances he loaded without re-requesting
- * balances data which might be very expensive.
- */
-let walletBalancesState: Partial<Record<Chain, WalletBalancesRD>> = {}
-
-// Whenever network is changed we have to reset stored cached values for all chains
-network$.subscribe(() => {
-  walletBalancesState = {}
-})
-
-const getChainBalance$ = (chain: Chain): WalletBalancesLD => {
-  const chainService = getServiceByChain(chain)
-  const reload$ = FP.pipe(
-    chainService.reloadBalances$,
-    RxOp.finalize(() => {
-      // on finish a stream reset reload-trigger
-      // unsubscribe will be initiated on any View unmount
-      chainService.resetReloadBalances()
-    })
-  )
-
-  return FP.pipe(
-    reload$,
-    RxOp.switchMap((shouldReloadData) => {
-      const savedResult = walletBalancesState[chain]
-      // For every new simple subscription return cached results if they exist
-      if (!shouldReloadData && savedResult) {
-        return Rx.of(savedResult)
-      }
-      // If there is no cached data for appropriate chain request for it
-      // Re-request data ONLY for manual calling update trigger with `trigger`
-      // value inside of trigger$ stream
-      return FP.pipe(
-        chainService.balances$,
-        // For every successful load save results to the memory-based cache
-        // to avoid unwanted data re-requesting.
-        liveData.map((balances) => {
-          walletBalancesState[chain] = RD.success(balances)
-          return balances
-        }),
-        RxOp.startWith(savedResult || RD.initial)
-      )
-    })
-  )
-}
-
-/**
- * Transforms THOR balances into `ChainBalances`
- */
-const thorChainBalance$: ChainBalance$ = Rx.combineLatest([THOR.addressUI$, getChainBalance$('THOR')]).pipe(
-  RxOp.map(([walletAddress, balances]) => ({
-    walletType: 'keystore',
-    chain: THORChain,
-    walletAddress,
-    balances
-  }))
-)
-
-/**
- * Transforms LTC balances into `ChainBalances`
- */
-const litecoinBalance$: ChainBalance$ = Rx.combineLatest([LTC.addressUI$, getChainBalance$('LTC')]).pipe(
-  RxOp.map(([walletAddress, balances]) => ({
-    walletType: 'keystore',
-    chain: LTCChain,
-    walletAddress,
-    balances
-  }))
-)
-
-/**
- * Transforms BCH balances into `ChainBalances`
- */
-const bchChainBalance$: ChainBalance$ = Rx.combineLatest([BCH.addressUI$, getChainBalance$('BCH')]).pipe(
-  RxOp.map(([walletAddress, balances]) => ({
-    walletType: 'keystore',
-    chain: BCHChain,
-    walletAddress,
-    balances
-  }))
-)
-
-/**
- * Transforms BNB balances into `ChainBalances`
- */
-const bnbChainBalance$: ChainBalance$ = Rx.combineLatest([BNB.addressUI$, getChainBalance$('BNB'), network$]).pipe(
-  RxOp.map(([walletAddress, balances, network]) => ({
-    walletType: 'keystore',
-    chain: BNBChain,
-    walletAddress,
-    balances: FP.pipe(
-      balances,
-      RD.map((assets) => sortBalances(assets, [AssetBNB.ticker, getBnbRuneAsset(network).ticker]))
-    )
-  }))
-)
-
-/**
- * Transforms BTC balances into `ChainBalance`
- */
-const btcChainBalance$: ChainBalance$ = Rx.combineLatest([BTC.addressUI$, getChainBalance$('BTC')]).pipe(
-  RxOp.map(([walletAddress, balances]) => ({
-    walletType: 'keystore',
-    chain: BTCChain,
-    walletAddress,
-    balances
-  }))
-)
-
-const btcLedgerChainBalance$: ChainBalance$ = FP.pipe(
-  BTC.ledgerAddress$,
-  RxOp.switchMap((addressRd) =>
-    FP.pipe(
-      addressRd,
-      RD.map((address) => BTC.getBalanceByAddress$(address, 'ledger')),
-      RD.map(
-        RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
-          walletType: 'ledger',
-          chain: BTCChain,
-          walletAddress: FP.pipe(addressRd, RD.toOption),
-          balances
-        }))
-      ),
-      RD.getOrElse(() =>
-        Rx.of<ChainBalance>({
-          walletType: 'ledger',
-          chain: BTCChain,
-          walletAddress: O.none,
-          balances: RD.initial
-        })
-      )
-    )
-  ),
-  RxOp.shareReplay(1)
-)
-
-const btcLedgerBalance$ = FP.pipe(
-  btcLedgerChainBalance$,
-  RxOp.map((ledgerBalances) => ledgerBalances.balances)
-)
-
-const ethBalances$ = getChainBalance$('ETH')
-/**
- * Transforms ETH data (address + `WalletBalance`) into `ChainBalance`
- */
-const ethChainBalance$: ChainBalance$ = Rx.combineLatest([ETH.addressUI$, ethBalances$]).pipe(
-  RxOp.map(([walletAddress, balances]) => ({
-    walletType: 'keystore',
-    chain: ETHChain,
-    walletAddress,
-    balances
-  }))
-)
-
-/**
- * List of `ChainBalances` for all available chains (order is important)
- */
-export const chainBalances$: ChainBalances$ = Rx.combineLatest(
-  filterEnabledChains({
-    THOR: [thorChainBalance$],
-    BTC: [btcChainBalance$, btcLedgerChainBalance$],
-    BCH: [bchChainBalance$],
-    ETH: [ethChainBalance$],
-    BNB: [bnbChainBalance$],
-    LTC: [litecoinBalance$]
-  })
-).pipe(
-  // we ignore all `ChainBalances` with state of `initial` balances
-  // (e.g. a not connected Ledger )
-  RxOp.map(A.filter(({ balances }) => !RD.isInitial(balances)))
-)
-
-/**
- * Transform a list of BalancesLD
- * into a "single" state of `BalancesState`
- * to provide loading / error / data states in a single "state" object
- *
- * Note: Empty list of balances won't be included in `BalancesState`!!
- */
-export const balancesState$: Observable<BalancesState> = Rx.combineLatest(
-  filterEnabledChains({
-    THOR: [getChainBalance$(THORChain)],
-    BTC: [getChainBalance$(BTCChain), btcLedgerBalance$],
-    BCH: [getChainBalance$(BCHChain)],
-    ETH: [ethBalances$],
-    BNB: [getChainBalance$(BNBChain)],
-    LTC: [getChainBalance$(LTCChain)]
-  })
-).pipe(
-  RxOp.map((balancesList) => ({
-    balances: FP.pipe(
-      balancesList,
-      // filter results out
-      // Transformation: RD<ApiError, WalletBalances>[]`-> `WalletBalances[]`
-      A.filterMap(RD.toOption),
-      A.flatten,
-      NEA.fromArray
-    ),
-    loading: FP.pipe(balancesList, A.elem(eqBalancesRD)(RD.pending)),
-    errors: FP.pipe(
-      balancesList,
-      // filter errors out
-      A.filter(RD.isFailure),
-      // Transformation to get Errors out of RD:
-      // `RemoteData<Error, never>[]` -> `RemoteData<never, Error>[]` -> `O.some(Error)[]`
-      A.map(FP.flow(RD.recover(O.some), RD.toOption)),
-      // Transformation: `O.some(Error)[]` -> `O.some(Error[])`
-      sequenceTOptionFromArray,
-      O.chain(NEA.fromArray)
-    )
-  })),
-  RxOp.startWith(INITIAL_BALANCES_STATE)
-)

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -1,8 +1,13 @@
-import { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } from './balances'
+import { network$ } from '../app/service'
+import { createBalancesService } from './balances'
 import { setSelectedAsset, selectedAsset$ } from './common'
 import { keystoreService, removeKeystore } from './keystore'
 import { getTxs$, loadTxs, explorerUrl$, getExplorerTxUrl$, resetTxsPage } from './transaction'
 
+const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } = createBalancesService({
+  keystore$: keystoreService.keystore$,
+  network$
+})
 /**
  * Exports all functions and observables needed at UI level (provided by `WalletContext`)
  */

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -11,7 +11,7 @@ import * as Rx from 'rxjs'
 import { LedgerErrorId, Network } from '../../../shared/api/types'
 import { LiveData } from '../../helpers/rx/liveData'
 import { WalletBalance } from '../../types/wallet'
-import { LoadTxsParams, WalletBalancesRD } from '../clients'
+import { LoadTxsParams, WalletBalancesLD, WalletBalancesRD } from '../clients'
 
 export type WalletType = 'keystore' | 'ledger'
 
@@ -26,6 +26,7 @@ export type KeystoreContent = { phrase: Phrase }
  * (3) `Some<Some<KeystoreContent>>` -> UNLOCKED + IMPORTED STATUS (keystore file + phrase)
  */
 export type KeystoreState = O.Option<O.Option<KeystoreContent>>
+export type KeystoreState$ = Rx.Observable<KeystoreState>
 
 export type ValidatePasswordHandler = (password: string) => LiveData<Error, void>
 export type ValidatePasswordLD = LiveData<Error, void>
@@ -34,7 +35,7 @@ export type ImportKeystoreLD = LiveData<Error, void>
 export type LoadKeystoreLD = LiveData<Error, Keystore>
 
 export type KeystoreService = {
-  keystore$: Rx.Observable<KeystoreState>
+  keystore$: KeystoreState$
   addKeystore: (phrase: Phrase, password: string) => Promise<void>
   removeKeystore: () => Promise<void>
   importKeystore$: (keystore: Keystore, password: string) => ImportKeystoreLD
@@ -79,6 +80,8 @@ export type BalancesState = {
   loading: boolean
 }
 
+export type BalancesState$ = Rx.Observable<BalancesState>
+
 export type LoadTxsHandler = (props: LoadTxsParams) => void
 export type ResetTxsPageHandler = FP.Lazy<void>
 
@@ -100,6 +103,21 @@ export enum ErrorId {
   VALIDATE_NODE = 'VALIDATE_NODE',
   VALIDATE_RESULT = 'VALIDATE_RESULT',
   GET_ACTIONS = 'GET_ACTIONS'
+}
+
+export type ChainBalancesService = {
+  reloadBalances: FP.Lazy<void>
+  resetReloadBalances: FP.Lazy<void>
+  reloadBalances$: Rx.Observable<boolean>
+  balances$: WalletBalancesLD
+}
+
+export type BalancesService = {
+  reloadBalances: FP.Lazy<void>
+  reloadBalancesByChain: (chain: Chain) => FP.Lazy<void>
+  chainBalances$: ChainBalances$
+  balancesState$: BalancesState$
+  dispose: FP.Lazy<void>
 }
 
 // TODO(@Veado) Move type to clients/type


### PR DESCRIPTION
- [x] Reset balances in case of removing a wallet 
- [x] Wrap exported functions of `services/wallet/balances` into `createBalancesService` (Note: Almost no changes there, just wrapping) Most imported [changes are just these few lines of code](https://github.com/thorchain/asgardex-electron/pull/1360/files#diff-8fa39f79b46e4108ab4f3245f856a593fc5eab2ac190deb8d93f5ac194c1f426R128-R132) to subscribe changes of `keystore$`

Fix #1358 