### PR TITLE
Resolve: [Wallet] Don't send swap transcactions to BNB accounts with flags > 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@thorchain/asgardex-util": "^0.9.1",
     "@thorchain/ledger-thorchain": "^0.1.0-alpha.1",
     "@types/electron-devtools-installer": "^2.2.0",
-    "@xchainjs/xchain-binance": "^5.2.6",
+    "@xchainjs/xchain-binance": "^5.3.0",
     "@xchainjs/xchain-bitcoin": "0.15.11",
     "@xchainjs/xchain-bitcoincash": "0.11.8",
     "@xchainjs/xchain-client": "^0.10.2",

--- a/src/renderer/components/swap/EditableAddress.stories.tsx
+++ b/src/renderer/components/swap/EditableAddress.stories.tsx
@@ -15,7 +15,7 @@ const defaultProps: EditableAddressProps = {
   onClickOpenAddress: () => console.log('open address in explorer'),
   onChangeAddress: () => console.log('address changed'),
   onChangeEditableMode: () => console.log('edit mode changed'),
-  addressValidator: (address: Address) => eqString.equals(address, bnbAddress)
+  addressValidator: (address: Address) => Promise.resolve(eqString.equals(address, bnbAddress))
 }
 export const StoryDefault: Story = () => <EditableAddress {...defaultProps} />
 StoryDefault.storyName = 'default'

--- a/src/renderer/components/swap/EditableAddress.tsx
+++ b/src/renderer/components/swap/EditableAddress.tsx
@@ -9,7 +9,7 @@ import { useIntl } from 'react-intl'
 
 import { Network } from '../../../shared/api/types'
 import { truncateAddress } from '../../helpers/addressHelper'
