### PR TITLE
 Logo to Left of Asset On Detail View

### DIFF
--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -11,6 +11,7 @@ import { PoolDetails } from './PoolDetails'
 export const PoolDetailsStory = () => {
   return (
     <PoolDetails
+      network={'testnet'}
       poolDetail={poolDetailMock}
       poolStatsDetail={poolStatsDetailMock}
       earningsHistory={O.none}

--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -5,6 +5,7 @@ import * as A from 'antd'
 import BigNumber from 'bignumber.js'
 import * as O from 'fp-ts/Option'
 
+import { Network } from '../../../shared/api/types'
 import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
 import { PoolCards } from './PoolCards'
 import * as H from './PoolDetails.helpers'
@@ -22,6 +23,7 @@ export type Props = {
   HistoryView: React.ComponentType<{ poolAsset: Asset }>
   ChartView: React.ComponentType<{ isLoading?: boolean; priceRatio: BigNumber }>
   haltedChains?: Chain[]
+  network: Network
 }
 
 export const PoolDetails: React.FC<Props> = ({
@@ -34,7 +36,8 @@ export const PoolDetails: React.FC<Props> = ({
   isLoading,
   HistoryView,
   ChartView,
-  haltedChains
+  haltedChains,
+  network
 }) => {
   const price = useMemo(() => H.getPrice(poolDetail, priceRatio), [poolDetail, priceRatio])
   return (
@@ -42,6 +45,7 @@ export const PoolDetails: React.FC<Props> = ({
       <Styled.TopContainer>
         <A.Col span={24}>
           <PoolTitle
+            network={network}
             haltedChains={haltedChains}
             asset={O.some(asset)}
             price={price}

--- a/src/renderer/components/pool/PoolTitle.style.tsx
+++ b/src/renderer/components/pool/PoolTitle.style.tsx
@@ -2,7 +2,7 @@ import * as A from 'antd'
 import styled from 'styled-components'
 
 import { media } from '../../helpers/styleHelper'
-import { AssetIcon as AssetIconUI } from '../uielements/assets/assetIcon'
+import { AssetSelect as AssetSelectUI } from '../uielements/assets/assetSelect'
 import { Label } from '../uielements/label'
 
 export const Container = styled(A.Row)`
@@ -63,6 +63,11 @@ export const ButtonActions = styled.div`
   }
 `
 
-export const AssetIcon = styled(AssetIconUI).attrs({ size: 'small' })`
+export const AssetSelect = styled(AssetSelectUI)`
+  width: auto;
   margin-right: 10px;
+
+  & .label-wrapper {
+    padding: 0;
+  }
 `

--- a/src/renderer/components/pool/PoolTitle.style.tsx
+++ b/src/renderer/components/pool/PoolTitle.style.tsx
@@ -1,38 +1,18 @@
 import * as A from 'antd'
 import styled from 'styled-components'
+import { palette } from 'styled-theme'
 
 import { media } from '../../helpers/styleHelper'
-import { AssetSelect as AssetSelectUI } from '../uielements/assets/assetSelect'
 import { Label } from '../uielements/label'
 
 export const Container = styled(A.Row)`
   justify-content: space-between;
   flex-flow: row;
   width: 100%;
+  padding: 20px 0 10px 0;
 `
 
-export const Title = styled(Label).attrs({
-  weight: 'bold',
-  size: 'big'
-})`
-  display: flex;
-  margin-right: 16px;
-  width: fit-content;
-  place-items: center;
-  text-transform: uppercase;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-size: 18px;
-  ${media.lg`
-    font-size: 24px;
-  `}
-`
-
-export const Price = styled(Label).attrs({
-  weight: 'bold',
-  size: 'big'
-})`
+export const Price = styled(Label)`
   display: flex;
   width: fit-content;
   place-items: center;
@@ -40,9 +20,12 @@ export const Price = styled(Label).attrs({
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  font-size: 18px;
+  font-size: 27px;
+  padding: 0;
+  padding-left: 15px;
   ${media.lg`
-    font-size: 24px;
+    font-size: 49px;
+    padding-left: 40px;
   `}
 `
 
@@ -63,11 +46,45 @@ export const ButtonActions = styled.div`
   }
 `
 
-export const AssetSelect = styled(AssetSelectUI)`
-  width: auto;
-  margin-right: 10px;
+export const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding: 10px 0;
+`
 
-  & .label-wrapper {
-    padding: 0;
-  }
+export const AssetWrapper = styled.div`
+  margin-left: 10px;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+
+  ${media.lg`
+    width: auto;
+  `}
+`
+
+export const AssetTitle = styled.p`
+  margin-bottom: 0;
+  font-size: 17px;
+  line-height: 24px;
+  font-family: 'MainFontRegular';
+  color: ${palette('text', 0)};
+  text-transform: uppercase;
+  ${media.lg`
+  font-size: 27px;
+  line-height: 31px;
+  `}
+`
+
+export const AssetSubtitle = styled.p`
+  margin-bottom: 0px;
+  font-size: 9px;
+  font-family: 'MainFontRegular';
+  color: ${palette('text', 2)};
+  text-transform: uppercase;
+
+  ${media.lg`
+  font-size: 13px;
+  `}
 `

--- a/src/renderer/components/pool/PoolTitle.style.tsx
+++ b/src/renderer/components/pool/PoolTitle.style.tsx
@@ -2,6 +2,7 @@ import * as A from 'antd'
 import styled from 'styled-components'
 
 import { media } from '../../helpers/styleHelper'
+import { AssetIcon as AssetIconUI } from '../uielements/assets/assetIcon'
 import { Label } from '../uielements/label'
 
 export const Container = styled(A.Row)`
@@ -60,4 +61,8 @@ export const ButtonActions = styled.div`
   > :not(:first-child) {
     margin-left: 10px;
   }
+`
+
+export const AssetIcon = styled(AssetIconUI).attrs({ size: 'small' })`
+  margin-right: 10px;
 `

--- a/src/renderer/components/pool/PoolTitle.style.tsx
+++ b/src/renderer/components/pool/PoolTitle.style.tsx
@@ -22,10 +22,10 @@ export const Price = styled(Label)`
   text-overflow: ellipsis;
   font-size: 27px;
   padding: 0;
-  padding-left: 15px;
+  margin-left: 15px;
   ${media.lg`
     font-size: 49px;
-    padding-left: 40px;
+    margin-left: 40px;
   `}
 `
 

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 
 import { SwapOutlined } from '@ant-design/icons'
 import { AssetRune } from '@xchainjs/xchain-thorchain'
-import { Asset, AssetAmount, assetToString, Chain } from '@xchainjs/xchain-util'
+import { Asset, AssetAmount, assetToString, Chain, formatAssetAmount } from '@xchainjs/xchain-util'
 import { Grid } from 'antd'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
@@ -11,8 +11,10 @@ import { useHistory } from 'react-router-dom'
 
 import { Network } from '../../../shared/api/types'
 import * as PoolHelpers from '../../helpers/poolHelper'
+import { loadingString } from '../../helpers/stringHelper'
 import * as poolsRoutes from '../../routes/pools'
 import { ManageButton } from '../manageButton'
+import { AssetIcon } from '../uielements/assets/assetIcon'
 import { Button } from '../uielements/button'
 import * as Styled from './PoolTitle.style'
 
@@ -36,7 +38,33 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
         oAsset,
         O.fold(
           () => <>--</>,
-          (asset) => <Styled.AssetSelect balances={[]} asset={asset} onSelect={FP.constVoid} network={network} />
+          (asset) => (
+            <>
+              <AssetIcon
+                asset={asset}
+                size={isDesktopView ? 'big' : 'normal'}
+                key={assetToString(asset)}
+                network={network}
+              />
+
+              <Styled.AssetWrapper>
+                <Styled.AssetTitle>
+                  {FP.pipe(
+                    oAsset,
+                    O.map(({ ticker }) => ticker),
+                    O.getOrElse(() => loadingString)
+                  )}
+                </Styled.AssetTitle>
+                <Styled.AssetSubtitle>
+                  {FP.pipe(
+                    oAsset,
+                    O.map((asset) => asset.chain),
+                    O.getOrElse(() => loadingString)
+                  )}
+                </Styled.AssetSubtitle>
+              </Styled.AssetWrapper>
+            </>
+          )
         )
       ),
     [oAsset, network]
@@ -59,7 +87,7 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
         oAsset,
         O.fold(
           () => '',
-          () => `${priceSymbol} ${price.amount().toFormat(3)}`
+          () => `${priceSymbol} ${formatAssetAmount({ amount: price, decimal: 3 })}`
         )
       ),
     [oAsset, price, priceSymbol]
@@ -106,7 +134,7 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
   return (
     <Styled.Container>
       <Styled.RowItem>
-        <Styled.Title>{title}</Styled.Title>
+        <Styled.TitleContainer>{title}</Styled.TitleContainer>
         <Styled.Price>{priceStr}</Styled.Price>
       </Styled.RowItem>
       <Styled.RowItem>{buttons}</Styled.RowItem>

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -9,6 +9,7 @@ import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
+import { Network } from '../../../shared/api/types'
 import * as PoolHelpers from '../../helpers/poolHelper'
 import * as poolsRoutes from '../../routes/pools'
 import { ManageButton } from '../manageButton'
@@ -21,9 +22,10 @@ export type Props = {
   priceSymbol?: string
   isLoading?: boolean
   haltedChains?: Chain[]
+  network: Network
 }
 
-export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, haltedChains = [] }) => {
+export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, haltedChains = [], network }) => {
   const history = useHistory()
   const intl = useIntl()
   const isDesktopView = Grid.useBreakpoint()?.md ?? false
@@ -33,11 +35,16 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
       FP.pipe(
         oAsset,
         O.fold(
-          () => '--',
-          (asset) => `${asset.chain}.${asset.ticker}`
+          () => <>--</>,
+          (asset) => (
+            <>
+              <Styled.AssetIcon asset={asset} network={network} />
+              {asset.chain}.{asset.ticker}
+            </>
+          )
         )
       ),
-    [oAsset]
+    [oAsset, network]
   )
 
   const disableButton = useMemo(

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -36,12 +36,7 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
         oAsset,
         O.fold(
           () => <>--</>,
-          (asset) => (
-            <>
-              <Styled.AssetIcon asset={asset} network={network} />
-              {asset.chain}.{asset.ticker}
-            </>
-          )
+          (asset) => <Styled.AssetSelect balances={[]} asset={asset} onSelect={FP.constVoid} network={network} />
         )
       ),
     [oAsset, network]

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -67,7 +67,7 @@ export const PoolTitle: React.FC<Props> = ({ asset: oAsset, price, priceSymbol, 
           )
         )
       ),
-    [oAsset, network]
+    [oAsset, isDesktopView, network]
   )
 
   const disableButton = useMemo(

--- a/src/renderer/components/uielements/assets/assetIcon/AssetIcon.tsx
+++ b/src/renderer/components/uielements/assets/assetIcon/AssetIcon.tsx
@@ -104,24 +104,24 @@ export const AssetIcon: React.FC<Props> = ({
 
   const renderPendingIcon = useCallback(() => {
     return (
-      <Styled.IconWrapper size={size}>
+      <Styled.IconWrapper size={size} className={'asd ' + className}>
         <LoadingOutlined />
       </Styled.IconWrapper>
     )
-  }, [size])
+  }, [size, className])
   const renderFallbackIcon = useCallback(() => {
     const { ticker } = asset
     const numbers = getIntFromName(ticker)
     const backgroundImage = `linear-gradient(45deg,${rainbowStop(numbers[0])},${rainbowStop(numbers[1])})`
 
     return (
-      <Styled.IconWrapper {...rest} size={size}>
+      <Styled.IconWrapper {...rest} className={className} size={size}>
         <Styled.IconFallback style={{ backgroundImage }} size={size}>
           {ticker}
         </Styled.IconFallback>
       </Styled.IconWrapper>
     )
-  }, [asset, size, rest])
+  }, [asset, size, rest, className])
 
   return RD.fold(() => <></>, renderPendingIcon, renderFallbackIcon, renderIcon)(remoteIconImage)
 }

