### PR TITLE
Tx Confirmation Modal

### DIFF
--- a/src/renderer/components/modal/tx/extra/SwapAssets.tsx
+++ b/src/renderer/components/modal/tx/extra/SwapAssets.tsx
@@ -10,13 +10,13 @@ import * as SwapStyled from './SwapAssets.styles'
 export type Props = {
   source: C.AssetData
   target: C.AssetData
-  slip: BigNumber
+  slip?: BigNumber
   stepDescription: string
   network: Network
 }
 
 export const SwapAssets: React.FC<Props> = (props): JSX.Element => {
-  const { source, target, slip, stepDescription, network } = props
+  const { source, target, stepDescription, network, slip } = props
   return (
     <>
       <Styled.StepLabel>{stepDescription}</Styled.StepLabel>
@@ -27,7 +27,7 @@ export const SwapAssets: React.FC<Props> = (props): JSX.Element => {
           <Styled.AssetData asset={target.asset} amount={target.amount} network={network} />
         </Styled.AssetsContainer>
       </Styled.DataWrapper>
-      <SwapStyled.Trend amount={slip} />
+      {slip && <SwapStyled.Trend amount={slip} />}
     </>
   )
 }

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -646,7 +646,6 @@ export const Swap = ({
             source={{ asset: sourceAsset, amount: amountToSwapMax1e8 }}
             target={{ asset: targetAsset, amount: swapResultAmountMax1e8 }}
             stepDescription={stepLabel}
-            slip={swapData.slip}
             network={network}
           />
         )
@@ -662,7 +661,6 @@ export const Swap = ({
     swapState.stepsTotal,
     amountToSwapMax1e8,
     swapResultAmountMax1e8,
-    swapData.slip,
     network
   ])
 

--- a/src/renderer/components/uielements/txTimer/TxTimer.style.tsx
+++ b/src/renderer/components/uielements/txTimer/TxTimer.style.tsx
@@ -9,6 +9,7 @@ export const TxTimerWrapper = styled.div`
   border-radius: 50%;
   overflow: hidden;
   color: ${palette('gray', 0)};
+  text-transform: none;
 
   .timerchart-circular-progressbar {
     position: absolute;


### PR DESCRIPTION
- reset text-transform for `TxTimer`
- removed passing slip info to `TxModal`

as a part of #1305 

https://user-images.githubusercontent.com/67793194/119974110-f7f94f00-bfbc-11eb-8f17-8b566df9d74c.mov



