### PR TITLE
Prepare release 0.4.1-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 0.4.14 (2021-09-15)
+# 0.4.1-alpha (2021-09-26)
+
+## Fix
+
+- Use latest `xchain-thorchain@0.19.1` to increase `gas` limit to `30m`
+
+# 0.4.0 (2021-09-15)
 
 ## Add
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asgardex",
   "productName": "ASGARDEX",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha",
   "description": "WALLET AND EXCHANGE CLIENT FOR THORCHAIN",
   "main": "index.js",
   "scripts": {
@@ -83,7 +83,7 @@
     "@xchainjs/xchain-crypto": "^0.2.6",
     "@xchainjs/xchain-ethereum": "^0.22.5",
     "@xchainjs/xchain-litecoin": "^0.6.10",
-    "@xchainjs/xchain-thorchain": "^0.19.0",
+    "@xchainjs/xchain-thorchain": "^0.19.1",
     "@xchainjs/xchain-util": "^0.3.1",
     "antd": "^4.16.13",
     "axios": "^0.21.4",

--- a/src/renderer/views/wallet/WalletSettingsView.tsx
+++ b/src/renderer/views/wallet/WalletSettingsView.tsx
@@ -130,7 +130,8 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     [intl, thorLedgerAddressRD]
   )
 
-  const bnbLedgerWalletAddress: WalletAddress = useMemo(
+  // TODO (@asgdx-team) Disable temporary for `v0.4.1-alpha`
+  const _bnbLedgerWalletAddress: WalletAddress = useMemo(
     () => ({
       type: 'ledger',
       address: FP.pipe(
@@ -151,7 +152,8 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     const ethWalletAccount$ = walletAccount$({ addressUI$: ethAddressUI$, chain: ETHChain })
     const bnbWalletAccount$ = walletAccount$({
       addressUI$: bnbAddressUI$,
-      ledgerAddress: bnbLedgerWalletAddress,
+      // TODO (@asgdx-team) Disable temporary for `v0.4.1-alpha`
+      // ledgerAddress: bnbLedgerWalletAddress,
       chain: BNBChain
     })
     const bchWalletAccount$ = walletAccount$({ addressUI$: bchAddressUI$, chain: BCHChain })
@@ -178,7 +180,8 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     btcAddressUI$,
     ethAddressUI$,
     bnbAddressUI$,
-    bnbLedgerWalletAddress,
+    // TODO (@asgdx-team) Disable temporary for `v0.4.1-alpha`
+    // bnbLedgerWalletAddress,
     bchAddressUI$,
     ltcAddressUI$
   ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,10 +4889,10 @@
   resolved "https://registry.yarnpkg.com/@xchainjs/xchain-litecoin/-/xchain-litecoin-0.6.10.tgz#13844b420619c2f1bedcee0ef208a1b3111a095c"
   integrity sha512-LTQVULn9chLGFAy4AfZvVeAko8PDPJ6lAB1xzTFXU2f54HjNJS6eL+DTNBtrt6HFGfL2MImaShmuFaHsIB1kJA==
 
-"@xchainjs/xchain-thorchain@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-thorchain/-/xchain-thorchain-0.19.0.tgz#d4cbfd77c8fdc58e524aeed3c3b433c107158728"
-  integrity sha512-e398QJHP8e0xC15xYIcay9OdjzD452YggjDPVSwIVPnr2i+RH5SX78o2Pwleg4LPgQ80ZxE22h4jMtmw+4m+Lw==
+"@xchainjs/xchain-thorchain@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@xchainjs/xchain-thorchain/-/xchain-thorchain-0.19.1.tgz#33ead51b6e950b64fc33ae32f8aeeda278346daa"
+  integrity sha512-DoVnSZtakYRmJQtW3CQ81viJCZ8/3aWyFzwXocNyOVPE/TDH7FvGWc7/XW0j9UkEQod2xBYHXg5M/VOBkSEcBw==
 
 "@xchainjs/xchain-util@^0.3.1":
   version "0.3.1"


### PR DESCRIPTION
This is a pre-release to fix withdraw issues we currently have on `chaosnet` only. If this pre-release goes well, another "official" release v0.4.1` will be follow shortly today.