--- a/src/renderer/components/uielements/assets/assetInfo/AssetInfo.style.tsx
+++ b/src/renderer/components/uielements/assets/assetInfo/AssetInfo.style.tsx
@@ -27,20 +27,19 @@ export const CoinInfoWrapper = styled.div`
 `
 
 export const CoinTitle = styled.p`
-  margin-bottom: 10px;
-  font-size: 32px;
+  margin-bottom: 0;
+  font-size: 36px;
   font-family: 'MainFontRegular';
   color: ${palette('text', 0)};
-  line-height: 38px;
+  line-height: 42px;
   text-transform: uppercase;
 `
 
 export const CoinSubtitle = styled.p`
   margin-bottom: 0px;
-  font-size: 24px;
+  font-size: 19px;
   font-family: 'MainFontRegular';
   color: ${palette('text', 2)};
-  line-height: 29px;
   text-transform: uppercase;
 `
 

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -14,8 +14,10 @@ import { PoolDetails, Props as PoolDetailProps } from '../../components/pool/Poo
 import { ErrorView } from '../../components/shared/error'
 import { RefreshButton } from '../../components/uielements/button'
 import { ONE_BN } from '../../const'
+import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { PoolDetailRouteParams } from '../../routes/pools/detail'
+import { DEFAULT_NETWORK } from '../../services/const'
 import { PoolDetailRD, PoolEarningHistoryRD, PoolStatsDetailRD } from '../../services/midgard/types'
 import { PoolChartView } from './PoolChartView'
 import * as Styled from './PoolDetailsView.styles'
