### PR TITLE
[Header] Use `strings` as props for boolean

### DIFF
--- a/src/renderer/components/header/stats/HeaderStats.style.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.style.tsx
@@ -22,12 +22,12 @@ export const Container = styled.div<{ clickable: boolean }>`
   }
 `
 
-export const Label = styled(Text)<{ loading: boolean }>`
+export const Label = styled(Text)<{ loading: 'true' | 'false' }>`
   text-transform: uppercase;
   font-family: 'MainFontBold';
   font-size: 12px;
   line-height: 14px;
-  color: ${({ loading }) => (loading ? palette('gray', 2) : palette('text', 2))};
+  color: ${({ loading }) => (loading === 'true' ? palette('gray', 2) : palette('text', 2))};
   width: auto;
   padding: 0;
   margin: 0;

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -96,11 +96,11 @@ export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
     <Styled.Wrapper>
       <Styled.Container onClick={reloadRunePriceHandler} clickable={!RD.isPending(runePriceRD)}>
         <Styled.Title>{intl.formatMessage({ id: 'common.price.rune' })}</Styled.Title>
-        <Styled.Label loading={RD.isPending(runePriceRD)}>{runePriceLabel}</Styled.Label>
+        <Styled.Label loading={RD.isPending(runePriceRD) ? 'true' : 'false'}>{runePriceLabel}</Styled.Label>
       </Styled.Container>
       <Styled.Container onClick={reloadVolume24PriceHandler} clickable={!RD.isPending(volume24PriceRD)}>
         <Styled.Title>{intl.formatMessage({ id: 'common.volume24' })}</Styled.Title>
-        <Styled.Label loading={RD.isPending(volume24PriceRD)}>{volume24PriceLabel}</Styled.Label>
+        <Styled.Label loading={RD.isPending(volume24PriceRD) ? 'true' : 'false'}>{volume24PriceLabel}</Styled.Label>
       </Styled.Container>
     </Styled.Wrapper>
   )


### PR DESCRIPTION
to fix React warnings as reported by @thatStrangeGuyThorchain 

![image](https://user-images.githubusercontent.com/61792675/120634281-5a45ca00-c46b-11eb-9d07-cc0d5fe40c5b.png)
