### PR TITLE
Get gas rates from `inbound_addresses`

### DIFF
--- a/src/renderer/components/pool/FundsCap.style.tsx
+++ b/src/renderer/components/pool/FundsCap.style.tsx
@@ -5,7 +5,7 @@ export const Container = styled('div')`
   display: flex;
   justify-content: center;
   width: 100%;
-  background-color: solid ${palette('background', 0)};
+  color: ${palette('text', 1)};
   padding: 5px 10px;
   text-transform: uppercase;
 `

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -19,6 +19,8 @@ export const eqBigNumber: Eq.Eq<BigNumber> = {
   equals: (x, y) => x.isEqualTo(y)
 }
 
+export const eqOBigNumber: Eq.Eq<O.Option<BigNumber>> = O.getEq(eqBigNumber)
+
 export const eqAsset: Eq.Eq<Asset> = {
   equals: (x, y) =>
     Eq.eqString.equals(x.chain, y.chain) && Eq.eqString.equals(x.symbol.toUpperCase(), y.symbol.toUpperCase())

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -13,6 +13,8 @@ import { WalletBalance } from '../../types/wallet'
 
 export const eqOString = O.getEq(Eq.eqString)
 
+export const eqONumber = O.getEq(Eq.eqNumber)
+
 export const eqBigNumber: Eq.Eq<BigNumber> = {
   equals: (x, y) => x.isEqualTo(y)
 }

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -37,7 +37,7 @@ const wallet: WalletMessages = {
   'wallet.phrase.error.import': 'Error while importing phrase',
   'wallet.txs.last90days': 'Transactions for last 90 days',
   'wallet.empty.phrase.import': 'Import an existing wallet with funds on it',
-  'wallet.empty.phrase.create': 'Create a new wallet and funds on it',
+  'wallet.empty.phrase.create': 'Create a new wallet, add funds to it',
   'wallet.create.copy.phrase': 'Copy phrase below',
   'wallet.create.title': 'Create new wallet',
   'wallet.create.enter.phrase': 'Enter phrase correctly',

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -26,7 +26,8 @@ import {
   GetDepthHistoryRequest,
   DepthHistory,
   DepthHistoryItem,
-  SwapHistoryItem
+  SwapHistoryItem,
+  InboundAddressesItem
 } from '../../types/generated/midgard'
 import { PricePools, PricePoolAsset, PricePool } from '../../views/pools/Pools.types'
 import { Memo } from '../chain/types'
@@ -96,6 +97,13 @@ export type NativeFee = O.Option<BaseAmount>
 export type NativeFeeRD = RD.RemoteData<Error, NativeFee>
 export type NativeFeeLD = LiveData<Error, NativeFee>
 
+// To mMake sure we accept inbound addresses with valid chains only: chain:string -> chain:Chain
+export type InboundAddress = Omit<InboundAddressesItem, 'chain'> & { chain: Chain }
+export type InboundAddresses = InboundAddress[]
+export type InboundAddressesLD = LiveData<Error, InboundAddresses>
+
+export type GasRate = number
+export type GasRateLD = LiveData<Error, GasRate>
 /**
  * Type for addresses of a pool
  * A pool has a vault address
@@ -171,7 +179,7 @@ export type PoolsService = {
   reloadAllPools: FP.Lazy<void>
   selectedPoolAddress$: PoolAddress$
   poolAddressesByChain$: (chain: Chain) => PoolAddressLD
-  reloadPoolAddresses: FP.Lazy<void>
+  reloadInboundAddresses: FP.Lazy<void>
   selectedPoolDetail$: PoolDetailLD
   reloadSelectedPoolDetail: (delay?: number) => void
   reloadPoolStatsDetail: FP.Lazy<void>
@@ -188,6 +196,7 @@ export type PoolsService = {
   validatePool$: (poolAddresses: PoolAddress, chain: Chain) => ValidatePoolLD
   poolsFilters$: Rx.Observable<Record<string, O.Option<PoolFilter>>>
   setPoolsFilter: (poolKey: string, filter: O.Option<PoolFilter>) => void
+  gasRateByChain$: (chain: Chain) => GasRateLD
 }
 
 export type PoolShareType = DepositType | 'all'

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -102,7 +102,7 @@ export type InboundAddress = Omit<InboundAddressesItem, 'chain'> & { chain: Chai
 export type InboundAddresses = InboundAddress[]
 export type InboundAddressesLD = LiveData<Error, InboundAddresses>
 
-export type GasRate = number
+export type GasRate = BigNumber
 export type GasRateLD = LiveData<Error, GasRate>
 /**
  * Type for addresses of a pool

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -10,6 +10,7 @@ import {
   bn,
   BNBChain,
   BTCChain,
+  Chain,
   ETHChain,
   THORChain
 } from '@xchainjs/xchain-util'
@@ -23,8 +24,8 @@ import {
   FOUR_RUNE_BASE_AMOUNT
 } from '../../../shared/mock/amount'
 import { PRICE_POOLS_WHITELIST, AssetBUSDBAF, ZERO_BN } from '../../const'
-import { eqAsset, eqPoolShare, eqPoolShares } from '../../helpers/fp/eq'
-import { RUNE_PRICE_POOL } from '../../helpers/poolHelper'
+import { eqAsset, eqPoolShare, eqPoolShares, eqONumber } from '../../helpers/fp/eq'
+import { RUNE_POOL_ADDRESS, RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { PoolDetail } from '../../types/generated/midgard'
 import { PricePool, PricePools } from '../../views/pools/Pools.types'
 import { PoolAddress, PoolAssetDetail, PoolShare, PoolShares, PoolsState, PoolsStateRD } from './types'
@@ -43,8 +44,9 @@ import {
   getSharesByAssetAndType,
   getPoolAssetDetail,
   getPoolAssetsDetail,
-  toPoolAddresses,
-  getBUSDPoolData
+  inboundToPoolAddresses,
+  getBUSDPoolData,
+  getGasRateByChain
 } from './utils'
 
 describe('services/midgard/utils/', () => {
@@ -228,7 +230,7 @@ describe('services/midgard/utils/', () => {
     })
   })
 
-  describe.only('getBUSDPoolData', () => {
+  describe('getBUSDPoolData', () => {
     const runeDetail = { asset: assetToString(AssetRuneNative) } as PoolDetail
     const bnbDetail = { asset: assetToString(AssetBNB) } as PoolDetail
     const busdDetail = { asset: assetToString(AssetBUSDBAF) } as PoolDetail
@@ -252,9 +254,12 @@ describe('services/midgard/utils/', () => {
     })
   })
 
-  describe('toPoolAddresses', () => {
-    it('returns empty list', () => {
-      expect(toPoolAddresses([])).toEqual([])
+  describe('inboundToPoolAddresses', () => {
+    it('adds rune pool address empty list', () => {
+      expect(inboundToPoolAddresses([])).toEqual([RUNE_POOL_ADDRESS])
+    })
+    it('adds two `PoolAddress`es', () => {
+      expect(inboundToPoolAddresses([{ chain: 'BNB', address: 'bnb-address', router: '' }]).length).toEqual(2)
     })
   })
 
@@ -436,6 +441,33 @@ describe('services/midgard/utils/', () => {
       })
       it('returns empty list in case of invalid data', () => {
         expect(getPoolAssetsDetail([{ assetPrice: '1', asset: '' }])).toEqual([])
+      })
+    })
+
+    describe('getGasRateByChain', () => {
+      const data: { chain: Chain; gas_rate?: string }[] = [
+        { chain: 'BNB', gas_rate: '1' },
+        { chain: 'ETH', gas_rate: '2' },
+        { chain: 'BTC', gas_rate: '3' },
+        { chain: 'LTC' }, // no gas rate
+        { chain: 'BCH', gas_rate: 'invalid' } // invalid gas rate
+      ]
+
+      it('gas rate for BNB', () => {
+        const result = getGasRateByChain(data, 'BNB')
+        expect(eqONumber.equals(result, O.some(1))).toBeTruthy()
+      })
+      it('gas rate for ETH', () => {
+        const result = getGasRateByChain(data, 'ETH')
+        expect(eqONumber.equals(result, O.some(2))).toBeTruthy()
+      })
+      it('none for missing gas rate (LTC)', () => {
+        const result = getGasRateByChain(data, 'LTC')
+        expect(result).toBeNone()
+      })
+      it('none for invalid gas rate (BCH)', () => {
+        const result = getGasRateByChain(data, 'BCH')
+        expect(result).toBeNone()
       })
     })
   })

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -24,7 +24,7 @@ import {
   FOUR_RUNE_BASE_AMOUNT
 } from '../../../shared/mock/amount'
 import { PRICE_POOLS_WHITELIST, AssetBUSDBAF, ZERO_BN } from '../../const'
-import { eqAsset, eqPoolShare, eqPoolShares, eqONumber } from '../../helpers/fp/eq'
+import { eqAsset, eqPoolShare, eqPoolShares, eqOBigNumber } from '../../helpers/fp/eq'
 import { RUNE_POOL_ADDRESS, RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { PoolDetail } from '../../types/generated/midgard'
 import { PricePool, PricePools } from '../../views/pools/Pools.types'
@@ -259,7 +259,16 @@ describe('services/midgard/utils/', () => {
       expect(inboundToPoolAddresses([])).toEqual([RUNE_POOL_ADDRESS])
     })
     it('adds two `PoolAddress`es', () => {
-      expect(inboundToPoolAddresses([{ chain: 'BNB', address: 'bnb-address', router: '' }]).length).toEqual(2)
+      const result = inboundToPoolAddresses([{ chain: 'BNB', address: 'bnb-address', router: '' }])
+      expect(result.length).toEqual(2)
+      // RUNE `PoolAddress`
+      expect(result[0]).toEqual(RUNE_POOL_ADDRESS)
+      // bnb `PoolAddress`
+      expect(result[1]).toEqual({
+        chain: 'BNB',
+        address: 'bnb-address',
+        router: O.none
+      })
     })
   })
 
@@ -455,11 +464,11 @@ describe('services/midgard/utils/', () => {
 
       it('gas rate for BNB', () => {
         const result = getGasRateByChain(data, 'BNB')
-        expect(eqONumber.equals(result, O.some(1))).toBeTruthy()
+        expect(eqOBigNumber.equals(result, O.some(bn(1)))).toBeTruthy()
       })
       it('gas rate for ETH', () => {
         const result = getGasRateByChain(data, 'ETH')
-        expect(eqONumber.equals(result, O.some(2))).toBeTruthy()
+        expect(eqOBigNumber.equals(result, O.some(bn(2)))).toBeTruthy()
       })
       it('none for missing gas rate (LTC)', () => {
         const result = getGasRateByChain(data, 'LTC')

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -1,6 +1,16 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { PoolData } from '@thorchain/asgardex-util'
-import { assetFromString, bnOrZero, baseAmount, Asset, assetToString, Chain } from '@xchainjs/xchain-util'
+import {
+  assetFromString,
+  bnOrZero,
+  baseAmount,
+  Asset,
+  assetToString,
+  Chain,
+  isValidBN,
+  bn
+} from '@xchainjs/xchain-util'
+import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
@@ -164,7 +174,7 @@ export const getPoolAddressesByChain = (addresses: PoolAddresses, chain: Chain):
 export const getGasRateByChain = (
   addresses: Pick<InboundAddress, 'chain' | 'gas_rate'>[],
   chain: Chain
-): O.Option<number> =>
+): O.Option<BigNumber> =>
   FP.pipe(
     addresses,
     A.findFirst((address) => eqChain.equals(address.chain, chain)),
@@ -173,7 +183,10 @@ export const getGasRateByChain = (
         gas_rate,
         O.fromNullable,
         // accept valid numbers only
-        O.filterMap((v) => (isNaN(Number(v)) ? O.none : O.some(Number(v))))
+        O.filterMap((rate) => {
+          const rateBN = bn(rate)
+          return isValidBN(rateBN) ? O.some(rateBN) : O.none
+        })
       )
     )
   )

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -64,7 +64,7 @@ export const SymDepositView: React.FC<Props> = (props) => {
         selectedPricePoolAsset$,
         reloadSelectedPoolDetail,
         selectedPoolAddress$,
-        reloadPoolAddresses
+        reloadInboundAddresses
       },
       shares: { reloadShares }
     }
@@ -94,8 +94,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
 
   // reload inbound addresses at `onMount` to get always latest `pool address`
   useEffect(() => {
-    reloadPoolAddresses()
-  }, [reloadPoolAddresses])
+    reloadInboundAddresses()
+  }, [reloadInboundAddresses])
 
   const runPrice = useObservableState(priceRatio$, bn(1))
   const [selectedPricePoolAsset] = useObservableState(() => FP.pipe(selectedPricePoolAsset$, RxOp.map(O.toUndefined)))

--- a/src/renderer/views/pools/Pools.util.test.ts
+++ b/src/renderer/views/pools/Pools.util.test.ts
@@ -229,7 +229,7 @@ describe('filterTableData', () => {
   })
 })
 
-describe.only('minPoolTxAmount', () => {
+describe('minPoolTxAmount', () => {
   it('$200 for BTC', () => {
     const result = minPoolTxAmountUSD(AssetBTC)
     expect(eqBaseAmount.equals(result, assetToBase(assetAmount(200, 8)))).toBeTruthy()

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -41,7 +41,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { poolsState$, reloadPools, selectedPoolAddress$, reloadPoolAddresses },
+    pools: { poolsState$, reloadPools, selectedPoolAddress$, reloadInboundAddresses },
     setSelectedPoolAsset
   } = midgardService
   const {
@@ -81,8 +81,8 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
   // reload inbound addresses at `onMount` to get always latest `pool address`
   useEffect(() => {
-    reloadPoolAddresses()
-  }, [reloadPoolAddresses])
+    reloadInboundAddresses()
+  }, [reloadInboundAddresses])
 
   const sourceAssetDecimal$: AssetWithDecimalLD = useMemo(
     () =>
@@ -180,8 +180,8 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   const reloadHandler = useCallback(() => {
     reloadBalances()
     reloadPools()
-    reloadPoolAddresses()
-  }, [reloadBalances, reloadPoolAddresses, reloadPools])
+    reloadInboundAddresses()
+  }, [reloadBalances, reloadInboundAddresses, reloadPools])
 
   const onChangePath = useCallback(
     (path) => {

--- a/src/renderer/views/wallet/UpgradeView.tsx
+++ b/src/renderer/views/wallet/UpgradeView.tsx
@@ -55,14 +55,14 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
 
   const {
     service: {
-      pools: { poolAddressesByChain$, reloadPoolAddresses }
+      pools: { poolAddressesByChain$, reloadInboundAddresses }
     }
   } = useMidgardContext()
 
   // reload inbound addresses at `onMount` to get always latest `pool address`
   useEffect(() => {
-    reloadPoolAddresses()
-  }, [reloadPoolAddresses])
+    reloadInboundAddresses()
+  }, [reloadInboundAddresses])
 
   const [upgradeFeeRD] = useObservableState(
     () =>


### PR DESCRIPTION
- [x] Add `gasRateByChain$` stream
- [x] Add `getGasRateByChain` helper
- [x] Extend loading data of `inbound_addresses` to provide different streams to get `PoolAddresses` and `GasRate`s
- [x] Rename `poolAddressesXYZ` to `inboundAddressesXYZ`
- [x] Add `poolAddressesShared$
- [x] Quick fix i18n (fixes #1375)
- [x] Fix text color of funds cap label

Part of #1381 