### PR TITLE
Update state handling for importing keystores

### DIFF
--- a/src/renderer/components/shared/loading/Spin.styles.ts
+++ b/src/renderer/components/shared/loading/Spin.styles.ts
@@ -1,0 +1,12 @@
+import * as A from 'antd'
+import styled from 'styled-components'
+import { palette } from 'styled-theme'
+
+export const Spin = styled(A.Spin)`
+  & .ant-spin-text {
+    color: ${palette('gray', 2)};
+    font-size: 12px;
+    text-transform: uppercase;
+    font-family: 'MainFontRegular';
+  }
+`

--- a/src/renderer/components/shared/loading/index.ts
+++ b/src/renderer/components/shared/loading/index.ts
@@ -1,1 +1,2 @@
 export { LoadingView } from './LoadingView'
+export { Spin } from './Spin.styles'

--- a/src/renderer/components/wallet/keystore/ImportKeystore.stories.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.stories.tsx
@@ -10,7 +10,12 @@ const importKeystoreInitial$ = () => Rx.of(RD.initial)
 const loadKeystoreInitial$ = () => Rx.of(RD.initial)
 
 export const StoryInitial: Story = () => (
-  <ImportKeystore importKeystore$={importKeystoreInitial$} loadKeystore$={loadKeystoreInitial$} />
+  <ImportKeystore
+    importKeystore$={importKeystoreInitial$}
+    loadKeystore$={loadKeystoreInitial$}
+    readyToRedirect={false}
+    clientStates={RD.initial}
+  />
 )
 StoryInitial.storyName = 'initial'
 

--- a/src/renderer/components/wallet/keystore/ImportKeystore.stories.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.stories.tsx
@@ -13,7 +13,6 @@ export const StoryInitial: Story = () => (
   <ImportKeystore
     importKeystore$={importKeystoreInitial$}
     loadKeystore$={loadKeystoreInitial$}
-    readyToRedirect={false}
     clientStates={RD.initial}
   />
 )

--- a/src/renderer/components/wallet/keystore/ImportKeystore.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { CheckCircleTwoTone, UploadOutlined } from '@ant-design/icons'
 import * as RD from '@devexperts/remote-data-ts'
@@ -7,11 +7,9 @@ import { Form } from 'antd'
 import { Store } from 'antd/lib/form/interface'
 import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { KeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
-import * as walletRoutes from '../../../routes/wallet'
 import { ImportKeystoreLD, LoadKeystoreLD } from '../../../services/wallet/types'
 import { Spin } from '../../shared/loading'
 import { InputPassword } from '../../uielements/input'
@@ -21,13 +19,11 @@ type Props = {
   clientStates: KeystoreClientStates
   importKeystore$: (keystore: Keystore, password: string) => ImportKeystoreLD
   loadKeystore$: () => LoadKeystoreLD
-  readyToRedirect: boolean
 }
 
 export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
-  const { importKeystore$, loadKeystore$, clientStates, readyToRedirect } = props
+  const { importKeystore$, loadKeystore$, clientStates } = props
 
-  const history = useHistory()
   const [form] = Form.useForm()
 
   const intl = useIntl()
@@ -39,13 +35,6 @@ export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
   const { state: importKeystoreState, subscribe: subscribeImportKeystoreState } = useSubscriptionState<
     RD.RemoteData<Error, void>
   >(RD.initial)
-
-  useEffect(() => {
-    if (readyToRedirect) {
-      // redirect to wallets assets view
-      history.push(walletRoutes.assets.path())
-    }
-  }, [history, readyToRedirect])
 
   const submitForm = useCallback(
     ({ password }: Store) => {

--- a/src/renderer/components/wallet/keystore/Keystore.styles.tsx
+++ b/src/renderer/components/wallet/keystore/Keystore.styles.tsx
@@ -1,5 +1,6 @@
 import * as A from 'antd'
 import styled from 'styled-components'
+import { palette } from 'styled-theme'
 
 import { Button } from '../../../components/uielements/button'
 import { InnerForm } from '../../shared/form/Form.style'
@@ -20,6 +21,13 @@ export const Title = styled(UILabel).attrs({
 })`
   width: 100%;
   margin-bottom: 10px;
+`
+
+export const ErrorLabel = styled(UILabel)`
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  color: ${palette('error', 0)};
+  text-align: center;
 `
 
 export const KeystoreButton = styled(Button).attrs({

--- a/src/renderer/components/wallet/phrase/ImportPhrase.tsx
+++ b/src/renderer/components/wallet/phrase/ImportPhrase.tsx
@@ -8,12 +8,9 @@ import { Store } from 'antd/lib/form/interface'
 import Paragraph from 'antd/lib/typography/Paragraph'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
-// import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { KeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
-import * as walletRoutes from '../../../routes/wallet'
 import { Phrase } from '../../../services/wallet/types'
 import { Spin } from '../../shared/loading'
 import { InputPassword, InputTextArea } from '../../uielements/input'
@@ -22,12 +19,10 @@ import * as Styled from './Phrase.styles'
 type Props = {
   addKeystore: (phrase: Phrase, password: string) => Promise<void>
   clientStates: KeystoreClientStates
-  readyToRedirect: boolean
 }
 
 export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
-  const { addKeystore, clientStates, readyToRedirect } = props
-  const history = useHistory()
+  const { addKeystore, clientStates } = props
   const [form] = Form.useForm()
 
   const intl = useIntl()
@@ -53,13 +48,7 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
         (_) => {}
       )
     )
-  }, [clientStates, history])
-
-  useEffect(() => {
-    if (readyToRedirect) {
-      history.push(walletRoutes.assets.path())
-    }
-  }, [history, readyToRedirect])
+  }, [clientStates])
 
   const [validPhrase, setValidPhrase] = useState(false)
 

