### PR TITLE
[BTC + ETH] Use latest xchain-bitcoin@0.15.0 and @xchainjs/xchain-ethereum@0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@thorchain/asgardex-util": "^0.9.1",
     "@types/electron-devtools-installer": "^2.2.0",
     "@xchainjs/xchain-binance": "^5.0.0",
-    "@xchainjs/xchain-bitcoin": "^0.13.0",
+    "@xchainjs/xchain-bitcoin": "^0.15.0",
     "@xchainjs/xchain-bitcoincash": "^0.10.2",
     "@xchainjs/xchain-client": "^0.8.0",
     "@xchainjs/xchain-cosmos": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@xchainjs/xchain-client": "^0.8.0",
     "@xchainjs/xchain-cosmos": "^0.12.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
-    "@xchainjs/xchain-ethereum": "^0.19.0",
+    "@xchainjs/xchain-ethereum": "^0.21.0",
     "@xchainjs/xchain-litecoin": "^0.5.0",
     "@xchainjs/xchain-thorchain": "^0.14.0",
     "@xchainjs/xchain-util": "^0.2.7",

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -79,6 +79,7 @@ export type SendTxParams = {
   amount: BaseAmount
   memo: Memo
   feeOptionKey?: FeeOptionKey
+  walletIndex?: number
 }
 
 export type SendPoolTxParams = SendTxParams & {

--- a/src/renderer/services/ethereum/transaction.ts
+++ b/src/renderer/services/ethereum/transaction.ts
@@ -20,7 +20,7 @@ import { ApproveParams, Client$, TransactionService, IsApprovedLD } from './type
 export const createTransactionService = (client$: Client$): TransactionService => {
   const common = C.createTransactionService(client$)
 
-  const runSendPoolTx$ = (client: EthClient, params: SendPoolTxParams): TxHashLD => {
+  const runSendPoolTx$ = (client: EthClient, { walletIndex, ...params }: SendPoolTxParams): TxHashLD => {
     // helper for failures
     const failure$ = (msg: string) =>
       Rx.of(
@@ -46,7 +46,7 @@ export const createTransactionService = (client$: Client$): TransactionService =
                 // Note:
                 // Amounts need to use `toFixed` to convert `BaseAmount` to `Bignumber`
                 // since `value` and `gasPrice` type is `Bignumber`
-                client.call<{ hash: TxHash }>(router, ethRouterABI, 'deposit', [
+                client.call<{ hash: TxHash }>(walletIndex, router, ethRouterABI, 'deposit', [
                   params.recipient,
                   address,
                   // Send `BaseAmount` w/o decimal and always round down for currencies
@@ -84,10 +84,11 @@ export const createTransactionService = (client$: Client$): TransactionService =
       )
     )
 
-  const runApproveERC20Token$ = (client: EthClient, params: ApproveParams): TxHashLD =>
+  const runApproveERC20Token$ = (client: EthClient, { walletIndex = 0, ...params }: ApproveParams): TxHashLD =>
     Rx.from(
       client.approve({
         ...params,
+        walletIndex,
         feeOptionKey: 'fast'
       })
     ).pipe(

--- a/src/renderer/services/ethereum/types.ts
+++ b/src/renderer/services/ethereum/types.ts
@@ -35,6 +35,7 @@ export type ApproveParams = {
   spender: Address
   sender: Address
   amount?: BaseAmount
+  walletIndex?: number
 }
 
 export type PollInTxFeeParams = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4241,10 +4241,10 @@
   resolved "https://registry.yarnpkg.com/@xchainjs/xchain-binance/-/xchain-binance-5.0.0.tgz#353be7c9ae5e2a2b9c39fb0ca36708a0984caf72"
   integrity sha512-C8V1O6v8HQgcBZum9hrb8gB5STxhjWe3eC4Wk+sywznA/2GhEyOmSBauycGY8l0XR4zhS34ZnZabPBRcv00PzQ==
 
-"@xchainjs/xchain-bitcoin@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.13.0.tgz#ad4d8ab5d60dc3063c42bfd09ad16386702ad117"
-  integrity sha512-olcfxB5F/8gUjVzbFWrGVwPA5aJPrI9mgNzDqxmzXdao6BhYLmNuQ3EQieJ++Tqq05o3m39XneIgSXhUUH50zg==
+"@xchainjs/xchain-bitcoin@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.15.0.tgz#eee0cae23ee9a021e74bfa1d3182f0087a7695ee"
+  integrity sha512-gTFgQIH0ASmSfAannLPM6qAsnfopXRrysxitIKA3y3c0XP6wSd/a4871tZF9e9uEQeC7FMdaWvWTJFc5/sdNNA==
 
 "@xchainjs/xchain-bitcoincash@^0.10.2":
   version "0.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,10 +4275,10 @@
     hdkey "^2.0.1"
     uuid "^8.1.0"
 
-"@xchainjs/xchain-ethereum@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-ethereum/-/xchain-ethereum-0.19.0.tgz#d41e7a212e493e746c7419d4186d2a805db0cff5"
-  integrity sha512-5WL5Sdoyvm7VsJBd0hvdFCr8817fwZN09AgDjF84feaPAN6HsESOIsrJtkzk43VTWgJpJm1w3uHhZfTyRXW+4Q==
+"@xchainjs/xchain-ethereum@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-ethereum/-/xchain-ethereum-0.21.0.tgz#9b55e3d75179293f286668ed87bcdfa4927851bb"
+  integrity sha512-/RuG5+I36cXkOuYdUGVRTMl2uhSSHEpcdSEgzsXoBz3SaLvcMkwyJjf437jD45OqkPdOSa3yBz/rZlYwb4tunw==
 
 "@xchainjs/xchain-litecoin@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
- updated `xchain-btc` and `xchain-eth` packages
- fixed `walletIndex` issue for `xchain-eth`

closes #1476 