### PR TITLE
Refactor `ClientState` to be async

### DIFF
--- a/src/renderer/services/binance/common.ts
+++ b/src/renderer/services/binance/common.ts
@@ -6,7 +6,6 @@ import * as Rx from 'rxjs'
 import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { LiveData, liveData } from '../../helpers/rx/liveData'
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { Address$, ExplorerUrl$, GetExplorerTxUrl$, GetExplorerAddressUrl$ } from '../clients/types'
@@ -15,35 +14,6 @@ import { getClientStateForViews } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState, ClientState$, Client$ } from './types'
-
-/**
- * Helper to load and check flags of a Binance Account
- * We accept only accounts with `flags=0`
- *
- * Note: For accounts with zero balances, we can't check `flags` (because Binance API returns 404 in this case).
- * In this case we accept the account, because every new created account will have zero balances.
- */
-const getAccountFlags = async (client: Client, walletIndex: number): Promise<number> => {
-  const address = client.getAddress(walletIndex)
-  const data = await client.getBncClient().getAccount(address)
-
-  return data?.result?.flags ?? 0
-}
-
-/**
- * Helper to checks `flags` value of a Binance account
- */
-const checkAccountsFlags$ = (client: Client, walletIndex: number): LiveData<Error, Client> =>
-  FP.pipe(
-    Rx.from(getAccountFlags(client, walletIndex)),
-    RxOp.map((flag) =>
-      flag === 0 ? RD.success(client) : RD.failure<Error>(Error(`Invalid BNB account (flag id: ${flag}`))
-    ),
-    RxOp.startWith(RD.pending),
-    RxOp.catchError((error: Error) =>
-      Rx.of(RD.failure(Error(`Invalid account: ${error?.message ?? error.toString()}`)))
-    )
-  )
 
 /**
  * Stream to create an observable `BinanceClient` depending on existing phrase in keystore
@@ -61,7 +31,6 @@ const clientState$: ClientState$ = FP.pipe(
           getPhrase(keystore),
           O.map<string, ClientState>((phrase) => {
             try {
-              console.log('instantiate BNB client:', network, phrase)
               const client = new Client({ phrase, network })
               return RD.success(client)
             } catch (error) {
@@ -74,10 +43,6 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  // wait to have binance client fully instantiated
-  // TODO (@asgdx-team: Can be removed by using `xchain-binance@next`
-  RxOp.delay(500),
-  liveData.chain((client) => checkAccountsFlags$(client, 0)),
   RxOp.startWith<ClientState>(RD.initial),
   RxOp.shareReplay(1)
 )

--- a/src/renderer/services/binance/common.ts
+++ b/src/renderer/services/binance/common.ts
@@ -1,55 +1,58 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client } from '@xchainjs/xchain-binance'
-import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+import * as RxOp from 'rxjs/operators'
 
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { Address$, ExplorerUrl$, GetExplorerTxUrl$, GetExplorerAddressUrl$ } from '../clients/types'
 import { ClientStateForViews } from '../clients/types'
-import { getClient, getClientStateForViews } from '../clients/utils'
+import { getClientStateForViews } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState, ClientState$, Client$ } from './types'
 
 /**
- * Stream to create an observable BinanceClient depending on existing phrase in keystore
+ * Stream to create an observable `BinanceClient` depending on existing phrase in keystore
  *
- * Whenever a phrase has been added to keystore, a new BinanceClient will be created.
- * By the other hand: Whenever a phrase has been removed, the client is set to `none`
- * A BinanceClient will never be created as long as no phrase is available
+ * Whenever a phrase has been added to keystore, a new `BinanceClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `BinanceClient` will never be created as long as no phrase is available
  */
-const clientState$: ClientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
-  mergeMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  RxOp.switchMap(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const client = new Client({ phrase, network })
-              return O.some(right(client)) as ClientState
+              return RD.success(client)
             } catch (error) {
               console.log('BNB ClientState error:', error)
-              return O.some(left(error))
+              return RD.failure<Error>(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      }) as Observable<ClientState>
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Client$ = clientState$.pipe(map(getClient), shareReplay(1))
+const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * Helper stream to provide "ready-to-go" state of latest `BinanceClient`, but w/o exposing the client
  * It's needed by views only.
  */
