### PR TITLE
[UPDATE] Remove error state from upgrade alert

### DIFF
--- a/src/renderer/components/AppUpdate/AppUpdate.stories.tsx
+++ b/src/renderer/components/AppUpdate/AppUpdate.stories.tsx
@@ -4,23 +4,18 @@ import { Meta, Story } from '@storybook/react'
 
 import { AppUpdate } from './AppUpdate'
 
-export const Default: Story<{ type: 'success' | 'fail'; goToUpdates: () => void; close: () => void }> = ({
-  type,
+export const Default: Story<{ isOpen: boolean; goToUpdates: () => void; close: () => void }> = ({
+  isOpen,
   close,
   goToUpdates
 }) => {
-  if (type === 'success') {
-    return <AppUpdate isOpen={true} type={type} goToUpdates={goToUpdates} close={close} version={'test version'} />
-  }
-
-  return <AppUpdate isOpen={true} type={type} close={close} message={'error message'} />
+  return <AppUpdate isOpen={isOpen} goToUpdates={goToUpdates} close={close} version={'test version'} />
 }
 
 const argTypes = {
-  type: {
+  isOpen: {
     control: {
-      type: 'select',
-      options: ['success', 'fail'] as const
+      type: 'boolean'
     }
   },
   goToUpdates: {
@@ -31,7 +26,7 @@ const argTypes = {
   }
 }
 
-Default.args = { type: argTypes.type.control.options[0] }
+Default.args = { isOpen: true }
 
 const meta: Meta = {
   title: 'AppUpdate',

--- a/src/renderer/components/AppUpdate/AppUpdate.tsx
+++ b/src/renderer/components/AppUpdate/AppUpdate.tsx
@@ -8,16 +8,9 @@ import * as Styled from './AppUpdate.styles'
 export type AppUpdateModalProps =
   | {
       isOpen: true
-      type: 'success'
       goToUpdates: () => void
       version: string
       close: () => void
-    }
-  | {
-      isOpen: true
-      type: 'fail'
-      close: () => void
-      message: string
     }
   | {
       isOpen: false
@@ -27,7 +20,7 @@ export const AppUpdate: React.FC<AppUpdateModalProps> = (props) => {
   const intl = useIntl()
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
 
-  if (props.isOpen && props.type === 'success') {
+  if (props.isOpen) {
     return (
       <Styled.Success
         action={
@@ -49,20 +42,6 @@ export const AppUpdate: React.FC<AppUpdateModalProps> = (props) => {
                 </Styled.OkContent>
               </Styled.OkButton>
             )}
-          </Styled.Content>
-        }
-        onClose={props.close}
-        closable
-      />
-    )
-  }
-
-  if (props.isOpen && props.type === 'fail') {
-    return (
-      <Styled.Error
-        message={
-          <Styled.Content>
-            <Styled.Title>{intl.formatMessage({ id: 'update.checkFailed' }, { error: props.message })}</Styled.Title>
           </Styled.Content>
         }
         onClose={props.close}

--- a/src/renderer/views/app/AppUpdateView.tsx
+++ b/src/renderer/views/app/AppUpdateView.tsx
@@ -28,25 +28,12 @@ export const AppUpdateView: React.FC = () => {
     () =>
       FP.pipe(
         appUpdater,
-        RD.chain<Error, O.Option<string>, string>((oVersion) =>
-          FP.pipe(
-            oVersion,
-            O.fold(() => RD.initial, RD.success)
-          )
-        ),
-        // TODO will be converted to the Option at all by #1393
-        RD.fold(
+        RD.toOption,
+        O.flatten,
+        O.fold(
           (): AppUpdateModalProps => ({ isOpen: false }),
-          (): AppUpdateModalProps => ({ isOpen: false }),
-          ({ message }): AppUpdateModalProps => ({
-            isOpen: true,
-            type: 'fail',
-            close: resetAppUpdater,
-            message
-          }),
           (version): AppUpdateModalProps => ({
             isOpen: true,
-            type: 'success',
             goToUpdates: () => window.apiUrl.openExternal(`${ExternalUrl.GITHUB_RELEASE}${version}`),
             version,
             close: resetAppUpdater


### PR DESCRIPTION
- converted updated info to the plain `Option` for the `AppUpdateView`

closes #1393 