### PR TITLE
[Withdraw] Fix fee handling

### DIFF
--- a/src/renderer/components/deposit/withdraw/AsymWithdraw.stories.tsx
+++ b/src/renderer/components/deposit/withdraw/AsymWithdraw.stories.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
-import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, baseAmount, bn, Chain } from '@xchainjs/xchain-util'
+import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, baseAmount, bn } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { mockValidatePassword$ } from '../../../../shared/mock/wallet'
 import { INITIAL_WITHDRAW_STATE } from '../../../services/chain/const'
-import { Memo, WithdrawState$ } from '../../../services/chain/types'
+import { WithdrawState$ } from '../../../services/chain/types'
 import { AsymWithdraw, Props as AsymWitdrawProps } from './AsymWithdraw'
 
 const defaultProps: AsymWitdrawProps = {
@@ -41,7 +41,7 @@ const defaultProps: AsymWitdrawProps = {
           })
       )
     ),
-  fee$: (_chain: Chain, _memo: Memo) => Rx.of(RD.success(baseAmount(1000))),
+  fees$: (_) => Rx.of(RD.success(baseAmount(1000))),
   network: 'testnet'
 }
 
@@ -51,7 +51,7 @@ Default.storyName = 'default'
 export const ErrorNoFee: Story = () => {
   const props: AsymWitdrawProps = {
     ...defaultProps,
-    fee$: (_chain: Chain, _memo: Memo) => Rx.of(RD.failure(Error('no fees')))
+    fees$: (_) => Rx.of(RD.failure(Error('no fees')))
   }
   return <AsymWithdraw {...props} />
 }

--- a/src/renderer/components/deposit/withdraw/AsymWithdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/AsymWithdraw.tsx
@@ -1,33 +1,14 @@
-import React, { useState, useMemo, useCallback } from 'react'
+import React from 'react'
 