--- a/src/renderer/contexts/BinanceContext.tsx
+++ b/src/renderer/contexts/BinanceContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from 'react'
 
 import {
   client$,
-  clientViewState$,
+  clientState$,
   subscribeTransfers,
   miniTickers$,
   txs$,
@@ -24,7 +24,7 @@ import {
 
 export type BinanceContextValue = {
   client$: typeof client$
-  clientViewState$: typeof clientViewState$
+  clientState$: typeof clientState$
   subscribeTransfers: typeof subscribeTransfers
   miniTickers$: typeof miniTickers$
   txs$: typeof txs$
@@ -46,7 +46,7 @@ export type BinanceContextValue = {
 
 const initialContext: BinanceContextValue = {
   client$,
-  clientViewState$,
+  clientState$,
   subscribeTransfers,
   miniTickers$,
   txs$,

--- a/src/renderer/contexts/BitcoinCashContext.tsx
+++ b/src/renderer/contexts/BitcoinCashContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext } from 'react'
 
 import {
   client$,
+  clientState$,
   address$,
   addressUI$,
   balances$,
@@ -14,6 +15,7 @@ import {
 
 export type BitcoinCashContextValue = {
   client$: typeof client$
+  clientState$: typeof clientState$
   address$: typeof address$
   addressUI$: typeof addressUI$
   reloadBalances: typeof reloadBalances
@@ -26,6 +28,7 @@ export type BitcoinCashContextValue = {
 
 const initialContext: BitcoinCashContextValue = {
   client$,
+  clientState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/contexts/BitcoinContext.tsx
+++ b/src/renderer/contexts/BitcoinContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext } from 'react'
 
 import {
   client$,
+  clientState$,
   address$,
   addressUI$,
   reloadBalances,
@@ -22,6 +23,7 @@ import {
 
 export type BitcoinContextValue = {
   client$: typeof client$
+  clientState$: typeof clientState$
   address$: typeof address$
   addressUI$: typeof addressUI$
   reloadBalances: typeof reloadBalances
@@ -42,6 +44,7 @@ export type BitcoinContextValue = {
 
 const initialContext: BitcoinContextValue = {
   client$,
+  clientState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/contexts/EthereumContext.tsx
+++ b/src/renderer/contexts/EthereumContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from 'react'
 
 import {
   client$,
-  clientViewState$,
+  clientState$,
   txs$,
   resetTx,
   subscribeTx,
@@ -23,7 +23,7 @@ import {
 
 export type EthereumContextValue = {
   client$: typeof client$
-  clientViewState$: typeof clientViewState$
+  clientState$: typeof clientState$
   txs$: typeof txs$
   resetTx: typeof resetTx
   subscribeTx: typeof subscribeTx
@@ -44,7 +44,7 @@ export type EthereumContextValue = {
 
 const initialContext: EthereumContextValue = {
   client$,
-  clientViewState$,
+  clientState$,
   txs$,
   resetTx,
   subscribeTx,

--- a/src/renderer/contexts/LitecoinContext.tsx
+++ b/src/renderer/contexts/LitecoinContext.tsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext } from 'react'
 
 import {
+  client$,
+  clientState$,
   address$,
   addressUI$,
-  client$,
   balances$,
   reloadBalances,
   txs$,
@@ -19,9 +20,10 @@ import {
 } from '../services/litecoin'
 
 export type LitecoinContextValue = {
+  client$: typeof client$
+  clientState$: typeof clientState$
   address$: typeof address$
   addressUI$: typeof addressUI$
-  client$: typeof client$
   reloadBalances: typeof reloadBalances
   balances$: typeof balances$
   txs$: typeof txs$
@@ -37,9 +39,10 @@ export type LitecoinContextValue = {
 }
 
 const initialContext: LitecoinContextValue = {
+  client$,
+  clientState$,
   address$,
   addressUI$,
-  client$,
   reloadBalances,
   balances$,
   txs$,

--- a/src/renderer/contexts/ThorchainContext.tsx
+++ b/src/renderer/contexts/ThorchainContext.tsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext } from 'react'
 
 import {
+  client$,
+  clientState$,
   address$,
   addressUI$,
-  client$,
   balances$,
   reloadBalances,
   txs$,
@@ -25,9 +26,10 @@ import {
 } from '../services/thorchain'
 
 export type ThorchainContextValue = {
+  client$: typeof client$
+  clientState$: typeof clientState$
   address$: typeof address$
   addressUI$: typeof addressUI$
-  client$: typeof client$
   reloadBalances: typeof reloadBalances
   balances$: typeof balances$
   txs$: typeof txs$
@@ -49,9 +51,10 @@ export type ThorchainContextValue = {
 }
 
 const initialContext: ThorchainContextValue = {
+  client$,
+  clientState$,
   address$,
   addressUI$,
-  client$,
   reloadBalances,
   balances$,
   txs$,

--- a/src/renderer/hooks/useKeystoreClientStates.ts
+++ b/src/renderer/hooks/useKeystoreClientStates.ts
@@ -1,0 +1,43 @@
+import * as RD from '@devexperts/remote-data-ts'
+import * as FP from 'fp-ts/lib/function'
+import { useObservableState } from 'observable-hooks'
+import * as RxOp from 'rxjs/operators'
+
+import { useBinanceContext } from '../contexts/BinanceContext'
+import { useBitcoinCashContext } from '../contexts/BitcoinCashContext'
+import { useBitcoinContext } from '../contexts/BitcoinContext'
+import { useEthereumContext } from '../contexts/EthereumContext'
+import { useLitecoinContext } from '../contexts/LitecoinContext'
+import { useThorchainContext } from '../contexts/ThorchainContext'
+import { liveData } from '../helpers/rx/liveData'
+
+export type KeystoreClientStates = RD.RemoteData<Error, boolean>
+
+export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates } => {
+  const { clientState$: bnbClientState$ } = useBinanceContext()
+  const { clientState$: btcClientState$ } = useBitcoinContext()
+  const { clientState$: bchClientState$ } = useBitcoinCashContext()
+  const { clientState$: ltcClientState$ } = useLitecoinContext()
+  const { clientState$: ethClientState$ } = useEthereumContext()
+  const { clientState$: thorClientState$ } = useThorchainContext()
+
+  // State of initializing all clients
+  const [clientStates] = useObservableState<KeystoreClientStates>(
+    () =>
+      FP.pipe(
+        liveData.sequenceS({
+          bnb: bnbClientState$,
+          btc: btcClientState$,
+          bch: bchClientState$,
+          eth: ethClientState$,
+          ltc: ltcClientState$,
+          thor: thorClientState$
+        }),
+        liveData.map((_) => true),
+        RxOp.startWith(RD.pending)
+      ),
+    RD.initial
+  )
+
+  return { clientStates }
+}

--- a/src/renderer/hooks/useKeystoreClientStates.ts
+++ b/src/renderer/hooks/useKeystoreClientStates.ts
@@ -1,5 +1,8 @@
+import { useMemo } from 'react'
+
 import * as RD from '@devexperts/remote-data-ts'
 import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
@@ -9,17 +12,24 @@ import { useBitcoinContext } from '../contexts/BitcoinContext'
 import { useEthereumContext } from '../contexts/EthereumContext'
 import { useLitecoinContext } from '../contexts/LitecoinContext'
 import { useThorchainContext } from '../contexts/ThorchainContext'
+import { useWalletContext } from '../contexts/WalletContext'
 import { liveData } from '../helpers/rx/liveData'
+import { INITIAL_KEYSTORE_STATE } from '../services/wallet/const'
+import { hasImportedKeystore } from '../services/wallet/util'
 
 export type KeystoreClientStates = RD.RemoteData<Error, boolean>
 
-export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates } => {
+export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates; readyToRedirect: boolean } => {
   const { clientState$: bnbClientState$ } = useBinanceContext()
   const { clientState$: btcClientState$ } = useBitcoinContext()
   const { clientState$: bchClientState$ } = useBitcoinCashContext()
   const { clientState$: ltcClientState$ } = useLitecoinContext()
   const { clientState$: ethClientState$ } = useEthereumContext()
   const { clientState$: thorClientState$ } = useThorchainContext()
+  const {
+    keystoreService: { keystore$ }
+  } = useWalletContext()
+  const keystore = useObservableState(keystore$, INITIAL_KEYSTORE_STATE)
 
   // State of initializing all clients
   const [clientStates] = useObservableState<KeystoreClientStates>(
@@ -39,5 +49,17 @@ export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates 
     RD.initial
   )
 
-  return { clientStates }
+  const readyToRedirect = useMemo(
+    () =>
+      FP.pipe(
+        clientStates,
+        RD.toOption,
+        O.map((_) => hasImportedKeystore(keystore)),
+        O.getOrElse(() => false)
+      ),
+
+    [clientStates, keystore]
+  )
+
+  return { clientStates, readyToRedirect }
 }

--- a/src/renderer/hooks/useKeystoreClientStates.ts
+++ b/src/renderer/hooks/useKeystoreClientStates.ts
@@ -1,8 +1,5 @@
-import { useMemo } from 'react'
-
 import * as RD from '@devexperts/remote-data-ts'
 import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
@@ -12,24 +9,17 @@ import { useBitcoinContext } from '../contexts/BitcoinContext'
 import { useEthereumContext } from '../contexts/EthereumContext'
 import { useLitecoinContext } from '../contexts/LitecoinContext'
 import { useThorchainContext } from '../contexts/ThorchainContext'
-import { useWalletContext } from '../contexts/WalletContext'
 import { liveData } from '../helpers/rx/liveData'
-import { INITIAL_KEYSTORE_STATE } from '../services/wallet/const'
-import { hasImportedKeystore } from '../services/wallet/util'
 
 export type KeystoreClientStates = RD.RemoteData<Error, boolean>
 
-export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates; readyToRedirect: boolean } => {
+export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates } => {
   const { clientState$: bnbClientState$ } = useBinanceContext()
   const { clientState$: btcClientState$ } = useBitcoinContext()
   const { clientState$: bchClientState$ } = useBitcoinCashContext()
   const { clientState$: ltcClientState$ } = useLitecoinContext()
   const { clientState$: ethClientState$ } = useEthereumContext()
   const { clientState$: thorClientState$ } = useThorchainContext()
-  const {
-    keystoreService: { keystore$ }
-  } = useWalletContext()
-  const keystore = useObservableState(keystore$, INITIAL_KEYSTORE_STATE)
 
   // State of initializing all clients
   const [clientStates] = useObservableState<KeystoreClientStates>(
@@ -49,17 +39,5 @@ export const useKeystoreClientStates = (): { clientStates: KeystoreClientStates;
     RD.initial
   )
 
-  const readyToRedirect = useMemo(
-    () =>
-      FP.pipe(
-        clientStates,
-        RD.toOption,
-        O.map((_) => hasImportedKeystore(keystore)),
-        O.getOrElse(() => false)
-      ),
-
-    [clientStates, keystore]
-  )
-
-  return { clientStates, readyToRedirect }
+  return { clientStates }
 }

--- a/src/renderer/hooks/useKeystoreRedirectAfterImport.ts
+++ b/src/renderer/hooks/useKeystoreRedirectAfterImport.ts
@@ -12,6 +12,14 @@ import { INITIAL_KEYSTORE_STATE } from '../services/wallet/const'
 import { hasImportedKeystore } from '../services/wallet/util'
 import { useKeystoreClientStates } from './useKeystoreClientStates'
 
+/**
+ * It redirects to wallet asset view
+ * whenever keystore have been imported
+ * and ALL clients have been initialized
+ *
+ * Use this hook in top level *views only (but not in components)
+ *
+ */
 export const useKeystoreRedirectAfterImport = (): void => {
   const history = useHistory()
   const { clientStates } = useKeystoreClientStates()
@@ -35,7 +43,7 @@ export const useKeystoreRedirectAfterImport = (): void => {
   useEffect(() => {
     if (readyToRedirect) {
       // redirect to wallets assets view
-      history.push(walletRoutes.assets.template)
+      history.push(walletRoutes.assets.path())
     }
   }, [history, readyToRedirect])
 }

--- a/src/renderer/hooks/useKeystoreRedirectAfterImport.ts
+++ b/src/renderer/hooks/useKeystoreRedirectAfterImport.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo } from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import { useObservableState } from 'observable-hooks'
+import { useHistory } from 'react-router-dom'
+
+import { useWalletContext } from '../contexts/WalletContext'
+import * as walletRoutes from '../routes/wallet'
+import { INITIAL_KEYSTORE_STATE } from '../services/wallet/const'
+import { hasImportedKeystore } from '../services/wallet/util'
+import { useKeystoreClientStates } from './useKeystoreClientStates'
+
+export const useKeystoreRedirectAfterImport = (): void => {
+  const history = useHistory()
+  const { clientStates } = useKeystoreClientStates()
+  const {
+    keystoreService: { keystore$ }
+  } = useWalletContext()
+  const keystore = useObservableState(keystore$, INITIAL_KEYSTORE_STATE)
+
+  const readyToRedirect = useMemo(
+    () =>
+      FP.pipe(
+        clientStates,
+        RD.toOption,
+        O.map((_) => hasImportedKeystore(keystore)),
+        O.getOrElse(() => false)
+      ),
+
+    [clientStates, keystore]
+  )
+
+  useEffect(() => {
+    if (readyToRedirect) {
+      // redirect to wallets assets view
+      history.push(walletRoutes.assets.template)
+    }
+  }, [history, readyToRedirect])
+}

--- a/src/renderer/services/binance/common.ts
+++ b/src/renderer/services/binance/common.ts
@@ -21,7 +21,7 @@ import { ClientState, ClientState$, Client$ } from './types'
  */
 const clientState$: ClientState$ = FP.pipe(
   Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
-  RxOp.mergeMap(
+  RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(
         FP.pipe(

--- a/src/renderer/services/binance/common.ts
+++ b/src/renderer/services/binance/common.ts
@@ -3,14 +3,11 @@ import { Client } from '@xchainjs/xchain-binance'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { Address$, ExplorerUrl$, GetExplorerTxUrl$, GetExplorerAddressUrl$ } from '../clients/types'
-import { ClientStateForViews } from '../clients/types'
-import { getClientStateForViews } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState, ClientState$, Client$ } from './types'
@@ -50,12 +47,6 @@ const clientState$: ClientState$ = FP.pipe(
 const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
- * Helper stream to provide "ready-to-go" state of latest `BinanceClient`, but w/o exposing the client
- * It's needed by views only.
- */
-const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(RxOp.map(getClientStateForViews))
-
-/**
  * Current `Address` depending on selected network
  */
 const address$: Address$ = C.address$(client$)
@@ -80,13 +71,4 @@ const getExplorerTxUrl$: GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
  */
 const getExplorerAddressUrl$: GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
-export {
-  client$,
-  clientState$,
-  clientViewState$,
-  address$,
-  addressUI$,
-  explorerUrl$,
-  getExplorerTxUrl$,
-  getExplorerAddressUrl$
-}
+export { client$, clientState$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }

--- a/src/renderer/services/binance/index.ts
+++ b/src/renderer/services/binance/index.ts
@@ -3,7 +3,7 @@ import { BNBChain } from '@xchainjs/xchain-util'
 import { balances$, reloadBalances, reloadBalances$, resetReloadBalances } from './balances'
 import {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   explorerUrl$,
   getExplorerTxUrl$,
@@ -22,7 +22,7 @@ const { ledgerAddress$, retrieveLedgerAddress, removeLedgerAddress, ledgerTxRD$,
 
 export {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -51,12 +51,6 @@ const clientState$: ClientState$ = FP.pipe(
 const client$: Observable<O.Option<BitcoinClient>> = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
- * Helper stream to provide "ready-to-go" state of latest `BitcoinClient`, but w/o exposing the client
- * It's needed by views only.
- */
-const clientViewState$: Observable<C.ClientStateForViews> = clientState$.pipe(RxOp.map(C.getClientStateForViews))
-
-/**
  * BTC `Address`
  */
 const address$: C.Address$ = C.address$(client$)
@@ -80,4 +74,4 @@ const getExplorerTxUrl$: C.GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
  */
 const getExplorerAddressUrl$: GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
-export { client$, clientViewState$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }
+export { client$, clientState$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }

--- a/src/renderer/services/bitcoin/index.ts
+++ b/src/renderer/services/bitcoin/index.ts
@@ -1,7 +1,7 @@
 import { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances } from './balances'
 import {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   addressUI$,
   explorerUrl$,
@@ -19,10 +19,10 @@ const { ledgerAddress$, retrieveLedgerAddress, removeLedgerAddress, pushLedgerTx
 
 export {
   client$,
+  clientState$,
   explorerUrl$,
   getExplorerTxUrl$,
   getExplorerAddressUrl$,
-  clientViewState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/services/bitcoincash/common.ts
+++ b/src/renderer/services/bitcoincash/common.ts
@@ -71,12 +71,6 @@ const clientState$: ClientState$ = FP.pipe(
 const client$: Observable<O.Option<BitcoinCashClient>> = clientState$.pipe(map(RD.toOption), shareReplay(1))
 
 /**
- * Helper stream to provide "ready-to-go" state of latest `BitcoinCashClient`, but w/o exposing the client
- * It's needed by views only.
- */
-const clientViewState$: Observable<C.ClientStateForViews> = clientState$.pipe(map(C.getClientStateForViews))
-
-/**
  * BCH `Address`
  */
 const address$: C.Address$ = C.address$(client$)
@@ -101,4 +95,4 @@ const getExplorerTxUrl$: C.GetExplorerTxUrl$ = C.getExplorerTxUrl$(client$)
  */
 const getExplorerAddressUrl$: GetExplorerAddressUrl$ = C.getExplorerAddressUrl$(client$)
 
-export { address$, addressUI$, client$, clientViewState$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }
+export { client$, clientState$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ }

--- a/src/renderer/services/bitcoincash/index.ts
+++ b/src/renderer/services/bitcoincash/index.ts
@@ -1,7 +1,7 @@
 import { balances$, reloadBalances, reloadBalances$, resetReloadBalances } from './balances'
 import {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   addressUI$,
   explorerUrl$,
@@ -16,10 +16,10 @@ const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$ } = createTran
 
 export {
   client$,
+  clientState$,
   explorerUrl$,
   getExplorerTxUrl$,
   getExplorerAddressUrl$,
-  clientViewState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -2,9 +2,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Address, TxHash, XChainClient } from '@xchainjs/xchain-client'
 import { TxsPage, Fees } from '@xchainjs/xchain-client'
 import { Asset } from '@xchainjs/xchain-util'
-import { getEitherM } from 'fp-ts/lib/EitherT'
 import * as O from 'fp-ts/lib/Option'
-import { option } from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
 import { LiveData } from '../../helpers/rx/liveData'
@@ -20,13 +18,6 @@ import { TxHashLD } from '../wallet/types'
  */
 export type ClientState<C> = RD.RemoteData<Error, C>
 export type ClientState$<C> = LiveData<Error, C>
-
-// TODO (@veado) Remove Monad
-// Something like `EitherT<Option>` Monad
-export const ClientStateM = getEitherM(option)
-
-// TODO (@veado) Remove view states
-export type ClientStateForViews = 'notready' | 'pending' | 'ready' | 'error'
 
 export type XChainClient$ = Rx.Observable<O.Option<XChainClient>>
 

--- a/src/renderer/services/clients/utils.test.ts
+++ b/src/renderer/services/clients/utils.test.ts
@@ -1,43 +1,6 @@
-import * as RD from '@devexperts/remote-data-ts'
-import { Client } from '@xchainjs/xchain-binance'
-
-import { ClientState } from '../clients/types'
-import { getClientStateForViews, toClientNetwork } from './utils'
-
-// Mocking non default class exports
-// https://jestjs.io/docs/en/es6-class-mocks#mocking-non-default-class-exports
-jest.mock('@xchainjs/xchain-binance', () => {
-  return {
-    Client: jest.fn().mockImplementation(() =>
-      /* return empty object - we don't need mock any functions in tests here */
-      {}
-    )
-  }
-})
+import { toClientNetwork } from './utils'
 
 describe('services/utils/', () => {
-  let mockClient: Client
-  beforeEach(() => {
-    mockClient = new Client({})
-  })
-
-  describe('getClientStateForViews (Binance)', () => {
-    it('returns true if a client has been created', () => {
-      const state: ClientState<Client> = RD.success(mockClient)
-      const result = getClientStateForViews<Client>(state)
-      expect(result).toEqual('ready')
-    })
-    it('returns false if no client has been created', () => {
-      const result = getClientStateForViews<Client>(RD.initial)
-      expect(result).toEqual('notready')
-    })
-    it('returns false if any errors occur', () => {
-      const state: ClientState<Client> = RD.failure(Error('any error'))
-      const result = getClientStateForViews(state)
-      expect(result).toEqual('error')
-    })
-  })
-
   describe('getClientNetwork', () => {
     it('for testnet', () => {
       expect(toClientNetwork('testnet')).toEqual('testnet')

--- a/src/renderer/services/clients/utils.ts
+++ b/src/renderer/services/clients/utils.ts
@@ -1,22 +1,6 @@
-import * as RD from '@devexperts/remote-data-ts'
 import * as Client from '@xchainjs/xchain-client'
-import * as FP from 'fp-ts/lib/function'
 
 import { Network } from '../../../shared/api/types'
-import { ClientStateForViews, ClientState } from './types'
-
-// TODO (@veado) Remove view states
-export const getClientStateForViews = <C>(clientState: ClientState<C>): ClientStateForViews =>
-  FP.pipe(
-    clientState,
-    RD.fold(
-      // None -> 'notready'
-      () => 'notready',
-      () => 'pending',
-      (_) => 'error',
-      (_) => 'ready'
-    )
-  )
 
 /**
  * Helper to type cast `Network` (ASGDX) -> `Client.Network` (xchain-client)

--- a/src/renderer/services/ethereum/common.ts
+++ b/src/renderer/services/ethereum/common.ts
@@ -5,7 +5,6 @@ import { Asset, assetToString } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { Observable } from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../shared/api/types'
@@ -13,8 +12,7 @@ import { envOrDefault } from '../../helpers/envHelper'
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
 import { Address$, ExplorerUrl$, GetExplorerTxUrl$, GetExplorerAddressUrl$ } from '../clients/types'
-import { ClientStateForViews } from '../clients/types'
-import { toClientNetwork, getClientStateForViews } from '../clients/utils'
+import { toClientNetwork } from '../clients/utils'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { Client$, ClientState, ClientState$ } from './types'
@@ -72,12 +70,6 @@ const clientState$: ClientState$ = FP.pipe(
 )
 
 const client$: Client$ = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
-
-/**
- * Helper stream to provide "ready-to-go" state of latest `EthereumClient`, but w/o exposing the client
- * It's needed by views only.
- */
-const clientViewState$: Observable<ClientStateForViews> = clientState$.pipe(RxOp.map(getClientStateForViews))
 
 /**
  * Current `Address` depending on selected network
@@ -139,7 +131,6 @@ const getDecimal = async (asset: Asset, network: Network): Promise<number> => {
 export {
   client$,
   clientState$,
-  clientViewState$,
   address$,
   addressUI$,
   explorerUrl$,

--- a/src/renderer/services/ethereum/index.ts
+++ b/src/renderer/services/ethereum/index.ts
@@ -3,7 +3,7 @@ import { ETHChain } from '@xchainjs/xchain-util'
 import { reloadBalances, balances$, reloadBalances$, resetReloadBalances } from './balances'
 import {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   addressUI$,
   explorerUrl$,
@@ -32,7 +32,7 @@ const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadAppr
 
 export {
   client$,
-  clientViewState$,
+  clientState$,
   address$,
   addressUI$,
   reloadBalances,

--- a/src/renderer/services/litecoin/index.ts
+++ b/src/renderer/services/litecoin/index.ts
@@ -1,5 +1,13 @@
 import { reloadBalances, balances$, reloadBalances$, resetReloadBalances } from './balances'
-import { client$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ } from './common'
+import {
+  client$,
+  clientState$,
+  address$,
+  addressUI$,
+  explorerUrl$,
+  getExplorerTxUrl$,
+  getExplorerAddressUrl$
+} from './common'
 import { createFeesService } from './fees'
 import { createTransactionService } from './transaction'
 
@@ -7,10 +15,11 @@ const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$ } = createTran
 const { reloadFees, fees$, feesWithRates$, reloadFeesWithRates } = createFeesService(client$)
 
 export {
+  client$,
+  clientState$,
   address$,
   addressUI$,
   explorerUrl$,
-  client$,
   reloadBalances,
   balances$,
   reloadBalances$,

--- a/src/renderer/services/thorchain/index.ts
+++ b/src/renderer/services/thorchain/index.ts
@@ -1,7 +1,15 @@
 import { THORChain } from '@xchainjs/xchain-util'
 
 import { reloadBalances, balances$, reloadBalances$, resetReloadBalances } from './balances'
-import { client$, address$, addressUI$, explorerUrl$, getExplorerTxUrl$, getExplorerAddressUrl$ } from './common'
+import {
+  client$,
+  clientState$,
+  address$,
+  addressUI$,
+  explorerUrl$,
+  getExplorerTxUrl$,
+  getExplorerAddressUrl$
+} from './common'
 import { createFeesService } from './fees'
 import { createInteractService$ } from './interact'
 import {
@@ -19,10 +27,11 @@ const { reloadFees, fees$ } = createFeesService({ client$, chain: THORChain })
 const interact$ = createInteractService$(sendPoolTx$, txStatus$)
 
 export {
+  client$,
+  clientState$,
   address$,
   addressUI$,
   explorerUrl$,
-  client$,
   reloadBalances,
   reloadBalances$,
   resetReloadBalances,

--- a/src/renderer/services/wallet/keystore.ts
+++ b/src/renderer/services/wallet/keystore.ts
@@ -4,7 +4,7 @@ import { THORChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
-import { catchError, map, startWith, switchMap } from 'rxjs/operators'
+import * as RxOp from 'rxjs/operators'
 
 import { Network } from '../../../shared/api/types'
 import { truncateAddress } from '../../helpers/addressHelper'
@@ -40,10 +40,12 @@ export const removeKeystore = async () => {
 const importKeystore$ = (keystore: CryptoKeystore, password: string): ImportKeystoreLD => {
   return FP.pipe(
     Rx.from(decryptFromKeystore(keystore, password)),
-    switchMap((phrase) => addKeystore(phrase, password)),
-    map(RD.success),
-    catchError((error) => Rx.of(RD.failure(new Error(`Could not decrypt phrase from keystore: ${error}`)))),
-    startWith(RD.pending)
+    // delay to give UI some time to render
+    RxOp.delay(300),
+    RxOp.switchMap((phrase) => addKeystore(phrase, password)),
+    RxOp.map(RD.success),
+    RxOp.catchError((error) => Rx.of(RD.failure(new Error(`Could not decrypt phrase from keystore: ${error}`)))),
+    RxOp.startWith(RD.pending)
   )
 }
 
@@ -66,23 +68,25 @@ const exportKeystore = async (runeNativeAddress: string, network: Network) => {
 const loadKeystore$ = (): LoadKeystoreLD => {
   return FP.pipe(
     Rx.from(window.apiKeystore.load()),
-    map((keystore) => (keystore ? RD.success(keystore) : RD.initial)), // handle undeifined keystore in case when the user click cancel in openDialog
-    catchError((err) => Rx.of(RD.failure(err))),
-    startWith(RD.pending)
+    // delay to give UI some time to render
+    RxOp.delay(300),
+    RxOp.map((keystore) => (keystore ? RD.success(keystore) : RD.initial)), // handle undeifined keystore in case when the user click cancel in openDialog
+    RxOp.catchError((err) => Rx.of(RD.failure(err))),
+    RxOp.startWith(RD.pending)
   )
 }
 
 const addPhrase = async (state: KeystoreState, password: string) => {
   // make sure
   if (!hasImportedKeystore(state)) {
-    // TODO(@Veado) i18m
+    // TODO(@Veado) i18n
     return Promise.reject('Keystore has to be imported first')
   }
 
   // make sure file still exists
   const exists = await window.apiKeystore.exists()
   if (!exists) {
-    // TODO(@Veado) i18m
+    // TODO(@Veado) i18n
     return Promise.reject('Keystore has to be imported first')
   }
 
@@ -93,7 +97,7 @@ const addPhrase = async (state: KeystoreState, password: string) => {
     setKeystoreState(O.some(O.some({ phrase })))
     return Promise.resolve()
   } catch (error) {
-    // TODO(@Veado) i18m
+    // TODO(@Veado) i18n
     return Promise.reject(`Could not decrypt phrase from keystore: ${error}`)
   }
 }
@@ -108,11 +112,11 @@ const validatePassword$ = (password: string): ValidatePasswordLD =>
   password
     ? FP.pipe(
         Rx.from(window.apiKeystore.get()),
-        switchMap((keystore) => Rx.from(decryptFromKeystore(keystore, password))),
-        map(RD.success),
+        RxOp.switchMap((keystore) => Rx.from(decryptFromKeystore(keystore, password))),
+        RxOp.map(RD.success),
         liveData.map(() => undefined),
-        catchError((err) => Rx.of(RD.failure(err))),
-        startWith(RD.pending)
+        RxOp.catchError((err) => Rx.of(RD.failure(err))),
+        RxOp.startWith(RD.pending)
       )
     : Rx.of(RD.initial)
 

--- a/src/renderer/services/wallet/keystore.ts
+++ b/src/renderer/services/wallet/keystore.ts
@@ -19,7 +19,7 @@ const { get$: getKeystoreState$, set: setKeystoreState } = observableState<Keyst
 /**
  * Creates a keystore and saves it to disk
  */
-const addKeystore = async (phrase: Phrase, password: string) => {
+const addKeystore = async (phrase: Phrase, password: string): Promise<void> => {
   try {
     // remove previous keystore before adding a new one to trigger changes of `KeystoreState
     await keystoreService.removeKeystore()
@@ -41,8 +41,9 @@ const importKeystore$ = (keystore: CryptoKeystore, password: string): ImportKeys
   return FP.pipe(
     Rx.from(decryptFromKeystore(keystore, password)),
     // delay to give UI some time to render
-    RxOp.delay(300),
-    RxOp.switchMap((phrase) => addKeystore(phrase, password)),
+    RxOp.delay(200),
+    RxOp.switchMap((phrase) => Rx.from(addKeystore(phrase, password))),
+    RxOp.map((v) => v),
     RxOp.map(RD.success),
     RxOp.catchError((error) => Rx.of(RD.failure(new Error(`Could not decrypt phrase from keystore: ${error}`)))),
     RxOp.startWith(RD.pending)
@@ -69,8 +70,8 @@ const loadKeystore$ = (): LoadKeystoreLD => {
   return FP.pipe(
     Rx.from(window.apiKeystore.load()),
     // delay to give UI some time to render
-    RxOp.delay(300),
-    RxOp.map((keystore) => (keystore ? RD.success(keystore) : RD.initial)), // handle undeifined keystore in case when the user click cancel in openDialog
+    RxOp.delay(200),
+    RxOp.map((keystore) => (keystore ? RD.success(keystore) : RD.initial)), // handle undefined keystore in case when the user click cancel in openDialog
     RxOp.catchError((err) => Rx.of(RD.failure(err))),
     RxOp.startWith(RD.pending)
   )

--- a/src/renderer/views/app/AppView.style.tsx
+++ b/src/renderer/views/app/AppView.style.tsx
@@ -29,6 +29,12 @@ export const AppWrapper = styled.div`
     &-spin-dot-item {
       background-color: ${palette('primary', 0)};
     }
+    &-form-item-explain {
+      text-transform: uppercase;
+    }
+    &-form-item-explain-error {
+      color: ${palette('error', 0)};
+    }
   }
 `
 

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -117,13 +117,11 @@ export const WalletView: React.FC = (): JSX.Element => {
   const renderWalletRoute = useCallback(
     // Redirect if  an user has not a phrase imported or wallet has been locked
     ({ location }: { location: H.Location }) => {
-      console.log('renderWalletRoute:', keystore)
       // Special case: keystore can be `undefined` (see comment at its definition using `useObservableState`)
       if (keystore === undefined) {
         return React.Fragment
       }
 
-      console.log('renderWalletRoute hasImportedKeystore:', hasImportedKeystore(keystore))
       if (!hasImportedKeystore(keystore)) {
         return (
           <Redirect

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -117,11 +117,13 @@ export const WalletView: React.FC = (): JSX.Element => {
   const renderWalletRoute = useCallback(
     // Redirect if  an user has not a phrase imported or wallet has been locked
     ({ location }: { location: H.Location }) => {
+      console.log('renderWalletRoute:', keystore)
       // Special case: keystore can be `undefined` (see comment at its definition using `useObservableState`)
       if (keystore === undefined) {
         return React.Fragment
       }
 
+      console.log('renderWalletRoute hasImportedKeystore:', hasImportedKeystore(keystore))
       if (!hasImportedKeystore(keystore)) {
         return (
           <Redirect

--- a/src/renderer/views/wallet/importsView/ImportsView.tsx
+++ b/src/renderer/views/wallet/importsView/ImportsView.tsx
@@ -9,6 +9,7 @@ import { ImportKeystore } from '../../../components/wallet/keystore'
 import { ImportPhrase } from '../../../components/wallet/phrase/'
 import { useWalletContext } from '../../../contexts/WalletContext'
 import { useKeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
+import { useKeystoreRedirectAfterImport } from '../../../hooks/useKeystoreRedirectAfterImport'
 import * as walletRoutes from '../../../routes/wallet'
 import * as Styled from './ImportsView.style'
 
@@ -22,7 +23,9 @@ export const ImportsView: React.FC = (): JSX.Element => {
   const history = useHistory()
   const { keystoreService } = useWalletContext()
   const { importKeystore$, loadKeystore$, addKeystore } = keystoreService
-  const { clientStates, readyToRedirect } = useKeystoreClientStates()
+  const { clientStates } = useKeystoreClientStates()
+  // redirect to wallet assets view  whenever keystore have been imported and ALL clients are initialized
+  useKeystoreRedirectAfterImport()
 
   const [activeTab, setActiveTab] = useState(TabKey.KEYSTORE)
 
@@ -31,32 +34,25 @@ export const ImportsView: React.FC = (): JSX.Element => {
       {
         key: TabKey.KEYSTORE,
         label: (
-          <span onClick={() => history.push(walletRoutes.imports.keystore.template)}>
+          <span onClick={() => history.push(walletRoutes.imports.keystore.path())}>
             {intl.formatMessage({ id: 'common.keystore' })}
           </span>
         ),
         content: (
-          <ImportKeystore
-            loadKeystore$={loadKeystore$}
-            importKeystore$={importKeystore$}
-            clientStates={clientStates}
-            readyToRedirect={readyToRedirect}
-          />
+          <ImportKeystore loadKeystore$={loadKeystore$} importKeystore$={importKeystore$} clientStates={clientStates} />
         )
       },
       {
         key: TabKey.PHRASE,
         label: (
-          <span onClick={() => history.push(walletRoutes.imports.phrase.template)}>
+          <span onClick={() => history.push(walletRoutes.imports.phrase.path())}>
             {intl.formatMessage({ id: 'common.phrase' })}
           </span>
         ),
-        content: (
-          <ImportPhrase clientStates={clientStates} addKeystore={addKeystore} readyToRedirect={readyToRedirect} />
-        )
+        content: <ImportPhrase clientStates={clientStates} addKeystore={addKeystore} />
       }
     ],
-    [addKeystore, clientStates, history, importKeystore$, intl, loadKeystore$, readyToRedirect]
+    [addKeystore, clientStates, history, importKeystore$, intl, loadKeystore$]
   )
 
   /**


### PR DESCRIPTION
- [x] Remove `clientViewState$`
- [x] Remove `getClientStateForViews` helper
- [x] Introduce `useKeystoreClientStates`
- [x] Introduce `useKeystoreRedirectAfterImport`
- [x] Export `clientState$` from `services/{chain}/common`
- [x] Use same `Spin` component everywhere

As part of #1571