-const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(map(getClientStateForViews))
+const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(RxOp.map(getClientStateForViews))
 
 /**
  * Current `Address` depending on selected network

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -44,7 +44,8 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  RxOp.startWith<ClientState>(RD.initial)
+  RxOp.startWith<ClientState>(RD.initial),
+  RxOp.shareReplay(1)
 )
 
 const client$: Observable<O.Option<BitcoinClient>> = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -1,56 +1,59 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client as BitcoinClient } from '@xchainjs/xchain-bitcoin'
-import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+import * as RxOp from 'rxjs/operators'
 
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { GetExplorerAddressUrl$ } from '../clients'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
-import { ClientState } from './types'
+import { ClientState, ClientState$ } from './types'
 
 /**
  * Stream to create an observable BitcoinClient depending on existing phrase in keystore
  *
- * Whenever a phrase has been added to keystore, a new BitcoinClient will be created.
- * By the other hand: Whenever a phrase has been removed, the client is set to `none`
- * A BitcoinClient will never be created as long as no phrase is available
+ * Whenever a phrase has been added to keystore, a new `BitcoinClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `BitcoinClient` will never be created as long as no phrase is available
  */
-const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
-  mergeMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  RxOp.switchMap(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const client = new BitcoinClient({
                 network,
                 phrase
               })
-              return O.some(right(client))
+              return RD.success(client)
             } catch (error) {
               console.error('Failed to create BTC client', error)
-              return O.some(left(error))
+              return RD.failure(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      })
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Observable<O.Option<BitcoinClient>> = clientState$.pipe(map(C.getClient), shareReplay(1))
+const client$: Observable<O.Option<BitcoinClient>> = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * Helper stream to provide "ready-to-go" state of latest `BitcoinClient`, but w/o exposing the client
  * It's needed by views only.
  */
-const clientViewState$: Observable<C.ClientStateForViews> = clientState$.pipe(map(C.getClientStateForViews))
+const clientViewState$: Observable<C.ClientStateForViews> = clientState$.pipe(RxOp.map(C.getClientStateForViews))
 
 /**
  * BTC `Address`

--- a/src/renderer/services/bitcoincash/common.ts
+++ b/src/renderer/services/bitcoincash/common.ts
@@ -64,7 +64,8 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  RxOp.startWith<ClientState>(RD.initial)
+  RxOp.startWith<ClientState>(RD.initial),
+  RxOp.shareReplay(1)
 )
 
 const client$: Observable<O.Option<BitcoinCashClient>> = clientState$.pipe(map(RD.toOption), shareReplay(1))

--- a/src/renderer/services/bitcoincash/common.ts
+++ b/src/renderer/services/bitcoincash/common.ts
@@ -1,10 +1,11 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client as BitcoinCashClient, ClientUrl, NodeAuth } from '@xchainjs/xchain-bitcoincash'
-import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import { Observable } from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+import { map, shareReplay } from 'rxjs/operators'
 
 import { envOrDefault } from '../../helpers/envHelper'
 import { clientNetwork$ } from '../app/service'
@@ -12,7 +13,7 @@ import * as C from '../clients'
 import { GetExplorerAddressUrl$ } from '../clients'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
-import { ClientState } from './types'
+import { ClientState, ClientState$ } from './types'
 
 const HASKOIN_API_URL: ClientUrl = {
   testnet: envOrDefault(process.env.REACT_APP_HASKOIN_TESTNET_URL, 'https://api.haskoin.com/bchtest'),
@@ -30,19 +31,20 @@ const NODE_AUTH: NodeAuth = {
 }
 
 /**
- * Stream to create an observable BitcoinCashClient depending on existing phrase in keystore
+ * Stream to create an observable `BitcoinCashClient` depending on existing phrase in keystore
  *
- * Whenever a phrase has been added to keystore, a new BitcoinCashClient will be created.
- * By the other hand: Whenever a phrase has been removed, the client is set to `none`
- * A BitcoinCashClient will never be created as long as no phrase is available
+ * Whenever a phrase has been added to keystore, a new `BitcoinCashClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `BitcoinCashClient` will never be created as long as no phrase is available
  */