@@ -29,10 +31,12 @@ const defaultDetailsProps: TargetPoolDetailProps = {
   ChartView: PoolChartView,
   poolDetail: poolDetailMock,
   poolStatsDetail: poolStatsDetailMock,
-  earningsHistory: O.none
+  earningsHistory: O.none,
+  network: DEFAULT_NETWORK
 }
 
 export const PoolDetailsView: React.FC = () => {
+  const { network$ } = useAppContext()
   const {
     service: {
       pools: {
@@ -48,6 +52,8 @@ export const PoolDetailsView: React.FC = () => {
       setSelectedPoolAsset
     }
   } = useMidgardContext()
+
+  const network = useObservableState(network$, DEFAULT_NETWORK)
 
   const intl = useIntl()
 
@@ -110,6 +116,7 @@ export const PoolDetailsView: React.FC = () => {
                 },
                 ([poolDetail, poolStatsDetail, poolEarningHistory]) => {
                   prevProps.current = {
+                    network,
                     priceRatio,
                     poolDetail,
                     poolStatsDetail,


### PR DESCRIPTION
- fixed missing `className` prop for `AssetIcon` component
- added asset icon to the `PoolDetails` component

## Desktop
![Screenshot from 2021-05-27 19-20-21](https://user-images.githubusercontent.com/61792675/119870198-5ec92a80-bf21-11eb-9533-37f00c7fbf5d.png)

## Mobile
![Screenshot from 2021-05-27 19-25-10](https://user-images.githubusercontent.com/61792675/119870191-5e309400-bf21-11eb-9963-369c2f83e6a2.png)



as a part of #1305 