### PR TITLE
Prerequisites: Update allow latest release

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -14,7 +14,7 @@ labels: 'bug'
 
 - [ ] Using yarn
 - [ ] Using node 12.x
-- [ ] Using an up-to-date [master branch](https://github.com/thorchain/asgardex-electron/tree/master/)
+- [ ] Using the latest release or an up-to-date [master branch](https://github.com/thorchain/asgardex-electron/tree/master/)
 - [ ] Link to stacktrace in a Gist (for bugs)
 
 ## Expected Behavior


### PR DESCRIPTION
Prerequisites previously only specified 'Using an up-to-date master branch', effectively prohibiting
release users from filing bugs (as they would then have to install git and know how to develop).
It now specifies "Using latest release or an up-to-date master branch".