-import { LazyAddressValidation } from '../../services/clients'
+import { AddressValidationAsync } from '../../services/clients'
 import * as Styled from './EditableAddress.styles'
 
 export type EditableAddressProps = {
@@ -19,7 +19,7 @@ export type EditableAddressProps = {
   onClickOpenAddress: (address: Address) => void
   onChangeAddress: (address: Address) => void
   onChangeEditableMode: (editModeActive: boolean) => void
-  addressValidator: LazyAddressValidation
+  addressValidator: AddressValidationAsync
 }
 export const EditableAddress = ({
   asset,

--- a/src/renderer/components/swap/EditableAddress.tsx
+++ b/src/renderer/components/swap/EditableAddress.tsx
@@ -9,7 +9,7 @@ import { useIntl } from 'react-intl'
 
 import { Network } from '../../../shared/api/types'
 import { truncateAddress } from '../../helpers/addressHelper'
-import { AddressValidation } from '../../services/clients'
+import { LazyAddressValidation } from '../../services/clients'
 import * as Styled from './EditableAddress.styles'
 
 export type EditableAddressProps = {
@@ -19,7 +19,7 @@ export type EditableAddressProps = {
   onClickOpenAddress: (address: Address) => void
   onChangeAddress: (address: Address) => void
   onChangeEditableMode: (editModeActive: boolean) => void
-  addressValidator: AddressValidation
+  addressValidator: LazyAddressValidation
 }
 export const EditableAddress = ({
   asset,
@@ -43,7 +43,8 @@ export const EditableAddress = ({
       if (!value) {
         return Promise.reject(intl.formatMessage({ id: 'wallet.errors.address.empty' }))
       }
-      if (!addressValidator(value)) {
+      const valid = await addressValidator(value)
+      if (!valid) {
         return Promise.reject(intl.formatMessage({ id: 'wallet.errors.address.invalid' }))
       }
     },

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -107,7 +107,7 @@ const defaultProps: SwapProps = {
   isApprovedERC20Token$: () => Rx.of(RD.success(true)),
   importWalletHandler: () => console.log('import wallet'),
   clickAddressLinkHandler: () => console.log('handle click on address'),
-  addressValidator: () => true
+  addressValidator: () => Promise.resolve(true)
 }
 
 export const StoryDefault: Story = () => <Swap {...defaultProps} />

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -56,7 +56,7 @@ import {
   SwapFees,
   FeeRD
 } from '../../services/chain/types'
-import { AddressValidation } from '../../services/clients'
+import { LazyAddressValidation } from '../../services/clients'
 import { ApproveFeeHandler, ApproveParams, IsApprovedRD, LoadApproveFeeHandler } from '../../services/ethereum/types'
 import { PoolAssetDetail, PoolAssetDetails, PoolAddress, PoolsDataMap } from '../../services/midgard/types'
 import { MimirHalt } from '../../services/thorchain/types'
@@ -113,7 +113,7 @@ export type SwapProps = {
   haltedChains: Chain[]
   mimirHalt: MimirHalt
   clickAddressLinkHandler: (address: Address) => void
-  addressValidator: AddressValidation
+  addressValidator: LazyAddressValidation
 }
 
 export const Swap = ({

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -56,7 +56,7 @@ import {
   SwapFees,
   FeeRD
 } from '../../services/chain/types'
-import { LazyAddressValidation } from '../../services/clients'
+import { AddressValidationAsync } from '../../services/clients'
 import { ApproveFeeHandler, ApproveParams, IsApprovedRD, LoadApproveFeeHandler } from '../../services/ethereum/types'
 import { PoolAssetDetail, PoolAssetDetails, PoolAddress, PoolsDataMap } from '../../services/midgard/types'
 import { MimirHalt } from '../../services/thorchain/types'
@@ -113,7 +113,7 @@ export type SwapProps = {
   haltedChains: Chain[]
   mimirHalt: MimirHalt
   clickAddressLinkHandler: (address: Address) => void
-  addressValidator: LazyAddressValidation
+  addressValidator: AddressValidationAsync
 }
 
 export const Swap = ({

--- a/src/renderer/helpers/clientHelper.test.ts
+++ b/src/renderer/helpers/clientHelper.test.ts
@@ -1,0 +1,18 @@
+import { Client as BnbClient } from '@xchainjs/xchain-binance'
+import { Client as BtcClient } from '@xchainjs/xchain-bitcoin'
+
+import { MOCK_PHRASE } from '../../shared/mock/wallet'
+import { isBnbClient } from './clientHelper'
+
+describe('helpers/clientHelper', () => {
+  describe('isBnbClient', () => {
+    it('returns true for BNB client', () => {
+      const client = new BnbClient({ phrase: MOCK_PHRASE })
+      expect(isBnbClient(client)).toBeTruthy()
+    })
+    it('returns false for BTC client', () => {
+      const client = new BtcClient({ phrase: MOCK_PHRASE })
+      expect(isBnbClient(client)).toBeFalsy()
+    })
+  })
+})

--- a/src/renderer/helpers/clientHelper.ts
+++ b/src/renderer/helpers/clientHelper.ts
@@ -1,0 +1,6 @@
+import { Client as BnbClient } from '@xchainjs/xchain-binance'
+
+/**
+ * Check whether client is Bnb chain
+ */
+export const isBnbClient = (client: unknown): client is BnbClient => client instanceof BnbClient

--- a/src/renderer/hooks/useValidateAddress.ts
+++ b/src/renderer/hooks/useValidateAddress.ts
@@ -10,11 +10,11 @@ import * as RxOp from 'rxjs/operators'
 import { useChainContext } from '../contexts/ChainContext'
 import { isBnbClient } from '../helpers/clientHelper'
 import { eqChain } from '../helpers/fp/eq'
-import { AddressValidation, LazyAddressValidation } from '../services/clients'
+import { AddressValidation, AddressValidationAsync } from '../services/clients'
 
 export const useValidateAddress = (
   chain: Chain
-): { validateAddress: AddressValidation; validateSwapAddress: LazyAddressValidation } => {
+): { validateAddress: AddressValidation; validateSwapAddress: AddressValidationAsync } => {
   const { clientByChain$ } = useChainContext()
   const [oClient, chainUpdated] = useObservableState<O.Option<XChainClient>, Chain>(
     (chain$) =>

--- a/src/renderer/hooks/useValidateAddress.ts
+++ b/src/renderer/hooks/useValidateAddress.ts
@@ -52,7 +52,6 @@ export const useValidateAddress = (
               // See https://github.com/thorchain/asgardex-electron/issues/1611
               // and https://docs.binance.org/changelog.html#apiv1accountaddress
               const { flags } = await client.getAccount(address)
-              console.log('flags:', flags)
               return flags === 0
             } catch (e) {
               return false

--- a/src/renderer/hooks/useValidateAddress.ts
+++ b/src/renderer/hooks/useValidateAddress.ts
@@ -8,10 +8,13 @@ import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
 import { useChainContext } from '../contexts/ChainContext'
+import { isBnbClient } from '../helpers/clientHelper'
 import { eqChain } from '../helpers/fp/eq'
-import { AddressValidation } from '../services/clients'
+import { AddressValidation, LazyAddressValidation } from '../services/clients'
 
-export const useValidateAddress = (chain: Chain): AddressValidation => {
+export const useValidateAddress = (
+  chain: Chain
+): { validateAddress: AddressValidation; validateSwapAddress: LazyAddressValidation } => {
   const { clientByChain$ } = useChainContext()
   const [oClient, chainUpdated] = useObservableState<O.Option<XChainClient>, Chain>(
     (chain$) =>
@@ -37,6 +40,31 @@ export const useValidateAddress = (chain: Chain): AddressValidation => {
       ),
     [oClient]
   )
+  const validateSwapAddress = useCallback(
+    async (address: Address) =>
+      FP.pipe(
+        oClient,
+        O.map(async (client) => {
+          const valid = client.validateAddress(address)
+          if (valid && isBnbClient(client)) {
+            try {
+              // check BNB account and block if flag !== 0
+              // See https://github.com/thorchain/asgardex-electron/issues/1611
+              // and https://docs.binance.org/changelog.html#apiv1accountaddress
+              const { flags } = await client.getAccount(address)
+              console.log('flags:', flags)
+              return flags === 0
+            } catch (e) {
+              return false
+            }
+          }
+          return valid
+        }),
+        // In case client is not available (it should never happen), skip validation by returning always `true`
+        O.getOrElse<Promise<boolean>>(() => Promise.resolve(true))
+      ),
+    [oClient]
+  )
 
-  return validateAddress
+  return { validateAddress, validateSwapAddress }
 }

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -46,6 +46,7 @@ export type ExplorerUrl$ = Rx.Observable<O.Option<string>>
 export type OpenExplorerTxUrl = (txHash: string) => Promise<boolean>
 export type OpenAddressUrl = (address: Address) => Promise<boolean>
 export type AddressValidation = (address: Address) => boolean
+export type LazyAddressValidation = (address: Address) => Promise<boolean>
 
 export type Address$ = Rx.Observable<O.Option<Address>>
 

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -46,7 +46,7 @@ export type ExplorerUrl$ = Rx.Observable<O.Option<string>>
 export type OpenExplorerTxUrl = (txHash: string) => Promise<boolean>
 export type OpenAddressUrl = (address: Address) => Promise<boolean>
 export type AddressValidation = (address: Address) => boolean
-export type LazyAddressValidation = (address: Address) => Promise<boolean>
+export type AddressValidationAsync = (address: Address) => Promise<boolean>
 
 export type Address$ = Rx.Observable<O.Option<Address>>
 

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -208,7 +208,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
       ),
     [targetAssetRD]
   )
-  const addressValidator = useValidateAddress(targetAssetChain)
+  const { validateSwapAddress } = useValidateAddress(targetAssetChain)
   const openAddressUrl = useOpenAddressUrl(targetAssetChain)
 
   return (
@@ -258,7 +258,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
                   isApprovedERC20Token$={isApprovedERC20Token$}
                   importWalletHandler={importWalletHandler}
                   clickAddressLinkHandler={openAddressUrl}
-                  addressValidator={addressValidator}
+                  addressValidator={validateSwapAddress}
                 />
               )
             }

--- a/src/renderer/views/wallet/BondsView.tsx
+++ b/src/renderer/views/wallet/BondsView.tsx
@@ -17,7 +17,6 @@ import { useAppContext } from '../../contexts/AppContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useUserNodesContext } from '../../contexts/UserNodesContext'
 import { useValidateAddress } from '../../hooks/useValidateAddress'
-import { AddressValidation } from '../../services/clients'
 import { DEFAULT_NETWORK } from '../../services/const'
 import { NodeInfoLD, NodeDataRD } from '../../services/thorchain/types'
 
@@ -32,7 +31,7 @@ export const BondsView: React.FC = (): JSX.Element => {
 
   const oClient = useObservableState<O.Option<ThorchainClient>>(client$, O.none)
 
-  const validateAddress: AddressValidation = useValidateAddress(THORChain)
+  const { validateAddress } = useValidateAddress(THORChain)
 
   const goToExplorerNodeAddress = useCallback(
     (address: Address) =>

--- a/src/renderer/views/wallet/Interact/BondView.tsx
+++ b/src/renderer/views/wallet/Interact/BondView.tsx
@@ -38,7 +38,7 @@ export const BondView: React.FC<Props> = ({ walletAddress, goToTransaction }) =>
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
 
-  const addressValidation = useValidateAddress(THORChain)
+  const { validateAddress } = useValidateAddress(THORChain)
 
   const [runeBalance] = useObservableState(
     () =>
@@ -85,10 +85,10 @@ export const BondView: React.FC<Props> = ({ walletAddress, goToTransaction }) =>
   return FP.pipe(
     interactState.txRD,
     RD.fold(
-      () => <Bond addressValidation={addressValidation} max={runeBalance} onFinish={bondTx} />,
+      () => <Bond addressValidation={validateAddress} max={runeBalance} onFinish={bondTx} />,
       () => (
         <Bond
-          addressValidation={addressValidation}
+          addressValidation={validateAddress}
           isLoading={true}
           max={runeBalance}
           onFinish={FP.identity}

--- a/src/renderer/views/wallet/Interact/LeaveView.tsx
+++ b/src/renderer/views/wallet/Interact/LeaveView.tsx
@@ -30,7 +30,7 @@ export const LeaveView: React.FC<Props> = ({ openExplorerTxUrl }) => {
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
 
-  const addressValidation = useValidateAddress(THORChain)
+  const { validateAddress } = useValidateAddress(THORChain)
 
   const leaveTx = useCallback(
     ({ memo }: { memo: string }) => {
@@ -62,10 +62,10 @@ export const LeaveView: React.FC<Props> = ({ openExplorerTxUrl }) => {
   return FP.pipe(
     interactState.txRD,
     RD.fold(
-      () => <Leave addressValidation={addressValidation} onFinish={leaveTx} />,
+      () => <Leave addressValidation={validateAddress} onFinish={leaveTx} />,
       () => (
         <Leave
-          addressValidation={addressValidation}
+          addressValidation={validateAddress}
           isLoading={true}
           onFinish={FP.identity}
           loadingProgress={stepLabel}

--- a/src/renderer/views/wallet/Interact/UnbondView.tsx
+++ b/src/renderer/views/wallet/Interact/UnbondView.tsx
@@ -30,7 +30,7 @@ export const UnbondView: React.FC<Props> = ({ openExplorerTxUrl: goToTransaction
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
 
-  const addressValidation = useValidateAddress(THORChain)
+  const { validateAddress } = useValidateAddress(THORChain)
 
   const unbondTx = useCallback(
     ({ memo }: { memo: string }) => {
@@ -61,10 +61,10 @@ export const UnbondView: React.FC<Props> = ({ openExplorerTxUrl: goToTransaction
   return FP.pipe(
     interactState.txRD,
     RD.fold(
-      () => <Unbond addressValidation={addressValidation} onFinish={unbondTx} />,
+      () => <Unbond addressValidation={validateAddress} onFinish={unbondTx} />,
       () => (
         <Unbond
-          addressValidation={addressValidation}
+          addressValidation={validateAddress}
           isLoading={true}
           onFinish={FP.identity}
           loadingProgress={stepLabel}

--- a/src/renderer/views/wallet/send/SendViewBCH.tsx
+++ b/src/renderer/views/wallet/send/SendViewBCH.tsx
@@ -58,7 +58,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
 
   const feesWithRatesLD: FeesWithRatesLD = useMemo(() => feesWithRates$(), [feesWithRates$])
   const feesWithRatesRD = useObservableState(feesWithRatesLD, RD.initial)
-  const addressValidation = useValidateAddress(BCHChain)
+  const { validateAddress } = useValidateAddress(BCHChain)
 
   const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
 
@@ -79,7 +79,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
         balance={walletBalance}
         isLoading={isLoading}
         onSubmit={onSend}
-        addressValidation={addressValidation}
+        addressValidation={validateAddress}
         feesWithRates={feesWithRatesRD}
         reloadFeesHandler={reloadFeesWithRates}
         validatePassword$={validatePassword$}
@@ -91,7 +91,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
       oBalances,
       isLoading,
       onSend,
-      addressValidation,
+      validateAddress,
       feesWithRatesRD,
       reloadFeesWithRates,
       validatePassword$,

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -68,7 +68,7 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
   /**
    * Address validation provided by BinanceClient
    */
-  const addressValidation = useValidateAddress(BNBChain)
+  const { validateAddress } = useValidateAddress(BNBChain)
 
   const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
 
@@ -90,7 +90,7 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
         balance={walletBalance}
         isLoading={isLoading}
         onSubmit={onSend}
-        addressValidation={addressValidation}
+        addressValidation={validateAddress}
         fee={feeRD}
         reloadFeesHandler={reloadFees}
         validatePassword$={validatePassword$}
@@ -98,7 +98,7 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
         network={network}
       />
     ),
-    [oBalances, isLoading, onSend, addressValidation, feeRD, reloadFees, validatePassword$, sendTxStatusMsg, network]
+    [oBalances, isLoading, onSend, validateAddress, feeRD, reloadFees, validatePassword$, sendTxStatusMsg, network]
   )
 
   const finishActionHandler = useCallback(() => {

--- a/src/renderer/views/wallet/send/SendViewBTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewBTC.tsx
@@ -59,7 +59,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
   const feesWithRatesLD: FeesWithRatesLD = useMemo(() => feesWithRates$(), [feesWithRates$])
   const feesWithRatesRD = useObservableState(feesWithRatesLD, RD.initial)
 
-  const addressValidation = useValidateAddress(BTCChain)
+  const { validateAddress } = useValidateAddress(BTCChain)
 
   const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
 
@@ -80,7 +80,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
         balance={walletBalance}
         isLoading={isLoading}
         onSubmit={onSend}
-        addressValidation={addressValidation}
+        addressValidation={validateAddress}
         feesWithRates={feesWithRatesRD}
         reloadFeesHandler={reloadFeesWithRates}
         validatePassword$={validatePassword$}
@@ -92,7 +92,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
       oBalances,
       isLoading,
       onSend,
-      addressValidation,
+      validateAddress,
       feesWithRatesRD,
       reloadFeesWithRates,
       validatePassword$,

--- a/src/renderer/views/wallet/send/SendViewLTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewLTC.tsx
@@ -59,7 +59,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
   const feesWithRatesLD: FeesWithRatesLD = useMemo(() => feesWithRates$(), [feesWithRates$])
   const feesWithRatesRD = useObservableState(feesWithRatesLD, RD.initial)
 
-  const addressValidation = useValidateAddress(LTCChain)
+  const { validateAddress } = useValidateAddress(LTCChain)
 
   const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
 
@@ -80,7 +80,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
         balance={walletBalance}
         isLoading={isLoading}
         onSubmit={onSend}
-        addressValidation={addressValidation}
+        addressValidation={validateAddress}
         feesWithRates={feesWithRatesRD}
         reloadFeesHandler={reloadFeesWithRates}
         validatePassword$={validatePassword$}
@@ -92,7 +92,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
       oBalances,
       isLoading,
       onSend,
-      addressValidation,
+      validateAddress,
       feesWithRatesRD,
       reloadFeesWithRates,
       validatePassword$,

--- a/src/renderer/views/wallet/send/SendViewTHOR.tsx
+++ b/src/renderer/views/wallet/send/SendViewTHOR.tsx
@@ -63,7 +63,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
     RD.initial
   )
 
-  const addressValidation = useValidateAddress(THORChain)
+  const { validateAddress } = useValidateAddress(THORChain)
 
   const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
 
@@ -85,7 +85,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
         balance={balance}
         isLoading={isLoading}
         onSubmit={onSend}
-        addressValidation={addressValidation}
+        addressValidation={validateAddress}
         fee={feeRD}
         reloadFeesHandler={reloadFees}
         validatePassword$={validatePassword$}
@@ -93,7 +93,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
         network={network}
       />
     ),
-    [oBalances, isLoading, onSend, addressValidation, feeRD, reloadFees, validatePassword$, sendTxStatusMsg, network]
+    [oBalances, isLoading, onSend, validateAddress, feeRD, reloadFees, validatePassword$, sendTxStatusMsg, network]
   )
   const finishActionHandler = useCallback(() => {
     resetSendTxState()

--- a/src/shared/mock/wallet.ts
+++ b/src/shared/mock/wallet.ts
@@ -13,3 +13,7 @@ export const mockValidatePassword$ = (password: string) =>
       Rx.iif(() => pw === '123', Rx.of(RD.success(undefined)), Rx.of(RD.failure(new Error('invalid password'))))
     )
   )
+
+// Note: This MOCK phrase is created by https://iancoleman.io/bip39/ and will NEVER been used in a real-world
+// Copied from https://github.com/xchainjs/xchainjs-lib/blob/c17c625b666c0113779db62db2f585c076be587d/packages/xchain-binance/__tests__/client.test.ts#L60
+export const MOCK_PHRASE = 'rural bright ball negative already grass good grant nation screen model pizza'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4730,10 +4730,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
   integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
 
-"@xchainjs/xchain-binance@^5.2.6":
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-binance/-/xchain-binance-5.2.6.tgz#1eb666688b3e7843902cd596d85ed90dde2e5230"
-  integrity sha512-daXmT34NdM5IzGGVOd4JNpWIiCP9ofADttHoN9ku+8fKxJuoLFdfWyJtsddkiDn3pkixrCQW8b2+wBhv0xvMmw==
+"@xchainjs/xchain-binance@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-binance/-/xchain-binance-5.3.0.tgz#c8f03b06bc8bf8703a873bffed65450e6b0c7c4b"
+  integrity sha512-5uVce0juqaA8uvslxSWSBBpt9lC1q8W/dIrEwlnpvX/GnIfMpXfuBzRq5cqp9MpFELsdlQWcGFXXkhMxTyuPKg==
 
 "@xchainjs/xchain-bitcoin@0.15.11":
   version "0.15.11"


### PR DESCRIPTION
- [x] Extend `useValidateAddress` to add `validateSwapAddress`
- [x] Add `isBinanceClient` type guard
- [x] Use latest `xchain-binance@0.5.3` 

Close #1611 