### PR TITLE
Test swap fee helpers

### DIFF
--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -87,8 +87,7 @@ const defaultProps: SwapProps = {
     Rx.of(
       RD.success({
         inFee: { amount: baseAmount(10000000), asset: AssetRuneNative },
-        outFee: { amount: baseAmount(1000000), asset: AssetBTC },
-        refundFee: { amount: baseAmount(3000000), asset: AssetRuneNative }
+        outFee: { amount: baseAmount(1000000), asset: AssetBTC }
       })
     ),
   approveFee$: () => Rx.of(RD.success(baseAmount(10000000))),

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -21,7 +21,9 @@ import {
   getSwapResult,
   getSwapData,
   pickPoolAsset,
-  poolAssetDetailToAsset
+  poolAssetDetailToAsset,
+  minBalanceToSwap,
+  calcRefundFee
 } from './Swap.utils'
 
 describe('components/swap/utils', () => {
@@ -291,6 +293,26 @@ describe('components/swap/utils', () => {
       expect(poolAssetDetailToAsset(O.some({ asset: AssetRuneNative, assetPrice: bn(0) }))).toEqual(
         O.some(AssetRuneNative)
       )
+    })
+  })
+
+  describe('calcRefundFee', () => {
+    it('should be 3 x inbound fee', () => {
+      const result = calcRefundFee(baseAmount(2))
+      expect(eqBaseAmount.equals(result, baseAmount(6))).toBeTruthy()
+    })
+  })
+
+  describe('minBalanceToSwap', () => {
+    it('returns min. amount to cover inbound + refund fees', () => {
+      const params = {
+        inFee: {
+          amount: baseAmount(100),
+          asset: AssetBNB
+        }
+      }
+      const result = minBalanceToSwap(params)
+      expect(eqBaseAmount.equals(result, baseAmount(600))).toBeTruthy()
     })
   })
 })

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -1,3 +1,4 @@
+import { ETH_DECIMAL } from '@xchainjs/xchain-ethereum'
 import {
   assetAmount,
   AssetBNB,
@@ -11,7 +12,8 @@ import {
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
-import { ZERO_BASE_AMOUNT } from '../../const'
+import { AssetBUSD74E, AssetUSDTERC20, ZERO_BASE_AMOUNT } from '../../const'
+import { BNB_DECIMAL } from '../../helpers/assetHelper'
 import { eqBaseAmount } from '../../helpers/fp/eq'
 import { PoolsDataMap } from '../../services/midgard/types'
 import {
@@ -23,7 +25,8 @@ import {
   pickPoolAsset,
   poolAssetDetailToAsset,
   minBalanceToSwap,
-  calcRefundFee
+  calcRefundFee,
+  minAmountToSwapMax1e8
 } from './Swap.utils'
 
 describe('components/swap/utils', () => {
@@ -313,6 +316,223 @@ describe('components/swap/utils', () => {
       }
       const result = minBalanceToSwap(params)
       expect(eqBaseAmount.equals(result, baseAmount(600))).toBeTruthy()
+    })
+  })
+
+  describe('minAmountToSwapMax1e8', () => {
+    const poolsData = {
+      'BNB.BUSD-74E': {
+        assetBalance: assetToBase(assetAmount(20)), // 1 BUSD = 0.05 RUNE
+        runeBalance: assetToBase(assetAmount(1)) // 1 RUNE = 20 BUSD
+      },
+      'ETH.USDT-0xa3910454bf2cb59b8b3a401589a3bacc5ca42306': {
+        assetBalance: assetToBase(assetAmount(20)), // 1 USDT = 0.05 RUNE
+        runeBalance: assetToBase(assetAmount(1)) // 1 RUNE = 20 USDT
+      },
+      'BNB.BNB': {
+        assetBalance: assetToBase(assetAmount(1)), // 1 BNB = 30 RUNE (600 USD)
+        runeBalance: assetToBase(assetAmount(30)) // 1 RUNE = 0.03 BNB
+      },
+      'ETH.ETH': {
+        assetBalance: assetToBase(assetAmount(1)), // 1 ETH = 100 RUNE (2000 USD)
+        runeBalance: assetToBase(assetAmount(100)) // 1 RUNE = 0.01 ETH
+      }
+    }
+
+    it('non chain asset -> chain asset (same chain): BNB.USD -> BNB.BNB)', () => {
+      const inAssetDecimal = 6
+      const params = {
+        swapFees: {
+          inFee: {
+            amount: assetToBase(assetAmount(0.0001, BNB_DECIMAL)),
+            asset: AssetBNB
+          },
+          outFee: {
+            amount: assetToBase(assetAmount(0.0003, BNB_DECIMAL)),
+            asset: AssetBNB
+          }
+        },
+        inAsset: AssetBUSD74E,
+        inAssetDecimal,
+        outAsset: AssetBNB,
+        poolsData
+      }
+      // Prices
+      // 1 BNB = 600 BUSD or 1 BUSD = 0,001666667 BNB
+      // Formula:
+      // 1.5 * (inboundFeeInBUSD + outboundFeeInBUSD)
+      // = 1.5 * (0.0001 * 600 + 0.0003 * 600)
+      // = 1.5 * (0.06 + 0,18) = 1.5 * 0.24
+      // = 0.36
+
+      // Prices
+      // 1 BNB = 600 BUSD or 1 BUSD = 0,001666667 BNB
+      //
+      // Formula (success):
+      // inboundFeeInBUSD + outboundFeeInBUSD
+      // 0.0001 * 600 + 0.0003 * 600 = 0.06 + 0,18 = 0.24
+      //
+      // Formula (failure):
+      // inboundFeeInBUSD + refundFeeInBUSD
+      // 0.0001 * 600 + 0.0003 * 600 = 0.06 + 0,18 = 0.24
+      //
+      // Formula (minValue):
+      // 1,5 * max(success, failure)
+      // 1,5 * max(0.24, 0.24) = 1,5 * 0.24 = 0.36
+
+      const result = minAmountToSwapMax1e8(params)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.36, inAssetDecimal)))).toBeTruthy()
+    })
+
+    it('chain asset -> non chain asset (same chain): BNB.BNB -> BNB.USD', () => {
+      const inAssetDecimal = BNB_DECIMAL
+      const params = {
+        swapFees: {
+          inFee: {
+            amount: assetToBase(assetAmount(0.0001)),
+            asset: AssetBNB
+          },
+          outFee: {
+            amount: assetToBase(assetAmount(0.0003)),
+            asset: AssetBNB
+          }
+        },
+        inAsset: AssetBNB,
+        inAssetDecimal,
+        outAsset: AssetBUSD74E,
+        poolsData
+      }
+
+      // Prices
+      // All in BNB
+
+      // Formula (success):
+      // inboundFeeInBNB + outboundFeeInBNB
+      // 0.0001 + 0.0003 = 0.0004
+      //
+      // Formula (failure):
+      // inboundFeeInBNB + refundFeeInBNB
+      // 0.0001 + 0.0003 = 0.0004
+      //
+      // Formula (minValue):
+      // 1,5 * max(success, failure)
+      // 1,5 * max(0.0004, 0.0004) = 1,5 * 0.0004 = 0.0006
+
+      const result = minAmountToSwapMax1e8(params)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.0006, inAssetDecimal)))).toBeTruthy()
+    })
+
+    it('chain asset -> chain asset (same chains): ETH.USDT -> ETH.ETH', () => {
+      const inAssetDecimal = 7
+      const params = {
+        swapFees: {
+          inFee: {
+            amount: assetToBase(assetAmount(0.01, ETH_DECIMAL)),
+            asset: AssetETH
+          },
+          outFee: {
+            amount: assetToBase(assetAmount(0.03, ETH_DECIMAL)),
+            asset: AssetETH
+          }
+        },
+        inAsset: AssetUSDTERC20,
+        inAssetDecimal,
+        outAsset: AssetETH,
+        poolsData
+      }
+      // Prices
+      // 1 ETH = 2000 USDT or 1 USDT = 0,0005 ETH
+      //
+      // Formula (success):
+      // inboundFeeInUSDT + outboundFeeInUSDT
+      // 0.01 * 2000 + 0.03 * 2000 = 20 + 60 = 80
+      //
+      // Formula (failure):
+      // inboundFeeInUSDT + refundFeeInUSDT
+      // 0.01 * 2000 + 0.03 * 2000 = 20 + 60 = 80
+      //
+      // Formula (minValue):
+      // 1,5 * max(success, failure)
+      // 1,5 * max(80, 80) = 1,5 * 80 = 120
+
+      const result = minAmountToSwapMax1e8(params)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(120, inAssetDecimal)))).toBeTruthy()
+    })
+
+    it('chain asset -> chain asset (different chains): BNB.BNB -> ETH.ETH', () => {
+      const inAssetDecimal = BNB_DECIMAL
+      const params = {
+        swapFees: {
+          inFee: {
+            amount: assetToBase(assetAmount(0.0001)),
+            asset: AssetBNB
+          },
+          outFee: {
+            amount: assetToBase(assetAmount(0.01)),
+            asset: AssetETH
+          }
+        },
+        inAsset: AssetBNB,
+        inAssetDecimal,
+        outAsset: AssetETH,
+        poolsData
+      }
+      // Prices
+      // 1 BNB = 0.3 ETH or 1 ETH = 3.33 BNB
+      //
+      // Formula (success):
+      // inboundFeeInBNB + outboundFeeInBNB
+      // 0.0001 + (0.01 * 3.33) = 0.0001 + 0,0333 = 0.0334
+      //
+      // Formula (failure):
+      // inboundFeeInBNB + refundFeeInBNB
+      // 0.0001 + (0.0003 * 3.33) = 0.0001 + 0,000999 = 0.001099
+      //
+      // Formula (minValue):
+      // 1,5 * max(success, failure)
+      // 1,5 * max(0.03343, 0.001099) = 1,5 * 0.03343 = 0.0501
+
+      const result = minAmountToSwapMax1e8(params)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.05015, inAssetDecimal)))).toBeTruthy()
+    })
+
+    it('non chain asset -> non chain asset (different chains): BNB.BUSD -> ETH.USDT', () => {
+      const inAssetDecimal = 7
+      const params = {
+        swapFees: {
+          inFee: {
+            amount: assetToBase(assetAmount(0.0001)),
+            asset: AssetBNB
+          },
+          outFee: {
+            amount: assetToBase(assetAmount(0.01)),
+            asset: AssetETH
+          }
+        },
+        inAsset: AssetBUSD74E,
+        inAssetDecimal,
+        outAsset: AssetUSDTERC20,
+        poolsData
+      }
+
+      // Prices
+      // 1 ETH = 2000 USD or 1 USD = 0,0005 ETH
+      // 1 BNB = 600 USD or 1 USD = 0,001666667 BNB
+      //
+      // Formula (success):
+      // outboundFeeInBUSD
+      // (0.01 * 2000) = 20
+      //
+      // Formula (failure):
+      // refundFeeInBUSD
+      // 0.0003 * 600 = 0.18
+      //
+      // Formula (minValue):
+      // 1,5 * max(success, failure)
+      // 1,5 * max(10, 18) = 1,5 * 20 = 30
+
+      const result = minAmountToSwapMax1e8(params)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(30, inAssetDecimal)))).toBeTruthy()
     })
   })
 })