-const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
-  mergeMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  RxOp.switchMap(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const client = new BitcoinCashClient({
                 network,
@@ -51,19 +53,21 @@ const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$
                 nodeAuth: NODE_AUTH,
                 phrase
               })
-              return O.some(right(client))
+              return RD.success(client)
             } catch (error) {
               console.error('Failed to create BCH client', error)
-              return O.some(left(error))
+              return RD.failure(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      })
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Observable<O.Option<BitcoinCashClient>> = clientState$.pipe(map(C.getClient), shareReplay(1))
+const client$: Observable<O.Option<BitcoinCashClient>> = clientState$.pipe(map(RD.toOption), shareReplay(1))
 
 /**
  * Helper stream to provide "ready-to-go" state of latest `BitcoinCashClient`, but w/o exposing the client

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -2,10 +2,9 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Address, TxHash, XChainClient } from '@xchainjs/xchain-client'
 import { TxsPage, Fees } from '@xchainjs/xchain-client'
 import { Asset } from '@xchainjs/xchain-util'
-import * as E from 'fp-ts/lib/Either'
 import { getEitherM } from 'fp-ts/lib/EitherT'
 import * as O from 'fp-ts/lib/Option'
-import { Option, option } from 'fp-ts/lib/Option'
+import { option } from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
 import { LiveData } from '../../helpers/rx/liveData'
@@ -13,18 +12,21 @@ import { WalletBalance } from '../../types/wallet'
 import { ApiError, TxLD } from '../wallet/types'
 import { TxHashLD } from '../wallet/types'
 /**
- * Three States:
- * (1) None -> no client has been instantiated
- * (2) Some(Right) -> A client has been instantiated
- * (3) Some(Left) -> An error while trying to instantiate a client
+ * States:
+ * (1) `initial` -> no client has been instantiated
+ * (2) `pending -> A client is instantiated
+ * (3) `success -> A client has been successfully instantiated
+ * (4) `failure -> An error while trying to instantiate a client
  */
-export type ClientState<C> = Option<E.Either<Error, C>>
-export type ClientState$<C> = Rx.Observable<ClientState<C>>
+export type ClientState<C> = RD.RemoteData<Error, C>
+export type ClientState$<C> = LiveData<Error, C>
 
+// TODO (@veado) Remove Monad
 // Something like `EitherT<Option>` Monad
 export const ClientStateM = getEitherM(option)
 
-export type ClientStateForViews = 'notready' | 'ready' | 'error'
+// TODO (@veado) Remove view states
+export type ClientStateForViews = 'notready' | 'pending' | 'ready' | 'error'
 
 export type XChainClient$ = Rx.Observable<O.Option<XChainClient>>
 

--- a/src/renderer/services/clients/utils.test.ts
+++ b/src/renderer/services/clients/utils.test.ts
@@ -1,9 +1,8 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client } from '@xchainjs/xchain-binance'
-import * as E from 'fp-ts/lib/Either'
-import * as O from 'fp-ts/lib/Option'
 
 import { ClientState } from '../clients/types'
-import { getClient, hasClient, getClientStateForViews, toClientNetwork } from './utils'
+import { getClientStateForViews, toClientNetwork } from './utils'
 
 // Mocking non default class exports
 // https://jestjs.io/docs/en/es6-class-mocks#mocking-non-default-class-exports
@@ -22,52 +21,18 @@ describe('services/utils/', () => {
     mockClient = new Client({})
   })
 
