### PR TITLE
Update header UI to show RUNE price / 24h volume

### DIFF
--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useCallback, useRef } from 'react'
 
+import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
 import { Row, Col, Tabs, Grid } from 'antd'
 import * as FP from 'fp-ts/function'
 import * as A from 'fp-ts/lib/Array'
@@ -18,6 +19,7 @@ import { ReactComponent as MenuIcon } from '../../assets/svg/icon-menu.svg'
 import { ReactComponent as SwapIcon } from '../../assets/svg/icon-swap.svg'
 import { ReactComponent as WalletIcon } from '../../assets/svg/icon-wallet.svg'
 import { ReactComponent as AsgardexLogo } from '../../assets/svg/logo-asgardex.svg'
+import { AssetBUSDBD1 } from '../../const'
 import { useThemeContext } from '../../contexts/ThemeContext'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
@@ -32,6 +34,7 @@ import { HeaderNetStatus } from './netstatus'
 import { HeaderNetworkSelector } from './network'
 import { HeaderPriceSelector } from './price'
 import { HeaderSettings } from './settings'
+import { HeaderStats } from './stats/HeaderStats'
 import { HeaderTheme } from './theme'
 
 enum TabKey {
@@ -94,7 +97,6 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
   // store previous data to render it while reloading new data
   const prevPricePoolAssets = useRef<PricePoolAssets>()
 
-  // TODO (@Veado) Use `usePricePools` in parent view to provide pricePools
   const pricePoolAssets = useMemo(() => {
     return FP.pipe(
       oPricePools,
@@ -112,6 +114,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
   const [menuVisible, setMenuVisible] = useState(false)
 
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
+  const isLargeDesktopView = Grid.useBreakpoint()?.xl ?? false
 
   const toggleMenu = useCallback(() => {
     setMenuVisible(!menuVisible)
@@ -154,7 +157,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
     [intl]
   )
 
-  const headerHeight = useMemo(() => size('headerHeight', '50px')({ theme }), [theme])
+  const headerHeight = useMemo(() => size('headerHeight', '70px')({ theme }), [theme])
 
   const tabs = useMemo(
     () =>
@@ -300,6 +303,15 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   <AsgardexLogo />
                   {renderHeaderNetStatus}
                   <HeaderTheme isDesktopView={isDesktopView} />
+                  {isLargeDesktopView && (
+                    <HeaderStats
+                      runePrice={assetAmount(14.08)}
+                      volume24={{
+                        asset: AssetBUSDBD1,
+                        amount: assetToBase(assetAmount('24000000'))
+                      }}
+                    />
+                  )}
                 </Row>
               </Col>
               <Col span="auto">

--- a/src/renderer/components/header/lock/HeaderLock.style.tsx
+++ b/src/renderer/components/header/lock/HeaderLock.style.tsx
@@ -39,6 +39,6 @@ export const UnlockIcon = styled(UnlockWarningIconUI)`
 `
 
 export const Label = styled(Text)`
-  text-transform: 'upercase';
+  text-transform: uppercase;
   color: ${palette('text', 0)};
 `

--- a/src/renderer/components/header/stats/HeaderStats.stories.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, Story } from '@storybook/react'
+import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
+
+import { AssetBUSDBD1 } from '../../../const'
+import { HeaderStats as Component, Props as ComponentProps } from './HeaderStats'
+
+const defaultProps: ComponentProps = {
+  runePrice: assetAmount(14.08),
+  volume24: {
+    asset: AssetBUSDBD1,
+    amount: assetToBase(assetAmount('24000000'))
+  }
+}
+
+export const Default: Story = () => <Component {...defaultProps} />
+Default.storyName = 'default'
+
+const meta: Meta = {
+  component: Component,
+  title: 'Components/HeaderStats',
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '10px 0', backgroundColor: 'white', display: 'flex' }}>
+        <Story />
+      </div>
+    )
+  ]
+}
+
+export default meta

--- a/src/renderer/components/header/stats/HeaderStats.style.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.style.tsx
@@ -1,0 +1,39 @@
+import * as A from 'antd'
+import Text from 'antd/lib/typography/Text'
+import styled from 'styled-components'
+import { palette } from 'styled-theme'
+
+export const Wrapper = styled(A.Row)``
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3px 7px;
+  background: ${palette('gray', 0)};
+  border-radius: 5px;
+  margin-right: 10px;
+
+  &::last-child {
+    margin-right: 0;
+  }
+`
+
+export const Label = styled(Text)`
+  text-transform: uppercase;
+  font-size: 12px;
+  line-height: 14px;
+  color: ${palette('text', 2)};
+  width: auto;
+  padding: 0;
+  margin: 0;
+`
+
+export const SubLabel = styled(Text)`
+  text-transform: uppercase;
+  font-size: 9px;
+  line-height: 12px;
+  color: ${palette('text', 2)};
+  width: auto;
+  padding: 0;
+`

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { AssetAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+
+import { AssetWithAmount } from '../../../types/asgardex'
+import * as Styled from './HeaderStats.style'
+
+export type Props = {
+  runePrice: AssetAmount /* in USD */
+  volume24: AssetWithAmount
+}
+
+export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
+  const { runePrice, volume24 } = props
+
+  return (
+    <Styled.Wrapper>
+      <Styled.Container>
+        <Styled.SubLabel>Rune</Styled.SubLabel>
+        <Styled.Label>{formatAssetAmountCurrency({ amount: runePrice, decimal: 2 })}</Styled.Label>
+      </Styled.Container>
+      <Styled.Container>
+        <Styled.SubLabel>Vol. (24hrs)</Styled.SubLabel>
+        <Styled.Label>
+          {formatAssetAmountCurrency({ amount: baseToAsset(volume24.amount), asset: volume24.asset, decimal: 0 })}
+        </Styled.Label>
+      </Styled.Container>
+    </Styled.Wrapper>
+  )
+}

--- a/src/renderer/components/header/theme/HeaderTheme.style.tsx
+++ b/src/renderer/components/header/theme/HeaderTheme.style.tsx
@@ -24,6 +24,6 @@ export const NightThemeIcon = styled(NightThemeIconUI)`
   }
 `
 export const Label = styled(Text)`
-  text-transform: 'upercase';
+  text-transform: uppercase;
   color: ${palette('text', 0)};
 `


### PR DESCRIPTION
- [x] Introduce `HeaderStats` to show RUNE price + 24hrs volume in header

Note: Business logic will be added with another PR

![Peek 2021-05-28 18-03](https://user-images.githubusercontent.com/61792675/120011882-12442480-bfdf-11eb-9c8b-1da22f63283a.gif)


Part of #1373, #1328

