### PR TITLE
Resolve: "[PoolDetail] Disable SWAP button for pending pools"

### DIFF
--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -7,6 +7,7 @@ import * as O from 'fp-ts/Option'
 
 import { Network } from '../../../shared/api/types'
 import { EarningsHistoryItemPool, PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
+import { stringToGetPoolsStatus } from '../../views/pools/Pools.utils'
 import { PoolCards } from './PoolCards'
 import * as H from './PoolDetails.helpers'
 import { PoolTitle } from './PoolTitle'
@@ -48,6 +49,7 @@ export const PoolDetails: React.FC<Props> = ({
           price={price}
           priceSymbol={priceSymbol}
           isLoading={isLoading}
+          status={stringToGetPoolsStatus(poolDetail.status)}
         />
       </A.Col>
       <A.Col xs={24} md={8}>

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -13,6 +13,7 @@ import { Network } from '../../../shared/api/types'
 import * as PoolHelpers from '../../helpers/poolHelper'
 import { loadingString } from '../../helpers/stringHelper'
 import * as poolsRoutes from '../../routes/pools'
+import { GetPoolsStatusEnum } from '../../types/generated/midgard'
 import { ManageButton } from '../manageButton'
 import { AssetIcon } from '../uielements/assets/assetIcon'
 import { Button } from '../uielements/button'
@@ -25,6 +26,7 @@ export type Props = {
   isLoading?: boolean
   haltedChains?: Chain[]
   network: Network
+  status: GetPoolsStatusEnum
 }
 
 export const PoolTitle: React.FC<Props> = ({
@@ -33,7 +35,8 @@ export const PoolTitle: React.FC<Props> = ({
   priceSymbol,
   haltedChains = [],
   network,
-  isLoading
+  isLoading,
+  status
 }) => {
   const history = useHistory()
   const intl = useIntl()
@@ -115,27 +118,29 @@ export const PoolTitle: React.FC<Props> = ({
                   sizevalue={isDesktopView ? 'normal' : 'small'}
                   isTextView={isDesktopView}
                 />
-                <Button
-                  disabled={disableButton}
-                  round="true"
-                  sizevalue={isDesktopView ? 'normal' : 'small'}
-                  style={{ height: 30 }}
-                  onClick={(event) => {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    history.push(
-                      poolsRoutes.swap.path({ source: assetToString(asset), target: assetToString(AssetRune) })
-                    )
-                  }}>
-                  <SwapOutlined />
-                  {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
-                </Button>
+                {status === GetPoolsStatusEnum.Available && (
+                  <Button
+                    disabled={disableButton}
+                    round="true"
+                    sizevalue={isDesktopView ? 'normal' : 'small'}
+                    style={{ height: 30 }}
+                    onClick={(event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      history.push(
+                        poolsRoutes.swap.path({ source: assetToString(asset), target: assetToString(AssetRune) })
+                      )
+                    }}>
+                    <SwapOutlined />
+                    {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
+                  </Button>
+                )}
               </Styled.ButtonActions>
             )
           }
         )
       ),
-    [history, intl, isDesktopView, oAsset, disableButton]
+    [oAsset, disableButton, isDesktopView, status, intl, history]
   )
 
   return (

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -537,7 +537,6 @@ describe('components/swap/utils', () => {
       // 1,5 * max(1.02, 0.08) = 1,5 * 1.02 = 4,53
 
       const result = minAmountToSwapMax1e8(params)
-      console.log(result.amount().toString())
       expect(eqBaseAmount.equals(result, assetToBase(assetAmount(1.53, inAssetDecimal)))).toBeTruthy()
     })
 

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -465,7 +465,7 @@ describe('components/swap/utils', () => {
       expect(eqBaseAmount.equals(result, assetToBase(assetAmount(120, inAssetDecimal)))).toBeTruthy()
     })
 
-    it.only('chain asset -> chain asset (different chains): BNB.BNB -> ETH.ETH', () => {
+    it('chain asset -> chain asset (different chains): BNB.BNB -> ETH.ETH', () => {
       const inAssetDecimal = BNB_DECIMAL
       const params = {
         swapFees: {

--- a/src/renderer/views/pools/Pools.utils.ts
+++ b/src/renderer/views/pools/Pools.utils.ts
@@ -23,8 +23,8 @@ import { toPoolData } from '../../services/midgard/utils'
 import { GetPoolsStatusEnum, PoolDetail, LastblockItem } from '../../types/generated/midgard'
 import { PoolTableRowData, Pool } from './Pools.types'
 
-const stringToGetPoolsStatus = (str?: string): GetPoolsStatusEnum => {
-  switch (str) {
+export const stringToGetPoolsStatus = (status: string): GetPoolsStatusEnum => {
+  switch (status) {
     case GetPoolsStatusEnum.Suspended: {
       return GetPoolsStatusEnum.Suspended
     }


### PR DESCRIPTION
- [x] Hide SWAP button for pending pools
- [x]  Add test for `stringToGetPoolsStatus` 
- [x] Quick fix: Remove `only` + `console` statements + format test file

Fix #1559 