-  describe('getClient (Binance)', () => {
-    it('returns a client if it has been created before', () => {
-      const state: ClientState<Client> = O.some(E.right(mockClient))
-      const result = getClient(state)
-      expect(O.toNullable(result)).toEqual(mockClient)
-    })
-    it('returns none if a client has not been created before', () => {
-      const result = getClient(O.none)
-      expect(result).toBeNone()
-    })
-    it('returns none if creating a client has throw an error before', () => {
-      const state: ClientState<Client> = O.some(E.left(new Error('any error')))
-      const result = getClient<Client>(state)
-      expect(result).toBeNone()
-    })
-  })
-
-  describe('hasClient (Binance)', () => {
-    it('returns true if a client has been created', () => {
-      const state: ClientState<Client> = O.some(E.right(mockClient))
-      const result = hasClient(state)
-      expect(result).toBeTruthy()
-    })
-    it('returns false if no client has been created', () => {
-      const result = hasClient<Client>(O.none)
-      expect(result).toBeFalsy()
-    })
-    it('returns false if any errors occur', () => {
-      const state: ClientState<Client> = O.some(E.left(new Error('any error')))
-      const result = hasClient(state)
-      expect(result).toBeFalsy()
-    })
-  })
-
   describe('getClientStateForViews (Binance)', () => {
     it('returns true if a client has been created', () => {
-      const state: ClientState<Client> = O.some(E.right(mockClient))
+      const state: ClientState<Client> = RD.success(mockClient)
       const result = getClientStateForViews<Client>(state)
       expect(result).toEqual('ready')
     })
     it('returns false if no client has been created', () => {
-      const result = getClientStateForViews<Client>(O.none)
+      const result = getClientStateForViews<Client>(RD.initial)
       expect(result).toEqual('notready')
     })
     it('returns false if any errors occur', () => {
-      const state: ClientState<Client> = O.some(E.left(new Error('any error')))
+      const state: ClientState<Client> = RD.failure(Error('any error'))
       const result = getClientStateForViews(state)
       expect(result).toEqual('error')
     })

--- a/src/renderer/services/clients/utils.ts
+++ b/src/renderer/services/clients/utils.ts
@@ -1,31 +1,22 @@
+import * as RD from '@devexperts/remote-data-ts'
 import * as Client from '@xchainjs/xchain-client'
-import * as E from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
 
 import { Network } from '../../../shared/api/types'
-import { ClientStateM, ClientStateForViews, ClientState } from './types'
+import { ClientStateForViews, ClientState } from './types'
 
-export const getClient = <C>(clientState: ClientState<C>): O.Option<C> =>
-  ClientStateM.getOrElse(clientState, () => O.none)
+export const hasClient = <C>(clientState: ClientState<C>): boolean => FP.pipe(clientState, RD.isSuccess)
 
-export const hasClient = <C>(clientState: ClientState<C>): boolean => FP.pipe(clientState, getClient, O.isSome)
-
+// TODO (@veado) Remove view states
 export const getClientStateForViews = <C>(clientState: ClientState<C>): ClientStateForViews =>
   FP.pipe(
     clientState,
-    O.fold(
+    RD.fold(
       // None -> 'notready'
       () => 'notready',
-      // Check inner values of Some<Either>
-      // Some<Left<Error>> -> 'error
-      // Some<Right<BinanceClient>> -> 'ready
-      FP.flow(
-        E.fold(
-          (_) => 'error',
-          (_) => 'ready'
-        )
-      )
+      () => 'pending',
+      (_) => 'error',
+      (_) => 'ready'
     )
   )
 

--- a/src/renderer/services/clients/utils.ts
+++ b/src/renderer/services/clients/utils.ts
@@ -5,8 +5,6 @@ import * as FP from 'fp-ts/lib/function'
 import { Network } from '../../../shared/api/types'
 import { ClientStateForViews, ClientState } from './types'
 
-export const hasClient = <C>(clientState: ClientState<C>): boolean => FP.pipe(clientState, RD.isSuccess)
-
 // TODO (@veado) Remove view states
 export const getClientStateForViews = <C>(clientState: ClientState<C>): ClientStateForViews =>
   FP.pipe(

--- a/src/renderer/services/ethereum/common.ts
+++ b/src/renderer/services/ethereum/common.ts
@@ -1,11 +1,11 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { EtherscanProvider } from '@ethersproject/providers'
 import * as ETH from '@xchainjs/xchain-ethereum'
 import { Asset, assetToString } from '@xchainjs/xchain-util'
-import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
+import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../shared/api/types'
@@ -14,7 +14,7 @@ import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { Address$, ExplorerUrl$, GetExplorerTxUrl$, GetExplorerAddressUrl$ } from '../clients/types'
 import { ClientStateForViews } from '../clients/types'
-import { getClient, toClientNetwork, getClientStateForViews } from '../clients/utils'
+import { toClientNetwork, getClientStateForViews } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { Client$, ClientState, ClientState$ } from './types'
@@ -27,19 +27,20 @@ const ETHPLORER_API_KEY = envOrDefault(process.env.REACT_APP_ETHPLORER_API_KEY, 
 const ETHPLORER_API_URL = envOrDefault(process.env.REACT_APP_ETHPLORER_API_URL, 'https://api.ethplorer.io')
 
 /**
- * Stream to create an observable EthereumClient depending on existing phrase in keystore
+ * Stream to create an observable `EthereumClient` depending on existing phrase in keystore
  *
- * Whenever a phrase has been added to keystore, a new EthereumClient will be created.
- * By the other hand: Whenever a phrase has been removed, the client is set to `none`
- * A EthereumClient will never be created as long as no phrase is available
+ * Whenever a phrase has been added to keystore, a new `EthereumClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `EthereumClient` will never be created as long as no phrase is available
  */
-const clientState$: ClientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
   RxOp.switchMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const infuraCreds: ETH.InfuraCreds | undefined = INFURA_PROJECT_ID
                 ? {
@@ -55,19 +56,21 @@ const clientState$: ClientState$ = Rx.combineLatest([keystoreService.keystore$, 
                 phrase,
                 infuraCreds
               })
-              return O.some(right(client)) as ClientState
+              return RD.success(client)
             } catch (error) {
-              console.error('Failed to create ETH client', error)
-              return O.some(left(error))
+              console.error('Failed to create BCH client', error)
+              return RD.failure(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      }) as Observable<ClientState>
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Client$ = clientState$.pipe(RxOp.map(getClient), RxOp.shareReplay(1))
+const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * Helper stream to provide "ready-to-go" state of latest `EthereumClient`, but w/o exposing the client

--- a/src/renderer/services/ethereum/common.ts
+++ b/src/renderer/services/ethereum/common.ts
@@ -67,7 +67,8 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  RxOp.startWith<ClientState>(RD.initial)
+  RxOp.startWith<ClientState>(RD.initial),
+  RxOp.shareReplay(1)
 )
 
 const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))

--- a/src/renderer/services/litecoin/common.ts
+++ b/src/renderer/services/litecoin/common.ts
@@ -1,17 +1,16 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client, NodeAuth } from '@xchainjs/xchain-litecoin'
 import * as FP from 'fp-ts/function'
-import { right, left } from 'fp-ts/lib/Either'
 import * as O from 'fp-ts/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import * as RxOp from 'rxjs/operators'
 
 import { envOrDefault } from '../../helpers/envHelper'
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
-import { Client$, ClientState } from './types'
+import { Client$, ClientState$, ClientState } from './types'
 
 const LTC_NODE_TESTNET_URL = envOrDefault(
   process.env.REACT_APP_LTC_NODE_TESTNET_URL,
@@ -23,20 +22,22 @@ const NODE_AUTH: NodeAuth = {
   password: envOrDefault(process.env.REACT_APP_LTC_NODE_PASSWORD, 'password'),
   username: envOrDefault(process.env.REACT_APP_LTC_NODE_USERNAME, 'thorchain')
 }
+
 /**
- * Stream to create an observable LitecoinClient depending on existing phrase in keystore
+ * Stream to create an observable `LitecoinClient` depending on existing phrase in keystore
  *
- * Whenever a phrase is added to keystore, a new LitecoinClient will be created.
- * By the other hand: Whenever a phrase is removed, the client will be set to `none`
- * A LitecoinClient will never be created if a phrase is not available
+ * Whenever a phrase has been added to keystore, a new `LitecoinClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `LitecoinClient` will never be created as long as no phrase is available
  */
-const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
-  mergeMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  RxOp.switchMap(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const nodeUrl = network === 'mainnet' ? LTC_NODE_MAINNET_URL : LTC_NODE_TESTNET_URL
               const client = new Client({
@@ -45,19 +46,21 @@ const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$
                 nodeUrl,
                 nodeAuth: NODE_AUTH
               })
-              return O.some(right(client)) as ClientState
+              return RD.success(client)
             } catch (error) {
               console.error('Failed to create LTC client', error)
-              return O.some(left(error)) as ClientState
+              return RD.failure(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      })
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Client$ = clientState$.pipe(map(C.getClient), shareReplay(1))
+const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * `Address`

--- a/src/renderer/services/litecoin/common.ts
+++ b/src/renderer/services/litecoin/common.ts
@@ -57,7 +57,8 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  RxOp.startWith<ClientState>(RD.initial)
+  RxOp.startWith<ClientState>(RD.initial),
+  RxOp.shareReplay(1)
 )
 
 const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))