--- a/src/renderer/services/chain/fees/swap.ts
+++ b/src/renderer/services/chain/fees/swap.ts
@@ -24,8 +24,7 @@ const {
  */
 export const getZeroSwapFees = ({ inAsset, outAsset }: { inAsset: Asset; outAsset: Asset }): SwapFees => ({
   inFee: { amount: ZERO_BASE_AMOUNT, asset: getChainAsset(inAsset.chain) },
-  outFee: { amount: ZERO_BASE_AMOUNT, asset: getChainAsset(outAsset.chain) },
-  refundFee: { amount: ZERO_BASE_AMOUNT, asset: getChainAsset(outAsset.chain) }
+  outFee: { amount: ZERO_BASE_AMOUNT, asset: getChainAsset(outAsset.chain) }
 })
 
 // state of `SwapFeesParams` used for reloading swap fees
@@ -68,14 +67,6 @@ const swapFees$: SwapFeesHandler = (initialParams) => {
         inFee: poolFee$(inAsset),
         outFee: FP.pipe(
           outAsset,
-          poolFee$,
-          liveData.map((chainFee) => ({
-            ...chainFee,
-            amount: chainFee.amount.times(3)
-          }))
-        ),
-        refundFee: FP.pipe(
-          inAsset,
           poolFee$,
           liveData.map((chainFee) => ({
             ...chainFee,

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -131,8 +131,6 @@ export type SwapFees = {
   readonly inFee: SwapFee
   /** Outbound tx fee */
   readonly outFee: SwapFee
-  /** Refund tx fee */
-  readonly refundFee: SwapFee
 }
 
 export type SwapFeesRD = RD.RemoteData<Error, SwapFees>


### PR DESCRIPTION
All tests in ` Swap.utils`

- [x] Test `minBalanceToSwap` + `calcRefundFee` + `minAmountToSwapMax1e8`
- [x] Remove `refundFees` from `SwapFees` in favour of `calcRefundFee` helper

Closes #1390 