-import * as RD from '@devexperts/remote-data-ts'
-import { getWithdrawMemo } from '@thorchain/asgardex-util'
-import { Asset, baseAmount, BaseAmount, baseToAsset, Chain, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
-import { Col } from 'antd'
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
-import { useObservableState } from 'observable-hooks'
-import { useIntl } from 'react-intl'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../../shared/api/types'
-import { ZERO_BASE_AMOUNT } from '../../../const'
-import { eqAsset } from '../../../helpers/fp/eq'
-import { sequenceTOption } from '../../../helpers/fpHelpers'
-import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
-import { INITIAL_WITHDRAW_STATE } from '../../../services/chain/const'
-import { FeeLD, FeeRD, Memo, WithdrawState, AsymWithdrawStateHandler } from '../../../services/chain/types'
+import { AsymWithdrawStateHandler, ReloadWithdrawFeesHandler, WithdrawFeesHandler } from '../../../services/chain/types'
 import { PoolAddress } from '../../../services/midgard/types'
 import { ValidatePasswordHandler } from '../../../services/wallet/types'
-import { PasswordModal } from '../../modal/password'
-import { TxModal } from '../../modal/tx'
-import { DepositAssets } from '../../modal/tx/extra'
-import { Fees, UIFeesRD } from '../../uielements/fees'
-import { Label } from '../../uielements/label'
-import { getAsymWithdrawAmount } from './Withdraw.helper'
-import * as Styled from './Withdraw.styles'
 
 export type Props = {
   /** Asset to withdraw */
@@ -41,7 +22,7 @@ export type Props = {
   /** Selected price asset */
   selectedPriceAsset: Asset
   /** Callback to reload fees */
-  reloadFees: (chain: Chain) => void
+  reloadFees: ReloadWithdrawFeesHandler
   /** Share of Asset */
   share: BaseAmount
   /** Flag whether form has to be disabled or not */
@@ -51,7 +32,7 @@ export type Props = {
   validatePassword$: ValidatePasswordHandler
   reloadBalances: FP.Lazy<void>
   withdraw$: AsymWithdrawStateHandler
-  fee$: (chain: Chain, memo: Memo) => FeeLD
+  fees$: WithdrawFeesHandler
   network: Network
 }
 
@@ -60,315 +41,6 @@ export type Props = {
  *
  * Note: It currently supports asym deposits for paired asset only (but not for RUNE)
  */
-export const AsymWithdraw: React.FC<Props> = ({
-  asset,
-  assetPrice,
-  chainAssetBalance: oChainAssetBalance,
-  selectedPriceAsset,
-  share,
-  disabled,
-  poolAddresses: oPoolAddresses,
-  viewRuneTx = (_) => {},
-  validatePassword$,
-  reloadBalances = FP.constVoid,
-  reloadFees,
-  withdraw$,
-  fee$,
-  network
-}) => {
-  const intl = useIntl()
-
-  const {
-    state: withdrawState,
-    reset: resetWithdrawState,
-    subscribe: subscribeWithdrawState
-  } = useSubscriptionState<WithdrawState>(INITIAL_WITHDRAW_STATE)
-
-  const [withdrawPercent, setWithdrawPercent] = useState(disabled ? 0 : 50)
-
-  const memo = useMemo(() => getWithdrawMemo({ asset, percent: withdrawPercent }), [asset, withdrawPercent])
-
-  const feeLD: FeeLD = useMemo(() => {
-    return Rx.of(memo).pipe(
-      // Memo depends on changing `withdrawPercent`
-      // that's why we delay it to avoid many requests for fees
-      RxOp.delay(800),
-      RxOp.switchMap((_) => fee$(asset.chain, memo))
-    )
-  }, [asset, fee$, memo])
-
-  const feeRD: FeeRD = useObservableState(feeLD, RD.initial)
-  const oFee: O.Option<BaseAmount> = useMemo(() => RD.toOption(feeRD), [feeRD])
-
-  const isFeeError: boolean = useMemo(() => {
-    if (withdrawPercent <= 0) return false
-
-    return FP.pipe(
-      sequenceTOption(oFee, oChainAssetBalance),
-      O.fold(
-        // Missing (or loading) fees does not mean we can't sent something. No error then.
-        () => !O.isNone(oFee),
-        ([fee, balance]) => balance.amount().isLessThan(fee.amount())
-      )
-    )
-  }, [oFee, oChainAssetBalance, withdrawPercent])
-
-  const renderFeeError = useMemo(() => {
-    if (!isFeeError) return <></>
-
-    const chainAssetBalance = FP.pipe(
-      oChainAssetBalance,
-      O.getOrElse(() => ZERO_BASE_AMOUNT)
-    )
-
-    return FP.pipe(
-      oFee,
-      O.map((fee) => {
-        const msg = intl.formatMessage(
-          { id: 'deposit.withdraw.error.feeNotCovered' },
-          {
-            fee: formatAssetAmountCurrency({
-              amount: baseToAsset(fee),
-              asset: asset,
-              trimZeros: true
-            }),
-            balance: formatAssetAmountCurrency({
-              amount: baseToAsset(chainAssetBalance),
-              asset: asset,
-              trimZeros: true
-            })
-          }
-        )
-        return <Styled.FeeErrorLabel key="fee-error">{msg}</Styled.FeeErrorLabel>
-      }),
-      O.getOrElse(() => <></>)
-    )
-  }, [isFeeError, oChainAssetBalance, oFee, intl, asset])
-
-  const assetAmountToWithdraw = getAsymWithdrawAmount({ share, percent: withdrawPercent, fee: oFee })
-
-  // Withdraw start time
-  const [withdrawStartTime, setWithdrawStartTime] = useState<number>(0)
-
-  const txModalExtraContent = useMemo(() => {
-    const stepDescriptions = [
-      intl.formatMessage({ id: 'common.tx.healthCheck' }),
-      intl.formatMessage({ id: 'common.tx.sendingAsset' }, { assetTicker: asset.ticker }),
-      intl.formatMessage({ id: 'common.tx.checkResult' })
-    ]
-    const stepDescription = FP.pipe(
-      withdrawState.withdraw,
-      RD.fold(
-        () => '',
-        () =>
-          `${intl.formatMessage(
-            { id: 'common.step' },
-            { current: withdrawState.step, total: withdrawState.stepsTotal }
-          )}: ${stepDescriptions[withdrawState.step - 1]}`,
-        () => '',
-        () => `${intl.formatMessage({ id: 'common.done' })}!`
-      )
-    )
-
-    return (
-      <DepositAssets
-        target={{ asset, amount: assetAmountToWithdraw }}
-        source={O.none}
-        stepDescription={stepDescription}
-        network={network}
-      />
-    )
-  }, [
-    intl,
-    asset,
-    withdrawState.withdraw,
-    withdrawState.step,
-    withdrawState.stepsTotal,
-    assetAmountToWithdraw,
-    network
-  ])
-
-  const onFinishTxModal = useCallback(() => {
-    resetWithdrawState()
-    reloadBalances()
-  }, [reloadBalances, resetWithdrawState])
-
-  const renderTxModal = useMemo(() => {
-    const { withdraw: withdrawRD, withdrawTx } = withdrawState
-
-    // don't render TxModal in initial state
-    if (RD.isInitial(withdrawRD)) return <></>
-
-    // Get timer value
-    const timerValue = FP.pipe(
-      withdrawRD,
-      RD.fold(
-        () => 0,
-        FP.flow(
-          O.map(({ loaded }) => loaded),
-          O.getOrElse(() => 0)
-        ),
-        () => 0,
-        () => 100
-      )
-    )
-
-    // title
-    const txModalTitle = FP.pipe(
-      withdrawRD,
-      RD.fold(
-        () => 'deposit.withdraw.pending',
-        () => 'deposit.withdraw.pending',
-        () => 'deposit.withdraw.error',
-        () => 'deposit.withdraw.success'
-      ),
-      (id) => intl.formatMessage({ id })
-    )
-
-    const extraResult = (
-      <Styled.ExtraContainer>
-        {FP.pipe(withdrawTx, RD.toOption, (oTxHash) => (
-          <Styled.ViewTxButtonTop
-            txHash={oTxHash}
-            onClick={viewRuneTx}
-            label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: asset.ticker })}
-          />
-        ))}
-      </Styled.ExtraContainer>
-    )
-
-    return (
-      <TxModal
-        title={txModalTitle}
-        onClose={resetWithdrawState}
-        onFinish={onFinishTxModal}
-        startTime={withdrawStartTime}
-        txRD={withdrawRD}
-        timerValue={timerValue}
-        extraResult={extraResult}
-        extra={txModalExtraContent}
-      />
-    )
-  }, [
-    withdrawState,
-    resetWithdrawState,
-    onFinishTxModal,
-    withdrawStartTime,
-    txModalExtraContent,
-    intl,
-    viewRuneTx,
-    asset.ticker
-  ])
-
-  const [showPasswordModal, setShowPasswordModal] = useState(false)
-
-  const closePasswordModal = useCallback(() => {
-    setShowPasswordModal(false)
-  }, [setShowPasswordModal])
-
-  const onClosePasswordModal = useCallback(() => {
-    // close password modal
-    closePasswordModal()
-  }, [closePasswordModal])
-
-  const onSucceedPasswordModal = useCallback(() => {
-    // close private modal
-    closePasswordModal()
-
-    FP.pipe(
-      oPoolAddresses,
-      O.map((poolAddresses) => {
-        // set start time
-        setWithdrawStartTime(Date.now())
-
-        subscribeWithdrawState(
-          withdraw$({
-            asset,
-            poolAddress: poolAddresses,
-            network,
-            memo
-          })
-        )
-
-        return true
-      })
-    )
-  }, [closePasswordModal, oPoolAddresses, subscribeWithdrawState, withdraw$, asset, network, memo])
-
-  const uiFeesRD: UIFeesRD = useMemo(
-    () =>
-      FP.pipe(
-        feeRD,
-        RD.map((fee) => [{ asset, amount: fee }])
-      ),
-    [asset, feeRD]
-  )
-
-  const reloadFeesHandler = useCallback(() => reloadFees(asset.chain), [asset, reloadFees])
-
-  const disabledForm = useMemo(() => withdrawPercent <= 0 || disabled, [withdrawPercent, disabled])
-
-  return (
-    <Styled.Container>
-      <Label weight="bold" textTransform="uppercase">
-        {intl.formatMessage({ id: 'deposit.withdraw.asym.title' })}
-      </Label>
-      <Label>{intl.formatMessage({ id: 'deposit.withdraw.choseText' })}</Label>
-
-      <Styled.Slider
-        key={'asset amount slider'}
-        value={withdrawPercent}
-        onChange={setWithdrawPercent}
-        disabled={disabled}
-      />
-      <Label weight={'bold'} textTransform={'uppercase'}>
-        {intl.formatMessage({ id: 'deposit.withdraw.receiveText' })}
-      </Label>
-
-      <Styled.AssetContainer>
-        <Styled.AssetIcon asset={asset} network={network} />
-        <Styled.AssetLabel asset={asset} />
-        <Styled.OutputLabel weight={'bold'}>
-          {formatAssetAmountCurrency({
-            amount: baseToAsset(assetAmountToWithdraw),
-            asset: asset,
-            trimZeros: true
-          })}
-          {/* show pricing if price asset is different only */}
-          {!eqAsset.equals(asset, selectedPriceAsset) &&
-            ` (${formatAssetAmountCurrency({
-              amount: baseToAsset(baseAmount(assetAmountToWithdraw.amount().times(assetPrice))),
-              asset: selectedPriceAsset,
-              trimZeros: true
-            })})`}
-        </Styled.OutputLabel>
-      </Styled.AssetContainer>
-
-      <Styled.FeesRow gutter={{ lg: 32 }}>
-        <Col>
-          <Styled.FeeRow>
-            <Fees fees={uiFeesRD} reloadFees={reloadFeesHandler} />
-          </Styled.FeeRow>
-          <Styled.FeeErrorRow>
-            <Col>
-              <>{renderFeeError}</>
-            </Col>
-          </Styled.FeeErrorRow>
-        </Col>
-      </Styled.FeesRow>
-      <Styled.SubmitButtonWrapper>
-        <Styled.SubmitButton sizevalue="big" onClick={() => setShowPasswordModal(true)} disabled={disabledForm}>
-          {intl.formatMessage({ id: 'common.withdraw' })}
-        </Styled.SubmitButton>
-      </Styled.SubmitButtonWrapper>
-      {showPasswordModal && (
-        <PasswordModal
-          onSuccess={onSucceedPasswordModal}
-          onClose={onClosePasswordModal}
-          validatePassword$={validatePassword$}
-        />
-      )}
-      {renderTxModal}
-    </Styled.Container>
-  )
+export const AsymWithdraw: React.FC<Props> = () => {
+  return <div>ASYM withdraw is coming soon</div>
 }

--- a/src/renderer/components/deposit/withdraw/Withdraw.helper.ts
+++ b/src/renderer/components/deposit/withdraw/Withdraw.helper.ts
@@ -10,12 +10,9 @@ export const getWithdrawAmounts = (
   percentAmount: number
 ): { rune: BaseAmount; asset: BaseAmount } => {
   const percentBn = bn(percentAmount / 100)
-  const rune = baseAmount(percentBn.multipliedBy(runeShare.amount()))
-  const asset = baseAmount(percentBn.multipliedBy(assetShare.amount()), assetShare.decimal)
-
   return {
-    rune,
-    asset
+    rune: runeShare.times(percentBn),
+    asset: assetShare.times(percentBn)
   }
 }
 

--- a/src/renderer/components/deposit/withdraw/Withdraw.stories.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.stories.tsx
@@ -2,22 +2,20 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
-import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, baseAmount, bn, Chain } from '@xchainjs/xchain-util'
-import * as O from 'fp-ts/lib/Option'
+import { AssetBNB, AssetRuneNative, baseAmount, bn } from '@xchainjs/xchain-util'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { mockValidatePassword$ } from '../../../../shared/mock/wallet'
 import { BNB_DECIMAL } from '../../../helpers/assetHelper'
 import { INITIAL_WITHDRAW_STATE } from '../../../services/chain/const'
-import { Memo, WithdrawState$ } from '../../../services/chain/types'
+import { WithdrawState$ } from '../../../services/chain/types'
 import { Withdraw, Props as WitdrawProps } from './Withdraw'
 
 const defaultProps: WitdrawProps = {
   asset: { asset: AssetBNB, decimal: BNB_DECIMAL },
   runePrice: bn(1),
   assetPrice: bn(60.972),
-  runeBalance: O.some(assetToBase(assetAmount(100))),
   selectedPriceAsset: AssetRuneNative,
   reloadFees: () => console.log('reload fees'),
   shares: { rune: baseAmount('193011422'), asset: baseAmount('3202499') },
@@ -26,7 +24,7 @@ const defaultProps: WitdrawProps = {
   // mock password validation
   // Password: "123"
   validatePassword$: mockValidatePassword$,
-  reloadBalances: () => console.log('reload balances'),
+  reloadShares: () => console.log('reload balances'),
   // mock successfull result of withdraw$
   withdraw$: (params) =>
     Rx.of(params).pipe(
@@ -41,7 +39,7 @@ const defaultProps: WitdrawProps = {
           })
       )
     ),
-  fee$: (_chain: Chain, _memo: Memo) => Rx.of(RD.success(baseAmount(1000))),
+  fees$: (_) => Rx.of(RD.success(baseAmount(1000))),
   network: 'testnet'
 }
 