--- a/src/renderer/services/thorchain/common.ts
+++ b/src/renderer/services/thorchain/common.ts
@@ -1,50 +1,51 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Client } from '@xchainjs/xchain-thorchain'
-import { right, left } from 'fp-ts/lib/Either'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable, Observer } from 'rxjs'
-import { map, mergeMap, shareReplay } from 'rxjs/operators'
+import * as RxOp from 'rxjs/operators'
 
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
-import { getClient } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
-import { Client$, ClientState } from './types'
+import { Client$, ClientState, ClientState$ } from './types'
 
 /**
- * Stream to create an observable ThorchainClient depending on existing phrase in keystore
+ * Stream to create an observable `ThorchainClient` depending on existing phrase in keystore
  *
- * Whenever a phrase is added to keystore, a new ThorchainClient will be created.
- * By the other hand: Whenever a phrase is removed, the client will be set to `none`
- * A ThorchainClient will never be created if a phrase is not available
+ * Whenever a phrase has been added to keystore, a new `ThorchainClient` will be created.
+ * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
+ * A `ThorchainClient` will never be created as long as no phrase is available
  */
-const clientState$ = Rx.combineLatest([keystoreService.keystore$, clientNetwork$]).pipe(
-  mergeMap(
-    ([keystore, network]) =>
-      new Observable((observer: Observer<ClientState>) => {
-        const client: ClientState = FP.pipe(
+const clientState$: ClientState$ = FP.pipe(
+  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  RxOp.switchMap(
+    ([keystore, network]): ClientState$ =>
+      Rx.of(
+        FP.pipe(
           getPhrase(keystore),
-          O.chain((phrase) => {
+          O.map<string, ClientState>((phrase) => {
             try {
               const client = new Client({
                 network,
                 phrase
               })
-              return O.some(right(client)) as ClientState
+              return RD.success(client)
             } catch (error) {
-              console.error('Failed to create THOR client', error)
-              return O.some(left(error)) as ClientState
+              console.error('Failed to create BCH client', error)
+              return RD.failure(error)
             }
-          })
+          }),
+          // Set back to `initial` if no phrase is available (locked wallet)
+          O.getOrElse<ClientState>(() => RD.initial)
         )
-        observer.next(client)
-      })
-  )
+      ).pipe(RxOp.startWith(RD.pending))
+  ),
+  RxOp.startWith<ClientState>(RD.initial)
 )
 
-const client$: Client$ = clientState$.pipe(map(getClient), shareReplay(1))
+const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * `Address`

--- a/src/renderer/services/thorchain/common.ts
+++ b/src/renderer/services/thorchain/common.ts
@@ -42,7 +42,8 @@ const clientState$: ClientState$ = FP.pipe(
         )
       ).pipe(RxOp.startWith(RD.pending))
   ),
-  RxOp.startWith<ClientState>(RD.initial)
+  RxOp.startWith<ClientState>(RD.initial),
+  RxOp.shareReplay(1)
 )
 
 const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))


### PR DESCRIPTION
- [ ] ~~Check `flags` using endpoint~~
- [x] Refactor `ClientState` to be `RemoteData` (instead of `Either`)
- [x] Remove deprecated helpers `getClient`, `hasClient`

Part of #1571 