### PR TITLE
[PoolChart] Fix week time range

### DIFF
--- a/src/renderer/components/uielements/chart/PoolDetailsChart.helpers.ts
+++ b/src/renderer/components/uielements/chart/PoolDetailsChart.helpers.ts
@@ -81,6 +81,20 @@ export const getChartOptions = ({ unit, colors, isDesktopView }: ChartOptionsPar
   plugins: {
     legend: {
       display: false
+    },
+    tooltip: {
+      titleFont: { family: 'MainFontRegular', size: 16 },
+      bodyFont: { family: 'MainFontRegular', size: 14 },
+      callbacks: {
+        label: (context) => {
+          const label = Number(context.dataset.data[context.dataIndex]) || 0
+          // if greater than 100M
+          if (label > 100000000) {
+            return `${unit}${abbreviateNumber(label, 0)}`
+          }
+          return `${unit}${new Intl.NumberFormat().format(Math.floor(label))}`
+        }
+      }
     }
   },
   animation: {

--- a/src/renderer/views/pool/PoolChartView.helper.ts
+++ b/src/renderer/views/pool/PoolChartView.helper.ts
@@ -1,34 +1,9 @@
 import { baseAmount, baseToAsset, bnOrZero } from '@xchainjs/xchain-util'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
-import moment from 'moment'
 
 import { ChartDetails } from '../../components/uielements/chart/PoolDetailsChart.types'
 import { DepthHistoryItem, LiquidityHistoryItem, SwapHistoryItem } from '../../types/generated/midgard'
-
-// Get end of date time
-export const getEoDTime = () => {
-  return moment()
-    .set({
-      hour: 23,
-      minute: 59,
-      second: 59,
-      millisecond: 999
-    })
-    .unix()
-}
-
-export const getWeekAgoTime = () => {
-  return moment()
-    .subtract(7, 'days')
-    .set({
-      hour: 23,
-      minute: 59,
-      second: 59,
-      millisecond: 999
-    })
-    .unix()
-}
 
 type PartialDepthHistoryItem = Pick<DepthHistoryItem, 'startTime' | 'runeDepth'>
 

--- a/src/renderer/views/pool/PoolChartView.tsx
+++ b/src/renderer/views/pool/PoolChartView.tsx
@@ -20,12 +20,7 @@ import {
   GetLiquidityHistoryIntervalEnum,
   GetSwapHistoryIntervalEnum
 } from '../../types/generated/midgard'
-import {
-  getLiquidityFromHistoryItems,
-  getVolumeFromHistoryItems,
-  getEoDTime,
-  getWeekAgoTime
-} from './PoolChartView.helper'
+import { getLiquidityFromHistoryItems, getVolumeFromHistoryItems } from './PoolChartView.helper'
 
 type Props = {
   priceRatio: BigNumber
@@ -50,8 +45,6 @@ export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
     dataType: 'liquidity'
   })
 
-  const curTime = getEoDTime()
-  const weekAgoTime = getWeekAgoTime()
   const [chartDataRD, updateChartData] = useObservableState<ChartDetailsRD, Partial<DataRequestParams>>(
     (params$) =>
       FP.pipe(
@@ -59,7 +52,7 @@ export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
         RxOp.startWith(savedParams),
         RxOp.map((params) => (savedParams.current = { ...savedParams.current, ...params })),
         RxOp.switchMap((params) => {
-          const requestParams = params.timeFrame === 'week' ? { from: weekAgoTime, to: curTime } : {}
+          const requestParams = params.timeFrame === 'week' ? { count: 7 } : {}
           return Rx.iif(
             () => params.dataType === 'liquidity',
             // (1) get data for depth history


### PR DESCRIPTION
- [x] Use `count: 7` param for `week`
- [x] Remove deprected helpers `getEoDTime` + `getWeekAgoTime`
- [x] Fix style / data of tooltip

![Screenshot from 2021-06-24 16-39-41](https://user-images.githubusercontent.com/61792675/123283447-b00e0f00-d50b-11eb-8f7d-c60248edbb11.png)


Fix #1582