### PR TITLE
Fix build (broken by #1524 before)

### DIFF
--- a/src/renderer/const.ts
+++ b/src/renderer/const.ts
@@ -146,8 +146,5 @@ export const ZERO_POOL_DATA: PoolData = { runeBalance: ZERO_BASE_AMOUNT, assetBa
 
 export const RECOVERY_TOOL_URL: Record<Network, string> = {
   testnet: 'https://testnet.asgard.exchange/deposit-sym-recovery/',
-  mainnet: 'https://app.asgard.exchange/deposit-sym-recovery/',
-  get chaosnet() {
-    return this.mainnet
-  }
+  mainnet: 'https://app.asgard.exchange/deposit-sym-recovery/'
 }


### PR DESCRIPTION
Fixes following build error on `develop` branch after merging #1524 into it:
```bash
ERROR in /home/runner/work/asgardex-electron/asgardex-electron/src/renderer/const.ts
    [tsl] ERROR in /home/runner/work/asgardex-electron/asgardex-electron/src/renderer/const.ts(150,7)
          TS2322: Type '{ testnet: string; mainnet: string; readonly chaosnet: string; }' is not assignable to type 'Record<Network, string>'.
      Object literal may only specify known properties, and 'chaosnet' does not exist in type 'Record<Network, string>'.
``` 
^ https://github.com/thorchain/asgardex-electron/runs/2784646724#step:8:44