### PR TITLE
Fix min. amount to swap

### DIFF
--- a/src/renderer/helpers/poolHelper.ts
+++ b/src/renderer/helpers/poolHelper.ts
@@ -24,7 +24,14 @@ import { emptyString } from './stringHelper'
 export const sortByDepth = (a: PoolTableRowData, b: PoolTableRowData) =>
   ordBaseAmount.compare(a.depthPrice, b.depthPrice)
 
-const ordByDepth = Ord.ord.contramap(ordBaseAmount, ({ depthPrice }: PoolTableRowData) => depthPrice)
+const ordByDepth = Ord.Contravariant.contramap(ordBaseAmount, ({ depthPrice }: PoolTableRowData) => depthPrice)
+
+/**
+ * RUNE based `PoolData`
+ * Note: We don't have a "RUNE" pool in THORChain,
+ * but do need such thing for pricing
+ */
+export const RUNE_POOL_DATA: PoolData = { assetBalance: ONE_RUNE_BASE_AMOUNT, runeBalance: ONE_RUNE_BASE_AMOUNT }
 
 /**
  * RUNE based `PricePool`
@@ -33,7 +40,7 @@ const ordByDepth = Ord.ord.contramap(ordBaseAmount, ({ depthPrice }: PoolTableRo
  */
 export const RUNE_PRICE_POOL: PricePool = {
   asset: AssetRuneNative,
-  poolData: { assetBalance: ONE_RUNE_BASE_AMOUNT, runeBalance: ONE_RUNE_BASE_AMOUNT }
+  poolData: RUNE_POOL_DATA
 }
 
 /**

--- a/src/renderer/views/pools/Pools.types.ts
+++ b/src/renderer/views/pools/Pools.types.ts
@@ -18,8 +18,8 @@ export type PricePoolCurrencyWeights = Record<string, number>
 
 // TODO (@asgdx-team) Move all PricePool* types into `src/renderer/services/midgard/types.ts`
 export type PricePool = {
-  asset: PricePoolAsset
-  poolData: PoolData
+  readonly asset: PricePoolAsset
+  readonly poolData: PoolData
 }
 
 export type PricePools = NonEmptyArray<PricePool>


### PR DESCRIPTION
- [x] Fix `priceFeeAmountForAsset` by considering `PoolData` in case of `RUNE`
- [x] Update test of `minAmountToSwapMax1e8` to cover ^

Fix #1557 