### PR TITLE
[Settings] Tweak app Settings UI 

### DIFF
--- a/src/renderer/components/wallet/settings/Settings.style.tsx
+++ b/src/renderer/components/wallet/settings/Settings.style.tsx
@@ -5,7 +5,6 @@ import { palette } from 'styled-theme'
 import { Label as UILabel } from '../../uielements/label'
 
 export const TitleWrapper = styled.div`
-  margin: 0px -8px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -38,12 +37,8 @@ export const Subtitle = styled(UILabel)`
 `
 
 export const Row = styled(A.Row)`
-  padding: 10px 30px;
   background-color: ${palette('background', 1)};
-
-  .ant-row {
-    margin: 0;
-  }
+  padding: 20px 0px 30px 40px;
 `
 
 export const Card = styled(A.Card)`

--- a/src/renderer/components/wallet/settings/Settings.tsx
+++ b/src/renderer/components/wallet/settings/Settings.tsx
@@ -27,7 +27,7 @@ export const Settings: React.FC<Props> = (props): JSX.Element => {
       </Row>
       <Styled.Row gutter={[16, 16]}>
         <Col sm={{ span: 24 }} lg={{ span: 12 }}>
-          <Row>
+          <Row style={{ paddingTop: 20 }}>
             <Col span={24}>
               <ClientSettingsView />
             </Col>

--- a/src/renderer/components/wallet/settings/Settings.tsx
+++ b/src/renderer/components/wallet/settings/Settings.tsx
@@ -25,13 +25,9 @@ export const Settings: React.FC<Props> = (props): JSX.Element => {
           <Styled.Divider />
         </Col>
       </Row>
-      <Styled.Row gutter={[16, 16]}>
-        <Col sm={{ span: 24 }} lg={{ span: 12 }}>
-          <Row style={{ paddingTop: 20 }}>
-            <Col span={24}>
-              <ClientSettingsView />
-            </Col>
-          </Row>
+      <Styled.Row>
+        <Col span={24}>
+          <ClientSettingsView />
         </Col>
       </Styled.Row>
     </>

--- a/src/renderer/components/wallet/settings/Settings.tsx
+++ b/src/renderer/components/wallet/settings/Settings.tsx
@@ -13,8 +13,7 @@ type Props = {
 
 export const Settings: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { selectedNetwork, ClientSettingsView } = props
+  const { ClientSettingsView } = props
 
   return (
     <>

--- a/src/renderer/components/wallet/settings/Settings.tsx
+++ b/src/renderer/components/wallet/settings/Settings.tsx
@@ -27,13 +27,11 @@ export const Settings: React.FC<Props> = (props): JSX.Element => {
       </Row>
       <Styled.Row gutter={[16, 16]}>
         <Col sm={{ span: 24 }} lg={{ span: 12 }}>
-          <Styled.Card>
-            <Row>
-              <Col span={24}>
-                <ClientSettingsView />
-              </Col>
-            </Row>
-          </Styled.Card>
+          <Row>
+            <Col span={24}>
+              <ClientSettingsView />
+            </Col>
+          </Row>
         </Col>
       </Styled.Row>
     </>

--- a/src/renderer/components/wallet/settings/Settings.tsx
+++ b/src/renderer/components/wallet/settings/Settings.tsx
@@ -27,7 +27,6 @@ export const Settings: React.FC<Props> = (props): JSX.Element => {
       </Row>
       <Styled.Row gutter={[16, 16]}>
         <Col sm={{ span: 24 }} lg={{ span: 12 }}>
-          <Styled.Subtitle>{intl.formatMessage({ id: 'setting.client' })}</Styled.Subtitle>
           <Styled.Card>
             <Row>
               <Col span={24}>


### PR DESCRIPTION
- [x] Remove Client title
- [x] Remove border
- [x] Adjust padding to be form elements aligned with title "Settings"
- [x] Adjust Settings container to have a width as same as parent "warning boxes"

Closes #1679