### PR TITLE
Add business logic to show volume (24hrs) in header

### DIFF
--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -17,6 +17,7 @@ import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import { usePricePools } from '../../hooks/usePricePools'
 import { useRunePrice } from '../../hooks/useRunePrice'
+import { useVolume24Price } from '../../hooks/useVolume24Price'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
 import { DEFAULT_NETWORK } from '../../services/const'
@@ -36,6 +37,7 @@ export const Header: React.FC = (): JSX.Element => {
   const oSelectedPricePoolAsset = useObservableState<SelectedPricePoolAsset>(selectedPricePoolAsset$, O.none)
 
   const runePriceRD = useRunePrice()
+  const volume24PriceRD = useVolume24Price()
 
   const pricePools = usePricePools()
 
@@ -127,6 +129,7 @@ export const Header: React.FC = (): JSX.Element => {
       pricePools={pricePools}
       setSelectedPricePool={setSelectedPricePool}
       runePrice={runePriceRD}
+      volume24Price={volume24PriceRD}
       selectedPricePoolAsset={oSelectedPricePoolAsset}
       locale={currentLocale}
       changeLocale={changeLocale}

--- a/src/renderer/components/header/HeaderComponent.stories.tsx
+++ b/src/renderer/components/header/HeaderComponent.stories.tsx
@@ -22,6 +22,7 @@ storiesOf('Components/Header', module).add('default', () => {
       lockHandler={() => console.log('lockHandler')}
       pricePools={O.none}
       runePrice={RD.initial}
+      volume24Price={RD.initial}
       setSelectedPricePool={() => console.log('setSelectedPricePool')}
       selectedPricePoolAsset={O.some(AssetRuneNative)}
       locale={Locale.EN}

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useCallback, useRef } from 'react'
 
-import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
 import { Row, Col, Tabs, Grid } from 'antd'
 import * as FP from 'fp-ts/function'
 import * as A from 'fp-ts/lib/Array'
@@ -18,12 +17,10 @@ import { ReactComponent as MenuIcon } from '../../assets/svg/icon-menu.svg'
 import { ReactComponent as SwapIcon } from '../../assets/svg/icon-swap.svg'
 import { ReactComponent as WalletIcon } from '../../assets/svg/icon-wallet.svg'
 import { ReactComponent as AsgardexLogo } from '../../assets/svg/logo-asgardex.svg'
-import { AssetBUSDBD1 } from '../../const'
 import { useThemeContext } from '../../contexts/ThemeContext'
-import { RunePriceRD } from '../../hooks/useRunePrice.types'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
-import { SelectedPricePoolAsset } from '../../services/midgard/types'
+import { PriceRD, SelectedPricePoolAsset } from '../../services/midgard/types'
 import { KeystoreState } from '../../services/wallet/types'
 import { isLocked } from '../../services/wallet/util'
 import { PricePoolAsset, PricePoolAssets, PricePools } from '../../views/pools/Pools.types'
@@ -55,7 +52,8 @@ type Props = {
   lockHandler: FP.Lazy<void>
   setSelectedPricePool: (asset: PricePoolAsset) => void
   pricePools: O.Option<PricePools>
-  runePrice: RunePriceRD
+  runePrice: PriceRD
+  volume24Price: PriceRD
   selectedPricePoolAsset: SelectedPricePoolAsset
   locale: Locale
   changeLocale?: (locale: Locale) => void
@@ -73,6 +71,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
     keystore,
     pricePools: oPricePools,
     runePrice: runePriceRD,
+    volume24Price: volume24PriceRD,
     selectedPricePoolAsset: oSelectedPricePoolAsset,
     lockHandler,
     setSelectedPricePool,
@@ -303,15 +302,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   <AsgardexLogo />
                   {renderHeaderNetStatus}
                   <HeaderTheme isDesktopView={isDesktopView} />
-                  {isLargeDesktopView && (
-                    <HeaderStats
-                      runePrice={runePriceRD}
-                      volume24={{
-                        asset: AssetBUSDBD1,
-                        amount: assetToBase(assetAmount('24000000'))
-                      }}
-                    />
-                  )}
+                  {isLargeDesktopView && <HeaderStats runePrice={runePriceRD} volume24Price={volume24PriceRD} />}
                 </Row>
               </Col>
               <Col span="auto">

--- a/src/renderer/components/header/stats/HeaderStats.stories.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.stories.tsx
@@ -10,10 +10,10 @@ const defaultProps: ComponentProps = {
     asset: AssetBUSDBD1,
     amount: assetToBase(assetAmount('14.08'))
   }),
-  volume24: {
+  volume24Price: RD.success({
     asset: AssetBUSDBD1,
     amount: assetToBase(assetAmount('24000000'))
-  }
+  })
 }
 
 export const Default: Story = () => <Component {...defaultProps} />

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -58,18 +58,15 @@ export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
         volume24PriceRD,
         RD.map(
           ({ asset, amount }) =>
-            `${currencySymbolByAsset(asset)} ${abbreviateNumber(
+            (prevVolume24PriceLabel.current /* store price label */ = `${currencySymbolByAsset(
+              asset
+            )} ${abbreviateNumber(
               baseToAsset(amount) /* show values as `AssetAmount`   */
                 .amount()
                 .toNumber(),
               2
-            )}`
+            )}`)
         ),
-        RD.map((label) => {
-          // store price label
-          prevVolume24PriceLabel.current = label
-          return label
-        }),
         RD.fold(
           () => prevVolume24PriceLabel.current,
           () => prevVolume24PriceLabel.current,

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -1,25 +1,26 @@
 import React, { useMemo, useRef } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import { baseToAsset, formatAssetAmountCurrency, currencySymbolByAsset } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
 import { isUSDAsset } from '../../../helpers/assetHelper'
+import { abbreviateNumber } from '../../../helpers/numberHelper'
 import { loadingString } from '../../../helpers/stringHelper'
-import { RunePriceRD } from '../../../hooks/useRunePrice.types'
-import { AssetWithAmount } from '../../../types/asgardex'
+import { PriceRD } from '../../../services/midgard/types'
 import * as Styled from './HeaderStats.style'
 
 export type Props = {
-  runePrice: RunePriceRD
-  volume24: AssetWithAmount
+  runePrice: PriceRD
+  volume24Price: PriceRD
 }
 
 export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
-  const { runePrice: runePriceRD } = props
+  const { runePrice: runePriceRD, volume24Price: volume24PriceRD } = props
 
   const intl = useIntl()
+
   const prevRunePriceLabel = useRef<string>(loadingString)
 
   const runePriceLabel = useMemo(
@@ -49,6 +50,36 @@ export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
 
     [runePriceRD]
   )
+  const prevVolume24PriceLabel = useRef<string>(loadingString)
+
+  const volume24PriceLabel = useMemo(
+    () =>
+      FP.pipe(
+        volume24PriceRD,
+        RD.map(
+          ({ asset, amount }) =>
+            `${currencySymbolByAsset(asset)} ${abbreviateNumber(
+              baseToAsset(amount) /* show values as `AssetAmount`   */
+                .amount()
+                .toNumber(),
+              2
+            )}`
+        ),
+        RD.map((label) => {
+          // store price label
+          prevVolume24PriceLabel.current = label
+          return label
+        }),
+        RD.fold(
+          () => prevVolume24PriceLabel.current,
+          () => prevVolume24PriceLabel.current,
+          () => '--',
+          FP.identity
+        )
+      ),
+
+    [volume24PriceRD]
+  )
 
   return (
     <Styled.Wrapper>
@@ -56,12 +87,10 @@ export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
         <Styled.Title>{intl.formatMessage({ id: 'common.price.rune' })}</Styled.Title>
         <Styled.Label loading={RD.isPending(runePriceRD)}>{runePriceLabel}</Styled.Label>
       </Styled.Container>
-      {/* <Styled.Container>
+      <Styled.Container>
         <Styled.Title>{intl.formatMessage({ id: 'common.volume24' })}</Styled.Title>
-        <Styled.Label>
-          {formatAssetAmountCurrency({ amount: baseToAsset(volume24.amount), asset: volume24.asset, decimal: 0 })}
-        </Styled.Label>
-      </Styled.Container> */}
+        <Styled.Label loading={RD.isPending(volume24PriceRD)}>{volume24PriceLabel}</Styled.Label>
+      </Styled.Container>
     </Styled.Wrapper>
   )
 }

--- a/src/renderer/helpers/fpHelpers.ts
+++ b/src/renderer/helpers/fpHelpers.ts
@@ -8,8 +8,8 @@ import * as O from 'fp-ts/lib/Option'
  * Sequence
  */
 
-export const sequenceTOption = sequenceT(O.option)
-export const sequenceTOptionFromArray = A.sequence(O.option)
+export const sequenceTOption = sequenceT(O.Apply)
+export const sequenceTOptionFromArray = A.sequence(O.Applicative)
 export const sequenceSOption = sequenceS(O.Applicative)
 
 export const sequenceTRD = sequenceT(RD.remoteData)

--- a/src/renderer/helpers/rx/liveData.ts
+++ b/src/renderer/helpers/rx/liveData.ts
@@ -7,10 +7,9 @@ import {
   coproductMapLeft
 } from '@devexperts/utils/dist/typeclasses/product-left-coproduct-left/product-left-coproduct-left.utils'
 import { sequenceS, sequenceT } from 'fp-ts/lib/Apply'
-import { array } from 'fp-ts/lib/Array'
+import * as A from 'fp-ts/lib/Array'
 import { Filterable2 } from 'fp-ts/lib/Filterable'
 import { MonadThrow2 } from 'fp-ts/lib/MonadThrow'
-import { pipeable } from 'fp-ts/lib/pipeable'
 import * as O from 'fp-ts/Option'
 import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -38,10 +37,9 @@ export const instanceLiveData: MonadThrow2<URIType> & CoproductLeft<URIType> & F
 
 export const liveData = {
   ...instanceLiveData,
-  ...pipeable(instanceLiveData),
   sequenceS: sequenceS(instanceLiveData),
   sequenceT: sequenceT(instanceLiveData),
-  sequenceArray: array.sequence(instanceLiveData),
+  sequenceArray: A.sequence(instanceLiveData),
   combine: coproductMapLeft(instanceLiveData),
   mapLeft:
     <L, V, A>(f: (l: L) => V) =>

--- a/src/renderer/helpers/rx/liveData.ts
+++ b/src/renderer/helpers/rx/liveData.ts
@@ -10,6 +10,7 @@ import { sequenceS, sequenceT } from 'fp-ts/lib/Apply'
 import * as A from 'fp-ts/lib/Array'
 import { Filterable2 } from 'fp-ts/lib/Filterable'
 import { MonadThrow2 } from 'fp-ts/lib/MonadThrow'
+import { pipeable } from 'fp-ts/lib/pipeable'
 import * as O from 'fp-ts/Option'
 import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -37,6 +38,7 @@ export const instanceLiveData: MonadThrow2<URIType> & CoproductLeft<URIType> & F
 
 export const liveData = {
   ...instanceLiveData,
+  ...pipeable(instanceLiveData),
   sequenceS: sequenceS(instanceLiveData),
   sequenceT: sequenceT(instanceLiveData),
   sequenceArray: A.sequence(instanceLiveData),

--- a/src/renderer/hooks/useRunePrice.ts
+++ b/src/renderer/hooks/useRunePrice.ts
@@ -9,8 +9,8 @@ import * as RxOp from 'rxjs/operators'
 import { ONE_RUNE_BASE_AMOUNT } from '../../shared/mock/amount'
 import { useMidgardContext } from '../contexts/MidgardContext'
 import { sequenceTOption } from '../helpers/fpHelpers'
+import { PriceRD } from '../services/midgard/types'
 import { pricePoolSelector } from '../services/midgard/utils'
-import { RunePriceRD } from './useRunePrice.types'
 
 export const useRunePrice = () => {
   const {
@@ -19,7 +19,7 @@ export const useRunePrice = () => {
     }
   } = useMidgardContext()
 
-  const [runePriceRD] = useObservableState<RunePriceRD>(
+  const [runePriceRD] = useObservableState<PriceRD>(
     () =>
       Rx.combineLatest([poolsState$, selectedPricePoolAsset$]).pipe(
         RxOp.map(([poolsState, oSelectedPricePoolAsset]) =>

--- a/src/renderer/hooks/useRunePrice.types.ts
+++ b/src/renderer/hooks/useRunePrice.types.ts
@@ -1,5 +1,0 @@
-import * as RD from '@devexperts/remote-data-ts'
-
-import { AssetWithAmount } from '../types/asgardex'
-
-export type RunePriceRD = RD.RemoteData<Error, AssetWithAmount>

--- a/src/renderer/hooks/useVolume24Price.ts
+++ b/src/renderer/hooks/useVolume24Price.ts
@@ -1,0 +1,60 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { getValueOfRuneInAsset } from '@thorchain/asgardex-util'
+import { baseAmount, bnOrZero } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import { useObservableState } from 'observable-hooks'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import { useMidgardContext } from '../contexts/MidgardContext'
+import { sequenceTRD } from '../helpers/fpHelpers'
+import { PriceRD } from '../services/midgard/types'
+import { AssetWithAmount } from '../types/asgardex'
+import { GetLiquidityHistoryIntervalEnum, GetSwapHistoryIntervalEnum } from '../types/generated/midgard'
+
+export const useVolume24Price = () => {
+  const {
+    service: {
+      pools: { poolsState$, selectedPricePool$, apiGetSwapHistory$, apiGetLiquidityHistory$ }
+    }
+  } = useMidgardContext()
+
+  const [volume24PriceRD] = useObservableState<PriceRD>(
+    () =>
+      FP.pipe(
+        Rx.combineLatest([
+          apiGetSwapHistory$({ interval: GetSwapHistoryIntervalEnum.Day, count: 1 }),
+          apiGetLiquidityHistory$({ interval: GetLiquidityHistoryIntervalEnum.Day, count: 1 }),
+          poolsState$,
+          selectedPricePool$
+        ]),
+        RxOp.map(
+          ([
+            swapHistoryRD,
+            liquidityHistoryRD,
+            poolStateRD,
+            { poolData: selectedPricePoolData, asset: pricePoolAsset }
+          ]) =>
+            FP.pipe(
+              sequenceTRD(swapHistoryRD, liquidityHistoryRD, poolStateRD),
+              RD.map(([{ intervals: swapIntervals }, { intervals: liquidityIntervals }, _]) => {
+                const swapVol = baseAmount(bnOrZero(swapIntervals[0]?.totalVolume))
+                const liquitidyVol = baseAmount(bnOrZero(liquidityIntervals[0]?.addLiquidityVolume))
+                const withdrawVol = baseAmount(bnOrZero(liquidityIntervals[0]?.withdrawVolume))
+                const volume24 = swapVol.plus(liquitidyVol).plus(withdrawVol)
+
+                const volume24Price: AssetWithAmount = {
+                  asset: pricePoolAsset,
+                  amount: getValueOfRuneInAsset(volume24, selectedPricePoolData)
+                }
+
+                return volume24Price
+              })
+            )
+        )
+      ),
+    RD.initial
+  )
+
+  return volume24PriceRD
+}

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -737,8 +737,8 @@ const createPoolsService = (
     RxOp.startWith(RD.pending)
   )
 
-  // Factory to get pool liquidity history from Midgard
-  const apiGetPoolLiquidityHistory$ = ({ from, to, ...request }: GetLiquidityHistoryRequest): PoolLiquidityHistoryLD =>
+  // Factory to get liquidity history from Midgard
+  const apiGetLiquidityHistory$ = ({ from, to, ...request }: GetLiquidityHistoryRequest): PoolLiquidityHistoryLD =>
     FP.pipe(
       Rx.combineLatest([midgardDefaultApi$, reloadPoolStatsDetail$]),
       RxOp.map(([api]) => api),
@@ -764,7 +764,7 @@ const createPoolsService = (
           O.fold(
             () => Rx.of(RD.initial),
             (asset) =>
-              apiGetPoolLiquidityHistory$({
+              apiGetLiquidityHistory$({
                 pool: assetToString(asset),
                 ...params
               })
@@ -777,12 +777,14 @@ const createPoolsService = (
   // Factory to get swap history from Midgard
   const apiGetSwapHistory$ = (params: ApiGetSwapHistoryParams): SwapHistoryLD => {
     const { poolAsset, from, to, ...otherParams } = params
+    const pool = FP.pipe(poolAsset, O.fromNullable, O.map(assetToString), O.toUndefined)
+
     return FP.pipe(
       midgardDefaultApi$,
       liveData.chain((api) =>
         FP.pipe(
           api.getSwapHistory({
-            pool: assetToString(poolAsset),
+            pool,
             from: O.toUndefined(roundToFiveMinutes(from)),
             to: O.toUndefined(roundToFiveMinutes(to)),
             ...otherParams
@@ -883,6 +885,8 @@ const createPoolsService = (
     poolEarningHistory$,
     getPoolLiquidityHistory$,
     getSelectedPoolSwapHistory$,
+    apiGetSwapHistory$,
+    apiGetLiquidityHistory$,
     reloadSwapHistory,
     getDepthHistory$,
     reloadDepthHistory,

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -797,7 +797,7 @@ const createPoolsService = (
 
   const { stream$: reloadSwapHistory$, trigger: reloadSwapHistory } = triggerStream()
 
-  const getSwapHistory$ = (params: GetSwapHistoryParams): SwapHistoryLD =>
+  const getSelectedPoolSwapHistory$ = (params: GetSwapHistoryParams): SwapHistoryLD =>
     FP.pipe(
       Rx.combineLatest([selectedPoolAsset$, reloadSwapHistory$]),
       RxOp.filter(([oSelectedPoolAsset, _]) => O.isSome(oSelectedPoolAsset)),
@@ -882,7 +882,7 @@ const createPoolsService = (
     poolLegacyDetail$,
     poolEarningHistory$,
     getPoolLiquidityHistory$,
-    getSwapHistory$,
+    getSelectedPoolSwapHistory$,
     reloadSwapHistory,
     getDepthHistory$,
     reloadDepthHistory,

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -194,7 +194,7 @@ export type PoolsService = {
   poolLegacyDetail$: PoolLegacyDetailLD
   poolEarningHistory$: PoolEarningHistoryLD
   getPoolLiquidityHistory$: (parmas: PoolLiquidityHistoryParams) => PoolLiquidityHistoryLD
-  getSwapHistory$: (params: GetSwapHistoryParams) => SwapHistoryLD
+  getSelectedPoolSwapHistory$: (params: GetSwapHistoryParams) => SwapHistoryLD
   reloadSwapHistory: FP.Lazy<void>
   getDepthHistory$: (params: GetDepthHistoryParams) => DepthHistoryLD
   reloadDepthHistory: FP.Lazy<void>

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -27,7 +27,8 @@ import {
   DepthHistory,
   DepthHistoryItem,
   SwapHistoryItem,
-  InboundAddressesItem
+  InboundAddressesItem,
+  GetLiquidityHistoryRequest
 } from '../../types/generated/midgard'
 import { PricePools, PricePoolAsset, PricePool } from '../../views/pools/Pools.types'
 import { Memo } from '../chain/types'
@@ -88,6 +89,8 @@ export type SelectedPoolChain = O.Option<Chain>
 export type SelectedPricePoolAsset = O.Option<PricePoolAsset>
 
 export type SelectedPricePool = PricePool
+
+export type PriceRD = RD.RemoteData<Error, AssetWithAmount>
 
 export type LastblockItems = LastblockItem[]
 export type ThorchainLastblockRD = RD.RemoteData<Error, LastblockItems>
@@ -153,7 +156,7 @@ export type PoolLiquidityHistoryParams = {
 export type PoolLiquidityHistoryRD = RD.RemoteData<Error, LiquidityHistory>
 export type PoolLiquidityHistoryLD = LiveData<Error, LiquidityHistory>
 
-export type ApiGetSwapHistoryParams = { poolAsset: Asset } & Omit<GetSwapHistoryRequest, 'pool'>
+export type ApiGetSwapHistoryParams = { poolAsset?: Asset } & Omit<GetSwapHistoryRequest, 'pool'>
 export type GetSwapHistoryParams = Omit<ApiGetSwapHistoryParams, 'poolAsset'>
 export type SwapHistoryRD = RD.RemoteData<Error, SwapHistory>
 export type SwapHistoryLD = LiveData<Error, SwapHistory>
@@ -195,6 +198,8 @@ export type PoolsService = {
   poolEarningHistory$: PoolEarningHistoryLD
   getPoolLiquidityHistory$: (parmas: PoolLiquidityHistoryParams) => PoolLiquidityHistoryLD
   getSelectedPoolSwapHistory$: (params: GetSwapHistoryParams) => SwapHistoryLD
+  apiGetSwapHistory$: (params: ApiGetSwapHistoryParams) => SwapHistoryLD
+  apiGetLiquidityHistory$: (params: GetLiquidityHistoryRequest) => PoolLiquidityHistoryLD
   reloadSwapHistory: FP.Lazy<void>
   getDepthHistory$: (params: GetDepthHistoryParams) => DepthHistoryLD
   reloadDepthHistory: FP.Lazy<void>

--- a/src/renderer/views/pool/PoolChartView.tsx
+++ b/src/renderer/views/pool/PoolChartView.tsx
@@ -34,7 +34,7 @@ type Props = {
 export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
   const {
     service: {
-      pools: { selectedPricePoolAsset$, getSwapHistory$, getDepthHistory$, getPoolLiquidityHistory$ }
+      pools: { selectedPricePoolAsset$, getSelectedPoolSwapHistory$, getDepthHistory$, getPoolLiquidityHistory$ }
     }
   } = useMidgardContext()
 
@@ -70,7 +70,7 @@ export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
             // (2) or get data for volume history
             FP.pipe(
               liveData.sequenceS({
-                swapHistory: getSwapHistory$({
+                swapHistory: getSelectedPoolSwapHistory$({
                   ...requestParams,
                   interval: GetSwapHistoryIntervalEnum.Day
                 }),


### PR DESCRIPTION
- [x] Introduce `useVolume24` hook
- [x] Renamed `getSwapHistory` -> `getSelectedPoolSwapHistory`
- [x] Few (quick) fixes for deprecated usage of `fp-ts` types  

![Peek 2021-06-01 17-17](https://user-images.githubusercontent.com/61792675/120351622-52b5e200-c300-11eb-9451-6c2ebfae091a.gif)


Close #1373