### PR TITLE
[Swap] Fix viewblock url for ETH tx

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -755,6 +755,17 @@ export const Swap = ({
       (id) => intl.formatMessage({ id })
     )
 
+    const onClickViewTxHandler = (txHash: string) =>
+      FP.pipe(
+        oSourceAsset,
+        O.map(({ chain }) => chain),
+        // Note: As long as we link to `viewblock` to open tx details in a browser,
+        // `0x` needs to be removed from tx hash in case of ETH
+        // @see https://github.com/thorchain/asgardex-electron/issues/1787#issuecomment-931934508
+        O.map((chain) => (isEthChain(chain) ? txHash.replace(/0x/i, '') : txHash)),
+        O.fold(FP.constVoid, goToTransaction)
+      )
+
     return (
       <TxModal
         title={txModalTitle}
@@ -762,12 +773,21 @@ export const Swap = ({
         onFinish={onFinishTxModal}
         startTime={swapStartTime}
         txRD={swap}
-        extraResult={<ViewTxButton txHash={RD.toOption(swapTx)} onClick={goToTransaction} />}
+        extraResult={<ViewTxButton txHash={RD.toOption(swapTx)} onClick={onClickViewTxHandler} />}
         timerValue={timerValue}
         extra={extraTxModalContent}
       />
     )
-  }, [extraTxModalContent, goToTransaction, intl, onFinishTxModal, resetSwapState, swapStartTime, swapState])
+  }, [
+    extraTxModalContent,
+    goToTransaction,
+    intl,
+    oSourceAsset,
+    onFinishTxModal,
+    resetSwapState,
+    swapStartTime,
+    swapState
+  ])
 
   const closePasswordModal = useCallback(() => {
     setShowPasswordModal(false)

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { assetFromString, AssetRuneNative, bnOrZero, Chain, THORChain } from '@xchainjs/xchain-util'
+import { Asset, assetFromString, AssetRuneNative, bnOrZero, Chain, THORChain } from '@xchainjs/xchain-util'
 import { Spin } from 'antd'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
@@ -69,8 +69,8 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
   const poolsState = useObservableState(poolsState$, RD.initial)
 
-  const oRouteSource = useMemo(() => O.fromNullable(assetFromString(source.toUpperCase())), [source])
-  const oRouteTarget = useMemo(() => O.fromNullable(assetFromString(target.toUpperCase())), [target])
+  const oRouteSource: O.Option<Asset> = useMemo(() => O.fromNullable(assetFromString(source.toUpperCase())), [source])
+  const oRouteTarget: O.Option<Asset> = useMemo(() => O.fromNullable(assetFromString(target.toUpperCase())), [target])
 
   useEffect(() => {
     // Source asset is the asset of the pool we need to interact with
@@ -134,8 +134,12 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   )
   const targetWalletAddress = useObservableState(address$, O.none)
 
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
-
+  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
+    FP.pipe(
+      oRouteSource,
+      O.map(({ chain }) => chain)
+    )
+  )
   const renderError = useCallback(
     (e: Error) => (
       <ErrorView

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -134,12 +134,8 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   )
   const targetWalletAddress = useObservableState(address$, O.none)
 
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
-    FP.pipe(
-      oRouteSource,
-      O.map(({ chain }) => chain)
-    )
-  )
+  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+
   const renderError = useCallback(
     (e: Error) => (
       <ErrorView


### PR DESCRIPTION
- [x] Remove `0x` from tx hash in case of ETH - needed to show tx at `viewblock`

Fix #1787 