@@ -51,7 +49,7 @@ Default.storyName = 'default'
 export const ErrorNoFee: Story = () => {
   const props: WitdrawProps = {
     ...defaultProps,
-    fee$: (_chain: Chain, _memo: Memo) => Rx.of(RD.failure(Error('no fees')))
+    fees$: (_) => Rx.of(RD.failure(Error('no fees')))
   }
   return <Withdraw {...props} />
 }

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -629,7 +629,8 @@ export const Swap = ({
     resetSwapState()
     reloadBalances()
     setAmountToSwapMax1e8(initialAmountToSwapMax1e8)
-  }, [resetSwapState, reloadBalances, setAmountToSwapMax1e8, initialAmountToSwapMax1e8])
+    reloadFeesHandler()
+  }, [resetSwapState, reloadBalances, setAmountToSwapMax1e8, initialAmountToSwapMax1e8, reloadFeesHandler])
 
   const renderTxModal = useMemo(() => {
     const { swapTx, swap } = swapState

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -10,8 +10,8 @@ import {
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,
-  withdrawFee$,
-  reloadWithdrawFee,
+  withdrawFees$,
+  reloadWithdrawFees,
   retrieveLedgerAddress,
   removeLedgerAddress,
   removeAllLedgerAddress,
@@ -37,8 +37,8 @@ type ChainContextValue = {
   reloadSymDepositFees: typeof reloadSymDepositFees
   asymDepositFee$: typeof asymDepositFee$
   reloadAsymDepositFee: typeof reloadAsymDepositFee
-  withdrawFee$: typeof withdrawFee$
-  reloadWithdrawFees: typeof reloadWithdrawFee
+  withdrawFees$: typeof withdrawFees$
+  reloadWithdrawFees: typeof reloadWithdrawFees
   symDepositTxMemo$: typeof symDepositTxMemo$
   asymDepositTxMemo$: typeof asymDepositTxMemo$
   getWithdrawMemo$: typeof getWithdrawMemo$
@@ -67,8 +67,8 @@ const initialContext: ChainContextValue = {
   reloadSymDepositFees,
   asymDepositFee$,
   reloadAsymDepositFee,
-  withdrawFee$,
-  reloadWithdrawFees: reloadWithdrawFee,
+  withdrawFees$,
+  reloadWithdrawFees,
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -55,7 +55,7 @@ const deposit: DepositMessages = {
   'deposit.withdraw.fees': 'Transaktionsgebühr: {thorMemo}, Auszahlungsgebühren: {thorOut} + {assetOut}',
   'deposit.withdraw.feeNote': 'Hinweis: {fee} werden für die Transaktionsgebühr in Deiner Wallet belassen',
   'deposit.withdraw.error.feeNotCovered':
-    'Transaktionsgebühr in Höhe von {fee} ist nicht über Dein Guthaben {balance} gedeckt.'
+    'Transaktionsgebühr in Höhe von {fee} ist nicht über das Auszahlungsbetrag {withdrawal} gedeckt.'
 }
 
 export default deposit

--- a/src/renderer/i18n/en/deposit.ts
+++ b/src/renderer/i18n/en/deposit.ts
@@ -53,8 +53,7 @@ const deposit: DepositMessages = {
   'deposit.withdraw.receiveText': 'You should receive.',
   'deposit.withdraw.fees': 'Transaction fee: {thorMemo}, Outbounding fees: {thorOut} + {assetOut}',
   'deposit.withdraw.feeNote': 'Note: {fee} BNB will be left in your wallet for the transaction fees.',
-  'deposit.withdraw.error.feeNotCovered':
-    'Transaction fee {fee} needs to be covered by your balance (currently {balance}).'
+  'deposit.withdraw.error.feeNotCovered': 'Transaction fee {fee} needs to be covered by your withdrawal {withdrawal}.'
 }
 
 export default deposit

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -37,7 +37,7 @@ const wallet: WalletMessages = {
   'wallet.phrase.error.import': 'Error while importing phrase',
   'wallet.txs.last90days': 'Transactions for last 90 days',
   'wallet.empty.phrase.import': 'Import an existing wallet with funds on it',
-  'wallet.empty.phrase.create': 'Create a new wallet and funds on it',
+  'wallet.empty.phrase.create': 'Create a new wallet, add funds to it',
   'wallet.create.copy.phrase': 'Copy phrase below',
   'wallet.create.title': 'Create new wallet',
   'wallet.create.enter.phrase': 'Enter phrase correctly',

--- a/src/renderer/i18n/fr/deposit.ts
+++ b/src/renderer/i18n/fr/deposit.ts
@@ -56,7 +56,7 @@ const deposit: DepositMessages = {
   'deposit.withdraw.feeNote':
     'Remarque: {fee} BNB seront laissés dans votre portefeuille pour les frais de transaction.',
   'deposit.withdraw.error.feeNotCovered':
-    'Les frais de transaction {fee} doivent être couverts par votre solde (actuellement {balance}).'
+    'Transaction fee {fee} needs to be covered by your withdrawal {withdrawal} - FR.'
 }
 
 export default deposit

--- a/src/renderer/i18n/ru/deposit.ts
+++ b/src/renderer/i18n/ru/deposit.ts
@@ -54,7 +54,7 @@ const deposit: DepositMessages = {
   'deposit.withdraw.fees': 'Комиссия транзакции: {thorMemo}, Исходящие комиссии: {thorOut} + {assetOut}',
   'deposit.withdraw.feeNote': 'Важно: {fee} BNB останется на вашем кошельке для покрытия комисий.',
   'deposit.withdraw.error.feeNotCovered':
-    'Комиссия транзакции {fee} должна покрываться вашим балансом (баланс: {balance})'
+    'Transaction fee {fee} needs to be covered by your withdrawal {withdrawal}. - RU'
 }
 
 export default deposit

--- a/src/renderer/services/chain/fees/deposit.ts
+++ b/src/renderer/services/chain/fees/deposit.ts
@@ -47,7 +47,7 @@ const depositFee$ = ({
 }): FeeLD => {
   switch (asset.chain) {
     case BNBChain:
-      return BNB.fees$().pipe(liveData.map(({ fast }) => fast))
+      return BNB.fees$().pipe(liveData.map((fees) => fees[FeeOptionKeys.DEPOSIT]))
     case BTCChain: {
       return BTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees[FeeOptionKeys.DEPOSIT]))
     }
@@ -88,8 +88,10 @@ const depositFee$ = ({
             })
           }
         ),
-        // Actual gas fee changes time to time so in many cases, actual fast gas fee is bigger than estimated fast fee
-        // To avoid low gas fee error, we apply fastest fee for ETH only
+        // Gas fee have been changed from time to time and in many cases for ETH,
+        // with a result that `fast` gas fee is bigger than estimated `fast` fee
+        // To avoid low gas fee error, we apply `fastest` for ETH fee calculation
+        // (but still use `fast` fees for sending deposit txs )
         liveData.map((fees) => fees['fastest'])
       )
     }

--- a/src/renderer/services/chain/fees/swap.ts
+++ b/src/renderer/services/chain/fees/swap.ts
@@ -4,7 +4,6 @@ import {
   BNBChain,
   THORChain,
   BTCChain,
-  baseAmount,
   ETHChain,
   CosmosChain,
   PolkadotChain,
@@ -191,7 +190,7 @@ const swapFees$: SwapFeesHandler = (oInitialParams) => {
               in$,
               txOutFee$(outTx)
             ) // Result needs to be 3 times as "normal" fee
-              .pipe(liveData.map((fee) => baseAmount(fee.amount().times(3), fee.decimal)))
+              .pipe(liveData.map((fee) => fee.times(3)))
 
             return liveData.sequenceS({
               inTx: in$,

--- a/src/renderer/services/chain/fees/withdraw.ts
+++ b/src/renderer/services/chain/fees/withdraw.ts
@@ -1,72 +1,101 @@
 import * as RD from '@devexperts/remote-data-ts'
 import {
+  Asset,
   BCHChain,
   BNBChain,
   BTCChain,
-  Chain,
   CosmosChain,
   ETHChain,
   LTCChain,
   PolkadotChain,
   THORChain
 } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
 
+import { ZERO_BASE_AMOUNT } from '../../../const'
+import { getChainAsset } from '../../../helpers/chainHelper'
 import { liveData } from '../../../helpers/rx/liveData'
+import { observableState } from '../../../helpers/stateHelper'
 import * as BNB from '../../binance'
 import * as BTC from '../../bitcoin'
 import * as BCH from '../../bitcoincash'
+import * as ETH from '../../ethereum'
 import * as LTC from '../../litecoin'
 import * as THOR from '../../thorchain'
-import { FeeLD, Memo } from '../types'
+import { FeeOptionKeys } from '../const'
+import { FeeLD, WithdrawFeesHandler, WithdrawFeesParams } from '../types'
 
-const reloadWithdrawFee = (chain: Chain) => {
-  switch (chain) {
-    case BNBChain:
-      BNB.reloadFees()
-      break
-    case BTCChain:
-      BTC.reloadFees()
-      break
-    case THORChain:
-      THOR.reloadFees()
-      break
-    case LTCChain:
-      LTC.reloadFees()
-      break
-    case ETHChain:
-      // TODO (@asgdx-team) Implement it for asym. withdraw (not needed for sym withdraw, since txs are RUNE based then)
-      // see https://github.com/thorchain/asgardex-electron/issues/1071
-      break
-    case CosmosChain:
-      // not implemented yet
-      break
-    case PolkadotChain:
-      // not implemented yet
-      break
-  }
-}
+const withdrawFeeByChain$ = (asset: Asset, memo: string): FeeLD => {
+  const chainAsset = getChainAsset(asset.chain)
 
-const withdrawFee$ = (chain: Chain, memo: Memo): FeeLD => {
-  switch (chain) {
+  switch (chainAsset.chain) {
     case BNBChain:
-      return BNB.fees$().pipe(liveData.map(({ fast }) => fast))
+      return FP.pipe(
+        BNB.fees$(),
+        liveData.map((fees) => fees[FeeOptionKeys.WITHDRAW])
+      )
     case BTCChain:
       // withdraw fee for BTC txs based on withdraw memo
-      return BTC.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees.fast))
+      return FP.pipe(
+        BTC.feesWithRates$(memo),
+        liveData.map(({ fees }) => fees[FeeOptionKeys.WITHDRAW])
+      )
     case THORChain:
-      return THOR.fees$().pipe(liveData.map(({ fast }) => fast))
+      return FP.pipe(
+        THOR.fees$(),
+        liveData.map((fees) => fees[FeeOptionKeys.WITHDRAW])
+      )
     case ETHChain:
-      return Rx.of(RD.failure(Error(`Withdraw fee for ETH has not been implemented`)))
+      return FP.pipe(
+        ETH.poolOutTxFee$(asset),
+        liveData.map((fees) => fees[FeeOptionKeys.WITHDRAW])
+      )
     case CosmosChain:
       return Rx.of(RD.failure(Error(`Withdraw fee for Cosmos has not been implemented`)))
     case PolkadotChain:
       return Rx.of(RD.failure(Error(`Withdraw fee for Polkadot has not been implemented`)))
     case BCHChain:
-      return BCH.feesWithRates$(memo).pipe(liveData.map(({ fees }) => fees.fast))
+      return FP.pipe(
+        BCH.feesWithRates$(memo),
+        liveData.map(({ fees }) => fees[FeeOptionKeys.WITHDRAW])
+      )
     case LTCChain:
-      return LTC.feesWithRates$(memo).pipe(liveData.map(({ fees: { fast } }) => fast))
+      return FP.pipe(
+        LTC.feesWithRates$(memo),
+        liveData.map(({ fees }) => fees[FeeOptionKeys.WITHDRAW])
+      )
   }
 }
 
-export { reloadWithdrawFee, withdrawFee$ }
+// state for reloading swap fees
+const { get$: reloadWithdrawFee$, set: reloadWithdrawFees } = observableState<O.Option<WithdrawFeesParams>>(O.none)
+
+const withdrawFees$: WithdrawFeesHandler = (oInitialParams) => {
+  return FP.pipe(
+    reloadWithdrawFee$,
+    RxOp.switchMap((oReloadParams) => {
+      return FP.pipe(
+        // (1) Always check reload params first
+        oReloadParams,
+        // (2) If reload params not set (which is by default), use initial params
+        O.alt(() => oInitialParams),
+        O.fold(
+          // If both (initial + reload params) are not set, return zero fees
+          () => Rx.of(RD.success(ZERO_BASE_AMOUNT)),
+          ({ asset, memo }) => {
+            return FP.pipe(
+              withdrawFeeByChain$(asset, memo),
+              // Result needs to be 3 times as "normal" fee
+              liveData.map((fee) => fee.times(3))
+            )
+          }
+        )
+      )
+    })
+  )
+}
+
+export { reloadWithdrawFees, withdrawFees$ }

--- a/src/renderer/services/chain/index.ts
+++ b/src/renderer/services/chain/index.ts
@@ -7,8 +7,8 @@ import {
   symDepositFees$,
   reloadAsymDepositFee,
   asymDepositFee$,
-  withdrawFee$,
-  reloadWithdrawFee,
+  withdrawFees$,
+  reloadWithdrawFees,
   reloadSwapFees,
   swapFees$
 } from './fees'
@@ -34,8 +34,8 @@ export {
   symDepositFees$,
   reloadAsymDepositFee,
   asymDepositFee$,
-  withdrawFee$,
-  reloadWithdrawFee,
+  withdrawFees$,
+  reloadWithdrawFees,
   symDepositTxMemo$,
   asymDepositTxMemo$,
   getWithdrawMemo$,

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -201,6 +201,10 @@ export type SymWithdrawParams = {
 
 export type SymWithdrawStateHandler = (p: SymWithdrawParams) => WithdrawState$
 
+export type WithdrawFeesParams = { asset: Asset; percent: Number; memo: Memo }
+export type WithdrawFeesHandler = (params: O.Option<WithdrawFeesParams>) => FeeLD
+export type ReloadWithdrawFeesHandler = (params: O.Option<WithdrawFeesParams>) => void
+
 export type AsymWithdrawParams = {
   readonly poolAddress: PoolAddress
   readonly asset: Asset

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -4,7 +4,8 @@ import { isChain, Chain } from '@xchainjs/xchain-util'
 import { Network } from '../../shared/api/types'
 import { envOrDefault } from '../helpers/envHelper'
 
-export const DEFAULT_NETWORK: Network = 'chaosnet'
+export const DEFAULT_NETWORK: Network = 'testnet'
+// export const DEFAULT_NETWORK: Network = 'chaosnet'
 export const DEFAULT_CLIENT_NETWORK: Client.Network = 'mainnet'
 export const AVAILABLE_NETWORKS: Network[] = ['testnet', 'chaosnet'] // ['testnet', 'chaosnet', 'mainnet']
 export const ENABLED_CHAINS: Chain[] = envOrDefault(process.env.REACT_APP_CHAINS_ENABLED, 'THOR,BNB,BTC,LTC,BCH,ETH')

--- a/src/renderer/services/const.ts
+++ b/src/renderer/services/const.ts
@@ -4,8 +4,7 @@ import { isChain, Chain } from '@xchainjs/xchain-util'
 import { Network } from '../../shared/api/types'
 import { envOrDefault } from '../helpers/envHelper'
 
-export const DEFAULT_NETWORK: Network = 'testnet'
-// export const DEFAULT_NETWORK: Network = 'chaosnet'
+export const DEFAULT_NETWORK: Network = 'chaosnet'
 export const DEFAULT_CLIENT_NETWORK: Client.Network = 'mainnet'
 export const AVAILABLE_NETWORKS: Network[] = ['testnet', 'chaosnet'] // ['testnet', 'chaosnet', 'mainnet']
 export const ENABLED_CHAINS: Chain[] = envOrDefault(process.env.REACT_APP_CHAINS_ENABLED, 'THOR,BNB,BTC,LTC,BCH,ETH')

--- a/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
+++ b/src/renderer/views/deposit/withdraw/AsymWithdrawView.tsx
@@ -36,7 +36,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
     }
   } = useMidgardContext()
 
-  const { withdrawFee$, reloadWithdrawFees, symWithdraw$, getExplorerUrlByAsset$ } = useChainContext()
+  const { withdrawFees$, reloadWithdrawFees, symWithdraw$, getExplorerUrlByAsset$ } = useChainContext()
 
   const runePrice = useObservableState(priceRatio$, bn(1))
 
@@ -103,7 +103,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
   const renderEmptyForm = useCallback(
     () => (
       <AsymWithdraw
-        fee$={withdrawFee$}
+        fees$={withdrawFees$}
         assetPrice={ZERO_BN}
         runePrice={runePrice}
         chainAssetBalance={O.none}
@@ -121,7 +121,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
       />
     ),
     [
-      withdrawFee$,
+      withdrawFees$,
       runePrice,
       asset,
       reloadWithdrawFees,
@@ -151,7 +151,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
         share={poolShare.assetAddedAmount}
         asset={asset}
         poolAddresses={oPoolAddress}
-        fee$={withdrawFee$}
+        fees$={withdrawFees$}
         reloadFees={reloadWithdrawFees}
         validatePassword$={validatePassword$}
         viewRuneTx={viewRuneTx}
@@ -165,7 +165,7 @@ export const AsymWithdrawView: React.FC<Props> = (props): JSX.Element => {
       chainAssetBalance,
       asset,
       oPoolAddress,
-      withdrawFee$,
+      withdrawFees$,
       reloadWithdrawFees,
       validatePassword$,
       viewRuneTx,


### PR DESCRIPTION
- [ ] Fix withdraw fees to handle fees for 3 txs: RUNE in, RUNE out, ASSET out (see spec in #640) 
- [x] Fix + improve reloading of withdraw fees (no request in case of zero percent to withdraw)  
- [x] Fix for deposit fee error handling (chain asset vs. non chain asset)
- [x] Quick fix i18n (fixes #1375)
- [x] Remove (deprecated) content in `AsymWithdraw` - it will be re-build with #827 

Part of #1355 