### PR TITLE
Add business logic to calculate + show RUNE price in header

### DIFF
--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -15,10 +15,12 @@ import { useLitecoinContext } from '../../contexts/LitecoinContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
+import { RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { usePricePools } from '../../hooks/usePricePools'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
 import { DEFAULT_NETWORK } from '../../services/const'
+import { SelectedPricePool, SelectedPricePoolAsset } from '../../services/midgard/types'
 import { HeaderComponent } from './HeaderComponent'
 
 export const Header: React.FC = (): JSX.Element => {
@@ -27,9 +29,12 @@ export const Header: React.FC = (): JSX.Element => {
   const keystore = useObservableState(keystoreService.keystore$, O.none)
   const { service: midgardService } = useMidgardContext()
   const {
-    pools: { setSelectedPricePoolAsset: setSelectedPricePool, selectedPricePoolAsset$ },
+    pools: { setSelectedPricePoolAsset: setSelectedPricePool, selectedPricePoolAsset$, selectedPricePool$ },
     apiEndpoint$
   } = midgardService
+
+  const oSelectedPricePoolAsset = useObservableState<SelectedPricePoolAsset>(selectedPricePoolAsset$, O.none)
+  const selectedPricePool = useObservableState<SelectedPricePool>(selectedPricePool$, RUNE_PRICE_POOL)
 
   const pricePools = usePricePools()
 
@@ -120,7 +125,8 @@ export const Header: React.FC = (): JSX.Element => {
       lockHandler={lock}
       pricePools={pricePools}
       setSelectedPricePool={setSelectedPricePool}
-      selectedPricePoolAsset$={selectedPricePoolAsset$}
+      selectedPricePool={selectedPricePool}
+      selectedPricePoolAsset={oSelectedPricePoolAsset}
       locale={currentLocale}
       changeLocale={changeLocale}
       binanceUrl={binanceUrl}

--- a/src/renderer/components/header/HeaderComponent.stories.tsx
+++ b/src/renderer/components/header/HeaderComponent.stories.tsx
@@ -4,9 +4,9 @@ import { storiesOf } from '@storybook/react'
 import { AssetRuneNative } from '@xchainjs/xchain-util'
 import { none } from 'fp-ts/lib/Option'
 import * as O from 'fp-ts/lib/Option'
-import * as Rx from 'rxjs'
 
 import { Locale } from '../../../shared/i18n/types'
+import { RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { HeaderComponent } from './HeaderComponent'
 
 const binanceUrl = O.some('https://testnet-dex.binance.org/api/v1')
@@ -22,7 +22,8 @@ storiesOf('Components/Header', module).add('default', () => {
       lockHandler={() => console.log('lockHandler')}
       pricePools={O.none}
       setSelectedPricePool={() => console.log('setSelectedPricePool')}
-      selectedPricePoolAsset$={Rx.of(O.some(AssetRuneNative))}
+      selectedPricePoolAsset={O.some(AssetRuneNative)}
+      selectedPricePool={RUNE_PRICE_POOL}
       locale={Locale.EN}
       binanceUrl={binanceUrl}
       midgardUrl={midgardUrl}

--- a/src/renderer/components/header/stats/HeaderStats.stories.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.stories.tsx
@@ -1,11 +1,15 @@
 import { Meta, Story } from '@storybook/react'
 import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/lib/Option'
 
 import { AssetBUSDBD1 } from '../../../const'
 import { HeaderStats as Component, Props as ComponentProps } from './HeaderStats'
 
 const defaultProps: ComponentProps = {
-  runePrice: assetAmount(14.08),
+  runePrice: O.some({
+    asset: AssetBUSDBD1,
+    amount: assetToBase(assetAmount('14.08'))
+  }),
   volume24: {
     asset: AssetBUSDBD1,
     amount: assetToBase(assetAmount('24000000'))

--- a/src/renderer/components/header/stats/HeaderStats.style.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.style.tsx
@@ -9,10 +9,11 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 3px 7px;
+  padding: 3px 10px;
   background: ${palette('gray', 0)};
-  border-radius: 5px;
+  border-radius: 10px;
   margin-right: 10px;
+  min-width: 90px;
 
   &::last-child {
     margin-right: 0;
@@ -21,16 +22,19 @@ export const Container = styled.div`
 
 export const Label = styled(Text)`
   text-transform: uppercase;
+  font-family: 'MainFontBold';
   font-size: 12px;
   line-height: 14px;
   color: ${palette('text', 2)};
   width: auto;
   padding: 0;
   margin: 0;
+  margin-right: 5px;
 `
 
-export const SubLabel = styled(Text)`
+export const Title = styled(Text)`
   text-transform: uppercase;
+  font-family: 'MainFontRegular';
   font-size: 9px;
   line-height: 12px;
   color: ${palette('text', 2)};

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -1,30 +1,61 @@
-import React from 'react'
+import React, { useMemo, useRef } from 'react'
 
-import { AssetAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import { baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import { useIntl } from 'react-intl'
 
+import { isUSDAsset } from '../../../helpers/assetHelper'
+import { loadingString } from '../../../helpers/stringHelper'
 import { AssetWithAmount } from '../../../types/asgardex'
 import * as Styled from './HeaderStats.style'
 
 export type Props = {
-  runePrice: AssetAmount /* in USD */
+  runePrice: O.Option<AssetWithAmount>
   volume24: AssetWithAmount
 }
 
 export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
-  const { runePrice, volume24 } = props
+  const { runePrice: oRunePrice } = props
+
+  const intl = useIntl()
+  const prevRunePriceLabel = useRef<O.Option<string>>(O.none)
+
+  const runePriceLabel = useMemo(
+    () =>
+      FP.pipe(
+        oRunePrice,
+        O.map(({ asset, amount }) =>
+          formatAssetAmountCurrency({
+            amount: baseToAsset(amount),
+            asset,
+            trimZeros: true,
+            decimal: isUSDAsset(asset) ? 2 : 6
+          })
+        ),
+        O.map((label) => {
+          // store price label
+          prevRunePriceLabel.current = O.some(label)
+          return label
+        }),
+        O.alt(() => prevRunePriceLabel.current),
+        O.getOrElse(() => loadingString)
+      ),
+    [oRunePrice]
+  )
 
   return (
     <Styled.Wrapper>
       <Styled.Container>
-        <Styled.SubLabel>Rune</Styled.SubLabel>
-        <Styled.Label>{formatAssetAmountCurrency({ amount: runePrice, decimal: 2 })}</Styled.Label>
+        <Styled.Title>{intl.formatMessage({ id: 'common.price.rune' })}</Styled.Title>
+        <Styled.Label>{runePriceLabel}</Styled.Label>
       </Styled.Container>
-      <Styled.Container>
-        <Styled.SubLabel>Vol. (24hrs)</Styled.SubLabel>
+      {/* <Styled.Container>
+        <Styled.Title>{intl.formatMessage({ id: 'common.volume24' })}</Styled.Title>
         <Styled.Label>
           {formatAssetAmountCurrency({ amount: baseToAsset(volume24.amount), asset: volume24.asset, decimal: 0 })}
         </Styled.Label>
-      </Styled.Container>
+      </Styled.Container> */}
     </Styled.Wrapper>
   )
 }

--- a/src/renderer/components/pool/PoolCards.tsx
+++ b/src/renderer/components/pool/PoolCards.tsx
@@ -75,7 +75,7 @@ export const PoolCards: React.FC<Props> = ({
         <PoolStatus
           isLoading={isLoading}
           fullValue={getFullValue(volume24)}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.volume24' })}
+          label={intl.formatMessage({ id: 'common.volume24' })}
           displayValue={`${priceSymbol} ${abbreviateNumber(volume24.amount().toNumber(), 2)}`}
         />
       </Styled.Col>

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -38,6 +38,7 @@ const common: CommonMessages = {
   'common.pools': 'Pools',
   'common.pool': 'Pool',
   'common.price': 'Preis',
+  'common.price.rune': 'RUNE Preis',
   'common.transaction': 'Transaktion',
   'common.viewTransaction': 'Transaktion ansehen',
   'common.fee': 'Gebühr',
@@ -80,7 +81,8 @@ const common: CommonMessages = {
   'common.time.week': 'Woche',
   'common.time.all': 'Gesamt',
   'common.theme.light': 'Tag modus',
-  'common.theme.dark': 'Nacht modus'
+  'common.theme.dark': 'Nacht modus',
+  'common.volume24': 'Volumen (24h)'
 }
 
 export default common

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -35,7 +35,6 @@ const deposit: DepositMessages = {
   'deposit.poolDetails.allTimeVal': 'Gesamtzeit Volumen',
   'deposit.poolDetails.totalSwaps': 'Gesamtanzahl Swaps',
   'deposit.poolDetails.totalUsers': 'Gesamtanzahl User',
-  'deposit.poolDetails.volume24': 'Volumen (24h)',
   'deposit.poolDetails.volumeTotal': 'Volumen (Gesamt)',
   'deposit.poolDetails.earnings': 'Einnahmen',
   'deposit.poolDetails.ilpPaid': 'ILP Zahlungen',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -38,6 +38,7 @@ const common: CommonMessages = {
   'common.pools': 'Pools',
   'common.pool': 'Pool',
   'common.price': 'Price',
+  'common.price.rune': 'RUNE price',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'View transaction',
   'common.fee': 'Fee',
@@ -80,7 +81,8 @@ const common: CommonMessages = {
   'common.time.week': 'week',
   'common.time.all': 'all',
   'common.theme.light': 'Day mode',
-  'common.theme.dark': 'Night mode'
+  'common.theme.dark': 'Night mode',
+  'common.volume24': 'Volume (24h)'
 }
 
 export default common

--- a/src/renderer/i18n/en/deposit.ts
+++ b/src/renderer/i18n/en/deposit.ts
@@ -34,7 +34,6 @@ const deposit: DepositMessages = {
   'deposit.poolDetails.allTimeVal': 'All time volume',
   'deposit.poolDetails.totalSwaps': 'Total swaps',
   'deposit.poolDetails.totalUsers': 'Total users',
-  'deposit.poolDetails.volume24': 'Volume (24h)',
   'deposit.poolDetails.volumeTotal': 'Volume (total)',
   'deposit.poolDetails.earnings': 'Earnings',
   'deposit.poolDetails.ilpPaid': 'ILP paid',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -38,6 +38,7 @@ const common: CommonMessages = {
   'common.pools': 'Pools',
   'common.pool': 'Pool',
   'common.price': 'Prix',
+  'common.price.rune': 'RUNE price - FR',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'Afficher la transaction',
   'common.fee': 'Frais',
@@ -80,7 +81,8 @@ const common: CommonMessages = {
   'common.time.week': 'Semaine',
   'common.time.all': 'Tout',
   'common.theme.light': 'Mode clair',
-  'common.theme.dark': 'Mode sombre'
+  'common.theme.dark': 'Mode sombre',
+  'common.volume24': 'Volume (24h) - FR'
 }
 
 export default common

--- a/src/renderer/i18n/fr/deposit.ts
+++ b/src/renderer/i18n/fr/deposit.ts
@@ -35,7 +35,6 @@ const deposit: DepositMessages = {
   'deposit.poolDetails.allTimeVal': 'Volume historique',
   'deposit.poolDetails.totalSwaps': 'Total des échanges',
   'deposit.poolDetails.totalUsers': 'Total des utilisateurs',
-  'deposit.poolDetails.volume24': 'Volume (24h) - FR',
   'deposit.poolDetails.volumeTotal': 'Volume (total) - FR',
   'deposit.poolDetails.earnings': 'Gains',
   'deposit.poolDetails.ilpPaid': 'ILP paid - FR',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -38,7 +38,7 @@ const common: CommonMessages = {
   'common.pools': 'Пулы',
   'common.pool': 'Пул',
   'common.price': 'Цена',
-  'common.price.rune': 'RUNE price - RU',
+  'common.price.rune': 'Стоимость RUNE',
   'common.transaction': 'Транзакция',
   'common.viewTransaction': 'Посмотреть транзакцию',
   'common.fee': 'Комиссия',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -38,6 +38,7 @@ const common: CommonMessages = {
   'common.pools': 'Пулы',
   'common.pool': 'Пул',
   'common.price': 'Цена',
+  'common.price.rune': 'RUNE price - RU',
   'common.transaction': 'Транзакция',
   'common.viewTransaction': 'Посмотреть транзакцию',
   'common.fee': 'Комиссия',
@@ -80,7 +81,8 @@ const common: CommonMessages = {
   'common.time.week': 'Неделя',
   'common.time.all': 'Все',
   'common.theme.light': 'Светлая тема',
-  'common.theme.dark': 'Темная тема'
+  'common.theme.dark': 'Темная тема',
+  'common.volume24': 'Количество (24ч)'
 }
 
 export default common

--- a/src/renderer/i18n/ru/deposit.ts
+++ b/src/renderer/i18n/ru/deposit.ts
@@ -34,7 +34,6 @@ const deposit: DepositMessages = {
   'deposit.poolDetails.allTimeVal': 'Количество за все время',
   'deposit.poolDetails.totalSwaps': 'Всего свапов',
   'deposit.poolDetails.totalUsers': 'Всего держателей',
-  'deposit.poolDetails.volume24': 'Количество (24ч)',
   'deposit.poolDetails.volumeTotal': 'Количество (всего)',
   'deposit.poolDetails.earnings': 'Прибыль',
   'deposit.poolDetails.ilpPaid': 'ILP выплачено',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -37,6 +37,7 @@ export type CommonMessageKey =
   | 'common.asset'
   | 'common.assets'
   | 'common.price'
+  | 'common.price.rune'
   | 'common.transaction'
   | 'common.viewTransaction'
   | 'common.fee'
@@ -82,6 +83,7 @@ export type CommonMessageKey =
   | 'common.time.all'
   | 'common.theme.light'
   | 'common.theme.dark'
+  | 'common.volume24'
 
 export type CommonMessages = {
   [key in CommonMessageKey]: string
@@ -293,7 +295,6 @@ type DepositMessageKey =
   | 'deposit.poolDetails.allTimeVal'
   | 'deposit.poolDetails.totalSwaps'
   | 'deposit.poolDetails.totalUsers'
-  | 'deposit.poolDetails.volume24'
   | 'deposit.poolDetails.volumeTotal'
   | 'deposit.poolDetails.earnings'
   | 'deposit.poolDetails.ilpPaid'

--- a/src/renderer/services/binance/utils.ts
+++ b/src/renderer/services/binance/utils.ts
@@ -1,38 +1,11 @@
-import { getValueOfAsset1InAsset2, PoolData, getValueOfRuneInAsset } from '@thorchain/asgardex-util'
 import { Balances as BinanceBalances } from '@xchainjs/xchain-binance'
-import { Balance, Balances } from '@xchainjs/xchain-client'
-import { BaseAmount, assetAmount, bnOrZero, assetFromString, Asset, assetToBase, AssetBNB } from '@xchainjs/xchain-util'
+import { Balances } from '@xchainjs/xchain-client'
+import { assetAmount, bnOrZero, assetFromString, Asset, assetToBase, AssetBNB } from '@xchainjs/xchain-util'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
-import { BNB_DECIMAL, isRuneNativeAsset } from '../../helpers/assetHelper'
-import { PoolDetails } from '../midgard/types'
-import { getPoolDetail, toPoolData } from '../midgard/utils'
-
-/**
- * Helper to get a pool price value for a given `Balance`
- */
-export const getPoolPriceValue = (
-  { asset, amount }: Balance,
-  poolDetails: PoolDetails,
-  selectedPricePoolData: PoolData
-): O.Option<BaseAmount> => {
-  return FP.pipe(
-    getPoolDetail(poolDetails, asset),
-    O.map(toPoolData),
-    // calculate value based on `pricePoolData`
-    O.map((poolData) => getValueOfAsset1InAsset2(amount, poolData, selectedPricePoolData)),
-    O.alt(() => {
-      // Calculate RUNE values based on `pricePoolData`
-      if (isRuneNativeAsset(asset)) {
-        return O.some(getValueOfRuneInAsset(amount, selectedPricePoolData))
-      }
-      // In all other cases we don't have any price pool and no price
-      return O.none
-    })
-  )
-}
+import { BNB_DECIMAL } from '../../helpers/assetHelper'
 
 /**
  * Converts a BinanceChain symbol to an `Asset`

--- a/src/renderer/views/pools/Pools.types.ts
+++ b/src/renderer/views/pools/Pools.types.ts
@@ -1,7 +1,6 @@
 import { PoolData } from '@thorchain/asgardex-util'
 import { BaseAmount, Asset, Chain } from '@xchainjs/xchain-util'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
-import * as Rx from 'rxjs'
 
 import { Network } from '../../../shared/api/types'
 import { GetPoolsStatusEnum } from '../../types/generated/midgard'
@@ -22,8 +21,6 @@ export type PricePool = {
   asset: PricePoolAsset
   poolData: PoolData
 }
-
-export type PricePool$ = Rx.Observable<PricePool>
 
 export type PricePools = NonEmptyArray<PricePool>
 

--- a/src/renderer/views/pools/Pools.types.ts
+++ b/src/renderer/views/pools/Pools.types.ts
@@ -1,8 +1,8 @@
 import { PoolData } from '@thorchain/asgardex-util'
 import { BaseAmount, Asset, Chain } from '@xchainjs/xchain-util'
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import * as Rx from 'rxjs'
 
-// import { PoolDetailStatusEnum } from '../../types/generated/midgard'
 import { Network } from '../../../shared/api/types'
 import { GetPoolsStatusEnum } from '../../types/generated/midgard'
 
@@ -17,10 +17,13 @@ export type PricePoolAssets = PricePoolAsset[]
 
 export type PricePoolCurrencyWeights = Record<string, number>
 
+// TODO (@asgdx-team) Move all PricePool* types into `src/renderer/services/midgard/types.ts`
 export type PricePool = {
   asset: PricePoolAsset
   poolData: PoolData
 }
+
+export type PricePool$ = Rx.Observable<PricePool>
 
 export type PricePools = NonEmptyArray<PricePool>
 


### PR DESCRIPTION

![Peek 2021-05-31 20-11](https://user-images.githubusercontent.com/61792675/120228929-66077580-c24c-11eb-9e0f-35e3c95d3c5f.gif)



- [x] Calculate RUNE prices based on selected `PricePool`
- [x] Update i18n
- [x] Quick fix: Remove duplicated `getPoolPriceValue' function in `src/renderer/services/binance/utils.ts`

Close #1328 