### PR TITLE
Fix BTC balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@thorchain/asgardex-util": "^0.9.1",
     "@types/electron-devtools-installer": "^2.2.0",
     "@xchainjs/xchain-binance": "^5.2.1",
-    "@xchainjs/xchain-bitcoin": "^0.15.4",
+    "@xchainjs/xchain-bitcoin": "^0.15.6",
     "@xchainjs/xchain-bitcoincash": "^0.11.5",
     "@xchainjs/xchain-client": "^0.9.3",
     "@xchainjs/xchain-cosmos": "^0.13.2",

--- a/src/renderer/components/wallet/assets/AssetDetails.style.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.style.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import { media } from '../../../helpers/styleHelper'
+import { ExternalLinkIcon as ExternalLinkIconUI } from '../../uielements/common/Common.style'
 import { Headline } from '../../uielements/headline'
 import { Label as UILabel } from '../../uielements/label'
 
@@ -53,6 +54,13 @@ export const TableHeadline = styled(Headline)`
   padding: 40px 0 20px 0;
   width: 100%;
   text-align: ${({ isDesktop }: TableHeadlineProps) => (isDesktop ? 'left' : 'center')};
+`
+
+export const TableHeadlineLinkIcon = styled(ExternalLinkIconUI)`
+  margin-left: 10px;
+  svg {
+    color: inherit;
+  }
 `
 
 export const UpgradeFeeErrorLabel = styled(UILabel).attrs({

--- a/src/renderer/components/wallet/assets/AssetDetails.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.tsx
@@ -30,6 +30,7 @@ type Props = {
   balances: O.Option<NonEmptyWalletBalances>
   asset: Asset
   getExplorerTxUrl?: O.Option<GetExplorerTxUrl>
+  getExplorerAddressUrl?: O.Option<GetExplorerTxUrl>
   reloadBalancesHandler?: FP.Lazy<void>
   loadTxsHandler?: LoadTxsHandler
   walletAddress?: O.Option<Address>
@@ -44,6 +45,7 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
     reloadBalancesHandler = FP.constVoid,
     loadTxsHandler = EMPTY_LOAD_TXS_HANDLER,
     getExplorerTxUrl: oGetExplorerTxUrl = O.none,
+    getExplorerAddressUrl: oGetExplorerAddressUrl = O.none,
     walletAddress: oWalletAddress = O.none,
     network
   } = props
@@ -92,6 +94,13 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
       FP.pipe(oGetExplorerTxUrl, O.ap(O.some(txHash)), O.map(window.apiUrl.openExternal))
     },
     [oGetExplorerTxUrl]
+  )
+
+  const clickAddressLinkHandler = useCallback(
+    (oAddress: O.Option<string>) => {
+      FP.pipe(oGetExplorerAddressUrl, O.ap(oAddress), O.map(window.apiUrl.openExternal))
+    },
+    [oGetExplorerAddressUrl]
   )
 
   const onChangePagination = useCallback(
@@ -214,7 +223,8 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
       <Row>
         <Col span={24}>
           <Styled.TableHeadline isDesktop={isDesktopView}>
-            {intl.formatMessage({ id: 'wallet.txs.last90days' })}
+            {intl.formatMessage({ id: 'wallet.txs.history' })}{' '}
+            <Styled.TableHeadlineLinkIcon onClick={() => clickAddressLinkHandler(oWalletAddress)} />
           </Styled.TableHeadline>
         </Col>
         <Col span={24}>

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -12,6 +12,7 @@ import {
   selectedAsset$,
   loadTxs,
   getExplorerTxUrl$,
+  getExplorerAddressUrl$,
   getTxs$,
   setSelectedAsset,
   resetTxsPage
@@ -25,6 +26,7 @@ type WalletContextValue = {
   loadTxs: typeof loadTxs
   reloadBalancesByChain: typeof reloadBalancesByChain
   getExplorerTxUrl$: typeof getExplorerTxUrl$
+  getExplorerAddressUrl$: typeof getExplorerAddressUrl$
   selectedAsset$: typeof selectedAsset$
   getTxs$: typeof getTxs$
   setSelectedAsset: typeof setSelectedAsset
@@ -39,6 +41,7 @@ const initialContext: WalletContextValue = {
   balancesState$,
   chainBalances$,
   getExplorerTxUrl$,
+  getExplorerAddressUrl$,
   selectedAsset$,
   getTxs$,
   setSelectedAsset,

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -35,7 +35,7 @@ const wallet: WalletMessages = {
   'wallet.phrase.error.valueRequired': 'Bitte Phrase angeben',
   'wallet.phrase.error.invalid': 'Invalide Phrase',
   'wallet.phrase.error.import': 'Error beim Importieren der Phrase',
-  'wallet.txs.last90days': 'Transaktionen der vergangenen 90 Tage',
+  'wallet.txs.history': 'Transaktionenverlauf',
   'wallet.empty.phrase.import': 'Importiere eine bestehende Wallet mit Guthaben',
   'wallet.empty.phrase.create': 'Erstelle eine neue Wallet und füge ein Guthaben hinzu',
   'wallet.create.copy.phrase': 'Phrase kopieren',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -35,7 +35,7 @@ const wallet: WalletMessages = {
   'wallet.phrase.error.valueRequired': 'Value for phrase is required',
   'wallet.phrase.error.invalid': 'Invalid phrase',
   'wallet.phrase.error.import': 'Error while importing phrase',
-  'wallet.txs.last90days': 'Transactions for last 90 days',
+  'wallet.txs.history': 'Transaction history',
   'wallet.empty.phrase.import': 'Import an existing wallet with funds on it',
   'wallet.empty.phrase.create': 'Create a new wallet, add funds to it',
   'wallet.create.copy.phrase': 'Copy phrase below',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -36,7 +36,7 @@ const wallet: WalletMessages = {
   'wallet.phrase.error.valueRequired': 'La phrase de récupération est requise',
   'wallet.phrase.error.invalid': 'Phrase de récupération incorrecte',
   'wallet.phrase.error.import': "Erreur lors de l'importation de la phrase de récupération",
-  'wallet.txs.last90days': 'Transactions des 90 derniers jours',
+  'wallet.txs.history': 'Transaction history - FR',
   'wallet.empty.phrase.import': 'Importez un portefeuille existant contenant des fonds',
   'wallet.empty.phrase.create': "Créez un nouveau portefeuille, et l'alimenter en fonds",
   'wallet.create.copy.phrase': 'Copiez la phrase ci-dessous',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -32,7 +32,7 @@ const wallet: WalletMessages = {
   'wallet.imports.error.instance': 'Не удалось создать экземпляр Клиента',
   'wallet.imports.error.keystore.load': 'Недопустимый Keystore',
   'wallet.imports.error.keystore.import': 'Неверный пароль',
-  'wallet.txs.last90days': 'Транзакции за последние 90 дней',
+  'wallet.txs.history': 'Transation history - RU',
   'wallet.phrase.error.valueRequired': 'Необходимо значение для фразы',
   'wallet.phrase.error.invalid': 'Неверная фраза',
   'wallet.phrase.error.import': 'Ошибка при импорте фразы',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -151,7 +151,7 @@ type WalletMessageKey =
   | 'wallet.phrase.error.valueRequired'
   | 'wallet.phrase.error.invalid'
   | 'wallet.phrase.error.import'
-  | 'wallet.txs.last90days'
+  | 'wallet.txs.history'
   | 'wallet.empty.phrase.import'
   | 'wallet.empty.phrase.create'
   | 'wallet.create.title'

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -25,7 +25,6 @@ import { INITIAL_BALANCES_STATE } from './const'
 import {
   ChainBalances$,
   ChainBalance$,
-  ChainBalance,
   BalancesService,
   ChainBalancesService,
   BalancesState$,
@@ -230,38 +229,6 @@ export const createBalancesService = ({
     }))
   )
 
-  const btcLedgerChainBalance$: ChainBalance$ = FP.pipe(
-    BTC.ledgerAddress$,
-    RxOp.switchMap((addressRd) =>
-      FP.pipe(
-        addressRd,
-        RD.map((address) => BTC.getBalanceByAddress$(address, 'ledger')),
-        RD.map(
-          RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
-            walletType: 'ledger',
-            chain: BTCChain,
-            walletAddress: FP.pipe(addressRd, RD.toOption),
-            balances
-          }))
-        ),
-        RD.getOrElse(() =>
-          Rx.of<ChainBalance>({
-            walletType: 'ledger',
-            chain: BTCChain,
-            walletAddress: O.none,
-            balances: RD.initial
-          })
-        )
-      )
-    ),
-    RxOp.shareReplay(1)
-  )
-
-  const btcLedgerBalance$ = FP.pipe(
-    btcLedgerChainBalance$,
-    RxOp.map((ledgerBalances) => ledgerBalances.balances)
-  )
-
   const ethBalances$ = getChainBalance$('ETH')
 
   /**
@@ -282,7 +249,7 @@ export const createBalancesService = ({
   const chainBalances$: ChainBalances$ = Rx.combineLatest(
     filterEnabledChains({
       THOR: [thorChainBalance$],
-      BTC: [btcChainBalance$, btcLedgerChainBalance$],
+      BTC: [btcChainBalance$],
       BCH: [bchChainBalance$],
       ETH: [ethChainBalance$],
       BNB: [bnbChainBalance$],
@@ -304,7 +271,7 @@ export const createBalancesService = ({
   const balancesState$: BalancesState$ = Rx.combineLatest(
     filterEnabledChains({
       THOR: [getChainBalance$(THORChain)],
-      BTC: [getChainBalance$(BTCChain), btcLedgerBalance$],
+      BTC: [getChainBalance$(BTCChain)],
       BCH: [getChainBalance$(BCHChain)],
       ETH: [ethBalances$],
       BNB: [getChainBalance$(BNBChain)],

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -2,7 +2,7 @@ import { network$ } from '../app/service'
 import { createBalancesService } from './balances'
 import { setSelectedAsset, selectedAsset$ } from './common'
 import { keystoreService, removeKeystore } from './keystore'
-import { getTxs$, loadTxs, explorerUrl$, getExplorerTxUrl$, resetTxsPage } from './transaction'
+import { getTxs$, loadTxs, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$, resetTxsPage } from './transaction'
 
 const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } = createBalancesService({
   keystore$: keystoreService.keystore$,
@@ -20,6 +20,7 @@ export {
   resetTxsPage,
   explorerUrl$,
   getExplorerTxUrl$,
+  getExplorerAddressUrl$,
   getTxs$,
   reloadBalances,
   reloadBalancesByChain,

--- a/src/renderer/services/wallet/transaction.ts
+++ b/src/renderer/services/wallet/transaction.ts
@@ -9,7 +9,7 @@ import * as BNB from '../binance'
 import * as BTC from '../bitcoin'
 import * as BCH from '../bitcoincash'
 import * as C from '../clients'
-import { ExplorerUrl$, GetExplorerTxUrl$, TxsPageLD, LoadTxsParams } from '../clients'
+import { ExplorerUrl$, GetExplorerTxUrl$, TxsPageLD, LoadTxsParams, GetExplorerAddressUrl$ } from '../clients'
 import * as ETH from '../ethereum'
 import * as LTC from '../litecoin'
 import * as THOR from '../thorchain'
@@ -20,6 +20,8 @@ import { ApiError, ErrorId, LoadTxsHandler, ResetTxsPageHandler } from './types'
 export const explorerUrl$: ExplorerUrl$ = C.explorerUrl$(client$)
 
 export const getExplorerTxUrl$: GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
+
+export const getExplorerAddressUrl$: GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
 /**
  * State of `LoadTxsProps`, which triggers reload of txs history

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -41,13 +41,22 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setSelectedAsset(oRouteAsset), [])
 
-  const { getTxs$, balancesState$, loadTxs, reloadBalancesByChain, setSelectedAsset, getExplorerTxUrl$, resetTxsPage } =
-    useWalletContext()
+  const {
+    getTxs$,
+    balancesState$,
+    loadTxs,
+    reloadBalancesByChain,
+    setSelectedAsset,
+    getExplorerTxUrl$,
+    getExplorerAddressUrl$,
+    resetTxsPage
+  } = useWalletContext()
 
   const [txsRD] = useObservableState(() => getTxs$(oWalletAddress), RD.initial)
   const { balances: oBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 
   const getExplorerTxUrl = useObservableState(getExplorerTxUrl$, O.none)
+  const getExplorerAddressUrl = useObservableState(getExplorerAddressUrl$, O.none)
 
   useEffect(() => {
     return () => resetTxsPage()
@@ -105,6 +114,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
               loadTxsHandler={loadTxs}
               reloadBalancesHandler={reloadBalancesByChain(asset.chain)}
               getExplorerTxUrl={getExplorerTxUrl}
+              getExplorerAddressUrl={getExplorerAddressUrl}
               walletAddress={oWalletAddress}
               network={network}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4241,10 +4241,10 @@
   resolved "https://registry.yarnpkg.com/@xchainjs/xchain-binance/-/xchain-binance-5.2.1.tgz#8d495757aff154ef3b68ef424d4500f5bfb8dff7"
   integrity sha512-B1th9SHm9C+KaQ+kxg2Nu4KLbjMLq2ZWefOr0WBF1DAiGawJVsx9o8NWOzGXTtGvzw8Pww4nuGUd/mmVUoHg8g==
 
-"@xchainjs/xchain-bitcoin@^0.15.4":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.15.4.tgz#615adf2e97d90e9c18a540c6dea1c0897aba6f78"
-  integrity sha512-fscQH7giTuu+c+kHEnUnH0OcqVDGsBrNatGzrLibLNkG/LkTSB4hmDFYCg0TNRo3Y40/XhyIKIZAo+aiHT3KtQ==
+"@xchainjs/xchain-bitcoin@^0.15.6":
+  version "0.15.6"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-bitcoin/-/xchain-bitcoin-0.15.6.tgz#bbbca1e99ebbaa2b34760223c54f7fd325acd7e8"
+  integrity sha512-siUFjtdOIBiFLZXJurRGPPl4XoCfYRhU+kCIMQMddx90T9za/r/Jd25izkajCNajQKF3BDlpy4y1CxL41FkwSw==
 
 "@xchainjs/xchain-bitcoincash@^0.11.5":
   version "0.11.5"


### PR DESCRIPTION
- [x] Use latest `xchain-btc` to get balances by using `Haskoin` API (instead of `Sochain`)
- [x] [AssetDetail] Rename title + add icon to link to Explorer for txs history (Note: `xchain-btc` still use `Sochain` for tx history, which returns an empty result - in this case an user can still click on this icon to see history in external explorer)
- [x] Remove deprecated `BTC` ledger stuff for balances 

![Screenshot from 2021-06-10 07-50-51](https://user-images.githubusercontent.com/61792675/121471842-9e335480-c9c0-11eb-9f55-8052a0ea5493.png)


Fix #1520 