### PR TITLE
Fix reload of mimir$ in case of offline mode

### DIFF
--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -6,8 +6,8 @@ import { useObservableState } from 'observable-hooks'
 
 import { getClientUrl } from '../../../shared/thorchain/client'
 import { useMidgardContext } from '../../contexts/MidgardContext'
+import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
-import { useMimirHalt } from '../../hooks/useMimirHalt'
 import { useNetwork } from '../../hooks/useNetwork'
 import { usePricePools } from '../../hooks/usePricePools'
 import { useRunePrice } from '../../hooks/useRunePrice'
@@ -17,9 +17,10 @@ import { HeaderComponent } from './HeaderComponent'
 
 export const Header: React.FC = (): JSX.Element => {
   const { keystoreService } = useWalletContext()
-  const { mimirHaltRD } = useMimirHalt()
+  const { mimir$ } = useThorchainContext()
   const { lock } = keystoreService
   const keystore = useObservableState(keystoreService.keystore$, O.none)
+  const mimir = useObservableState(mimir$, RD.initial)
   const { service: midgardService } = useMidgardContext()
   const {
     pools: { setSelectedPricePoolAsset: setSelectedPricePool, selectedPricePoolAsset$, inboundAddressesShared$ },
@@ -53,7 +54,7 @@ export const Header: React.FC = (): JSX.Element => {
       reloadVolume24Price={reloadVolume24Price}
       selectedPricePoolAsset={oSelectedPricePoolAsset}
       inboundAddresses={inboundAddresses}
-      mimirHalt={mimirHaltRD}
+      mimir={mimir}
       midgardUrl={midgardUrlRD}
       thorchainUrl={thorchainUrl}
     />

--- a/src/renderer/components/header/HeaderComponent.stories.tsx
+++ b/src/renderer/components/header/HeaderComponent.stories.tsx
@@ -22,7 +22,7 @@ storiesOf('Components/Header', module).add('default', () => {
       setSelectedPricePool={() => console.log('setSelectedPricePool')}
       selectedPricePoolAsset={O.some(AssetRuneNative)}
       inboundAddresses={RD.initial}
-      mimirHalt={RD.initial}
+      mimir={RD.initial}
       midgardUrl={RD.initial}
       thorchainUrl={'thorchain.info'}
     />

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -21,7 +21,7 @@ import * as appRoutes from '../../routes/app'
 import * as poolsRoutes from '../../routes/pools'
 import * as walletRoutes from '../../routes/wallet'
 import { InboundAddressRD, PriceRD, SelectedPricePoolAsset } from '../../services/midgard/types'
-import { MimirHaltRD } from '../../services/thorchain/types'
+import { MimirRD } from '../../services/thorchain/types'
 import { KeystoreState } from '../../services/wallet/types'
 import { isLocked } from '../../services/wallet/util'
 import { PricePoolAsset, PricePoolAssets, PricePools } from '../../views/pools/Pools.types'
@@ -58,7 +58,7 @@ type Props = {
   reloadVolume24Price: FP.Lazy<void>
   selectedPricePoolAsset: SelectedPricePoolAsset
   inboundAddresses: InboundAddressRD
-  mimirHalt: MimirHaltRD
+  mimir: MimirRD
   midgardUrl: RD.RemoteData<Error, string>
   thorchainUrl: string
 }
@@ -70,7 +70,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
     pricePools: oPricePools,
     runePrice: runePriceRD,
     inboundAddresses: inboundAddressRD,
-    mimirHalt: mimirHaltRD,
+    mimir: mimirRD,
     reloadRunePrice,
     volume24Price: volume24PriceRD,
     reloadVolume24Price,
@@ -235,12 +235,12 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
       <HeaderNetStatus
         isDesktopView={isDesktopView}
         midgardStatus={inboundAddressRD}
-        mimirStatus={mimirHaltRD}
+        mimirStatus={mimirRD}
         midgardUrl={midgardUrl}
         thorchainUrl={thorchainUrl}
       />
     ),
-    [inboundAddressRD, isDesktopView, midgardUrl, mimirHaltRD, thorchainUrl]
+    [inboundAddressRD, isDesktopView, midgardUrl, mimirRD, thorchainUrl]
   )
 
   const iconStyle = { fontSize: '1.5em', marginRight: '20px' }

--- a/src/renderer/components/header/netstatus/HeaderNetStatus.tsx
+++ b/src/renderer/components/header/netstatus/HeaderNetStatus.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as DownIcon } from '../../../assets/svg/icon-down.svg'
 import { useAppContext } from '../../../contexts/AppContext'
 import { OnlineStatus } from '../../../services/app/types'
 import { InboundAddressRD } from '../../../services/midgard/types'
-import { MimirHaltRD } from '../../../services/thorchain/types'
+import { MimirRD } from '../../../services/thorchain/types'
 import { ConnectionStatus } from '../../shared/icons/ConnectionStatus'
 import { Menu } from '../../shared/menu/Menu'
 import { headerNetStatusSubheadline, headerNetStatusColor, HeaderNetStatusColor } from '../Header.util'
@@ -29,7 +29,7 @@ type MenuItem = {
 type Props = {
   isDesktopView: boolean
   midgardStatus: InboundAddressRD
-  mimirStatus: MimirHaltRD
+  mimirStatus: MimirRD
   midgardUrl: RD.RemoteData<Error, string>
   thorchainUrl: string
 }


### PR DESCRIPTION
This PR fixes following edge case:

An user went offline, reload pools,  an 404 Ajax error will be shown and the network status in the header goes to "not connected" (red icon). All correct so far. By going back to online and reloading pools again, network status in the header will still show API of Midgard or THORChain are not connected (yellow icon), but both APIs should be re-connected (green icon)

Part of #1734