### PR TITLE
Refactor PoolHistoryTable to prepare layout changes

### DIFF
--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
@@ -9,6 +9,7 @@ import { PoolActions } from '../../services/midgard/types'
 import { ErrorId } from '../../services/wallet/types'
 import { PoolActionsHistory } from './PoolActionsHistory'
 import { Filter } from './types'
+import { WalletPoolActionsHistoryHeader } from './WalletPoolActionsHistoryHeader'
 
 const actions: PoolActions = [
   {
@@ -141,11 +142,21 @@ export const History: Story<{ dataStatus: RDStatus }> = ({ dataStatus }) => {
   const res = useMemo(() => getResults(dataStatus), [dataStatus])
   const [currentPage, setCurrentPage] = useState(1)
   const [filter, setFilter] = useState<Filter>('ALL')
-  return (
-    <PoolActionsHistory
+  const HeaderContent = (
+    <WalletPoolActionsHistoryHeader
       availableFilters={['ALL', 'SWITCH', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']}
       currentFilter={filter}
       setFilter={setFilter}
+      openViewblockUrl={() => {
+        console.log('open viewblock')
+        return Promise.resolve(true)
+      }}
+    />
+  )
+
+  return (
+    <PoolActionsHistory
+      headerContent={HeaderContent}
       openExplorerTxUrl={(txHash: TxHash) => {
         console.log(`Open explorer - tx hash ${txHash}`)
         return Promise.resolve(true)

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.styles.ts
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.styles.ts
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
+import { media } from '../../helpers/styleHelper'
+import { ExternalLinkIcon as ExternalLinkIconUI } from '../uielements/common/Common.styles'
+import { Headline as HeadlineUI } from '../uielements/headline'
+
 export const DateContainer = styled.span`
   color: ${palette('text', 0)};
   margin-right: 5px;
@@ -8,4 +12,51 @@ export const DateContainer = styled.span`
   &:last-child {
     margin-right: 0;
   }
+`
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background-color: ${palette('background', 1)};
+
+  ${media.md`
+    flex-direction: row;
+`}
+`
+
+export const HeaderFilterContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+
+  ${media.md`
+    flex-direction: row;
+`}
+`
+
+export const HeaderLinkContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: cemter;
+  padding-top: 20px;
+  ${media.md`
+  padding-top: 0;
+  flex-grow: 1;
+  justify-content: right;
+`}
+`
+
+export const ExplorerLinkIcon = styled(ExternalLinkIconUI)`
+  margin-left: 10px;
+  svg {
+    color: inherit;
+  }
+`
+export const Headline = styled(HeadlineUI)`
+  /* TODO (@asgdx-team) Will be enabled with #1811 */
+  display: none;
+  width: auto;
 `

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.tsx
@@ -2,32 +2,64 @@ import React, { useEffect, useRef } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Grid } from 'antd'
-import * as FP from 'fp-ts/function'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 
-import { PoolActionsHistoryPage } from '../../services/midgard/types'
+import { OpenExplorerTxUrl } from '../../services/clients'
+import { PoolActionsHistoryPage, PoolActionsHistoryPageRD } from '../../services/midgard/types'
+import * as Styled from './PoolActionsHistory.styles'
 import { PoolActionsHistoryList } from './PoolActionsHistoryList'
-import { PoolActionsHistoryTable } from './PoolActionsHistoryTable'
-import { Props } from './types'
+import { PoolActionsHistoryTable, Props as PoolActionsHistoryTableProps } from './PoolActionsHistoryTable'
+
+type Props = {
+  headerContent?: React.ReactNode
+  currentPage: number
+  actionsPageRD: PoolActionsHistoryPageRD
+  prevActionsPage?: O.Option<PoolActionsHistoryPage>
+  openExplorerTxUrl: OpenExplorerTxUrl
+  changePaginationHandler: (page: number) => void
+  className?: string
+}
 
 export const PoolActionsHistory: React.FC<Props> = (props) => {
+  const {
+    headerContent: HeaderContent,
+    actionsPageRD,
+    currentPage,
+    prevActionsPage,
+    changePaginationHandler,
+    openExplorerTxUrl
+  } = props
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
   // store previous data of Txs to render these while reloading
   const previousTxs = useRef<O.Option<PoolActionsHistoryPage>>(O.none)
 
   useEffect(() => {
     FP.pipe(
-      props.actionsPageRD,
+      actionsPageRD,
       RD.map((data) => {
         previousTxs.current = O.some(data)
         return true
       })
     )
-  }, [props])
+  }, [actionsPageRD])
 
-  return isDesktopView ? (
-    <PoolActionsHistoryTable prevActionsPage={previousTxs.current} {...props} />
-  ) : (
-    <PoolActionsHistoryList prevActionsPage={previousTxs.current} {...props} />
+  const tableProps: PoolActionsHistoryTableProps = {
+    currentPage,
+    actionsPageRD,
+    prevActionsPage,
+    openExplorerTxUrl,
+    changePaginationHandler
+  }
+
+  return (
+    <>
+      {HeaderContent && <Styled.Header>{HeaderContent}</Styled.Header>}
+      {isDesktopView ? (
+        <PoolActionsHistoryTable prevActionsPage={previousTxs.current} {...tableProps} />
+      ) : (
+        <PoolActionsHistoryList prevActionsPage={previousTxs.current} {...tableProps} />
+      )}
+    </>
   )
 }

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.tsx
@@ -6,7 +6,8 @@ import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import { useIntl } from 'react-intl'
 
-import { TxType } from '../uielements/txType'
+import { getTxTypeI18n } from '../../helpers/actionsHelper'
+import { TxType as TxTypeUI } from '../uielements/txType'
 import * as Styled from './PoolActionsHistoryFilter.styles'
 import { Filter } from './types'
 
@@ -46,7 +47,7 @@ export const PoolActionsHistoryFilter: React.FC<Props> = ({
         {FP.pipe(
           availableFilters,
           A.map((filter) => {
-            const content = filter === 'ALL' ? allItemContent : <TxType type={filter} />
+            const content = filter === 'ALL' ? allItemContent : <TxTypeUI type={filter} />
             return (
               <Menu.Item key={filter} onClick={() => onFilterChanged(filter)}>
                 <Styled.FilterItem>{content}</Styled.FilterItem>
@@ -61,7 +62,8 @@ export const PoolActionsHistoryFilter: React.FC<Props> = ({
   return (
     <Dropdown overlay={menu} trigger={['click']} disabled={disabled}>
       <Styled.FilterButton className={className}>
-        {intl.formatMessage({ id: 'common.filter' })} <CaretDownOutlined />{' '}
+        {currentFilter === 'ALL' ? intl.formatMessage({ id: 'common.all' }) : getTxTypeI18n(currentFilter, intl)}{' '}
+        <CaretDownOutlined />{' '}
       </Styled.FilterButton>
     </Dropdown>
   )

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.styles.ts
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.styles.ts
@@ -7,13 +7,6 @@ import { palette } from 'styled-theme'
 import { PoolAction } from '../../services/midgard/types'
 import { Button as UIButton } from '../uielements/button'
 import { TxType as TxTypeUI } from '../uielements/txType'
-import { PoolActionsHistoryFilter } from './PoolActionsHistoryFilter'
-
-export const ActionsFilter = styled(PoolActionsHistoryFilter)`
-  align-self: flex-end;
-  margin-right: 20px;
-  margin-bottom: 10px;
-`
 
 export const List = styled(A.List)`
   background: ${palette('background', 0)};

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
@@ -4,14 +4,14 @@ import * as RD from '@devexperts/remote-data-ts'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 
-import { PoolAction, PoolActionsHistoryPage } from '../../services/midgard/types'
+import { OpenExplorerTxUrl } from '../../services/clients'
+import { PoolAction, PoolActionsHistoryPage, PoolActionsHistoryPageRD } from '../../services/midgard/types'
 import { ErrorView } from '../shared/error'
 import { Pagination } from '../uielements/pagination'
 import { TxDetail } from '../uielements/txDetail'
 import { DEFAULT_PAGE_SIZE } from './PoolActionsHistory.const'
 import * as H from './PoolActionsHistory.helper'
 import * as Styled from './PoolActionsHistoryList.styles'
-import { Props } from './types'
 
 const renderItem = (goToTx: (txId: string) => void) => (action: PoolAction) => {
   const date = H.renderDate(action.date)
@@ -41,16 +41,22 @@ const renderItem = (goToTx: (txId: string) => void) => (action: PoolAction) => {
   )
 }
 
+type Props = {
+  currentPage: number
+  actionsPageRD: PoolActionsHistoryPageRD
+  prevActionsPage?: O.Option<PoolActionsHistoryPage>
+  openExplorerTxUrl: OpenExplorerTxUrl
+  changePaginationHandler: (page: number) => void
+  className?: string
+}
+
 export const PoolActionsHistoryList: React.FC<Props> = ({
   changePaginationHandler,
   actionsPageRD,
   prevActionsPage = O.none,
   openExplorerTxUrl: goToTx,
   currentPage,
-  currentFilter,
-  setFilter,
-  className,
-  availableFilters
+  className
 }) => {
   const renderListItem = useMemo(() => renderItem(goToTx), [goToTx])
   const renderList = useCallback(
@@ -75,12 +81,6 @@ export const PoolActionsHistoryList: React.FC<Props> = ({
 
   return (
     <div className={className}>
-      <Styled.ActionsFilter
-        availableFilters={availableFilters}
-        currentFilter={currentFilter}
-        onFilterChanged={setFilter}
-        disabled={!RD.isSuccess(actionsPageRD)}
-      />
       {FP.pipe(
         actionsPageRD,
         RD.fold(

--- a/src/renderer/components/poolActionsHistory/WalletPoolActionsHistoryHeader.tsx
+++ b/src/renderer/components/poolActionsHistory/WalletPoolActionsHistoryHeader.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import * as Styled from './PoolActionsHistory.styles'
+import { PoolActionsHistoryFilter } from './PoolActionsHistoryFilter'
+import { Filter } from './types'
+
+export type Props = {
+  availableFilters: Filter[]
+  currentFilter: Filter
+  setFilter: (filter: Filter) => void
+  openViewblockUrl: () => Promise<boolean>
+  disabled?: boolean
+}
+
+export const WalletPoolActionsHistoryHeader: React.FC<Props> = (props) => {
+  const { availableFilters, currentFilter, setFilter, openViewblockUrl, disabled = false } = props
+
+  return (
+    <>
+      <Styled.HeaderFilterContainer>
+        <PoolActionsHistoryFilter
+          availableFilters={availableFilters}
+          currentFilter={currentFilter}
+          onFilterChanged={setFilter}
+          disabled={disabled}
+        />
+        {/*
+        TODO (@asgdx-team) Will be implemented after #1810
+        <SelectAccountAddressComponent />
+        */}
+      </Styled.HeaderFilterContainer>
+      <Styled.HeaderLinkContainer>
+        <Styled.Headline onClick={openViewblockUrl}>
+          viewblock <Styled.ExplorerLinkIcon />
+        </Styled.Headline>
+      </Styled.HeaderLinkContainer>
+    </>
+  )
+}

--- a/src/renderer/components/poolActionsHistory/types.ts
+++ b/src/renderer/components/poolActionsHistory/types.ts
@@ -1,18 +1,3 @@
-import * as O from 'fp-ts/Option'
-
-import { OpenExplorerTxUrl } from '../../services/clients'
-import { PoolActionsHistoryPage, PoolActionsHistoryPageRD, TxType } from '../../services/midgard/types'
+import { TxType } from '../../services/midgard/types'
 
 export type Filter = TxType | 'ALL'
-
-export type Props = {
-  currentPage: number
-  actionsPageRD: PoolActionsHistoryPageRD
-  prevActionsPage?: O.Option<PoolActionsHistoryPage>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  changePaginationHandler: (page: number) => void
-  currentFilter: Filter
-  setFilter: (filter: Filter) => void
-  className?: string
-  availableFilters: Filter[]
-}

--- a/src/renderer/components/uielements/txType/TxType.tsx
+++ b/src/renderer/components/uielements/txType/TxType.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { useIntl } from 'react-intl'
 
@@ -7,7 +7,7 @@ import { ReactComponent as RefundIcon } from '../../../assets/svg/tx-refund.svg'
 import { ReactComponent as DepositIcon } from '../../../assets/svg/tx-stake.svg'
 import { ReactComponent as SwapIcon } from '../../../assets/svg/tx-swap.svg'
 import { ReactComponent as WithdrawIcon } from '../../../assets/svg/tx-withdraw.svg'
-import { CommonMessageKey } from '../../../i18n/types'
+import { getTxTypeI18n } from '../../../helpers/actionsHelper'
 import { TxType as MidgardTxType } from '../../../services/midgard/types'
 import * as Styled from './TxType.styles'
 
@@ -35,31 +35,13 @@ const getIcon = (type: MidgardTxType) => {
   }
 }
 
-const getTypeI18nKey = (type: MidgardTxType): CommonMessageKey | undefined => {
-  switch (type) {
-    case 'DEPOSIT':
-      return 'common.tx.type.deposit'
-    case 'WITHDRAW':
-      return 'common.tx.type.withdraw'
-    case 'SWAP':
-      return 'common.tx.type.swap'
-    case 'DONATE':
-      return 'common.tx.type.donate'
-    case 'REFUND':
-      return 'common.tx.type.refund'
-    case 'SWITCH':
-      return 'common.tx.type.upgrade'
-  }
-}
 export const TxType: React.FC<Props> = ({ type, className }) => {
   const intl = useIntl()
-
-  const typeKey = useMemo(() => getTypeI18nKey(type), [type])
 
   return (
     <Styled.Container className={className}>
       <Styled.IconContainer>{getIcon(type)}</Styled.IconContainer>
-      <Styled.Label>{typeKey ? intl.formatMessage({ id: typeKey }) : type}</Styled.Label>
+      <Styled.Label>{getTxTypeI18n(type, intl)}</Styled.Label>
     </Styled.Container>
   )
 }

--- a/src/renderer/helpers/actionsHelper.ts
+++ b/src/renderer/helpers/actionsHelper.ts
@@ -1,0 +1,26 @@
+import { IntlShape } from 'react-intl'
+
+import { CommonMessageKey } from '../i18n/types'
+import { TxType as MidgardTxType } from '../services/midgard/types'
+
+const getTxTypeI18nKey = (type: MidgardTxType): CommonMessageKey | undefined => {
+  switch (type) {
+    case 'DEPOSIT':
+      return 'common.tx.type.deposit'
+    case 'WITHDRAW':
+      return 'common.tx.type.withdraw'
+    case 'SWAP':
+      return 'common.tx.type.swap'
+    case 'DONATE':
+      return 'common.tx.type.donate'
+    case 'REFUND':
+      return 'common.tx.type.refund'
+    case 'SWITCH':
+      return 'common.tx.type.upgrade'
+  }
+}
+
+export const getTxTypeI18n = (type: MidgardTxType, intl: IntlShape): string => {
+  const id = getTxTypeI18nKey(type)
+  return id ? intl.formatMessage({ id }) : type
+}

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -9,6 +9,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { PoolActionsHistory } from '../../components/poolActionsHistory'
 import { DEFAULT_PAGE_SIZE } from '../../components/poolActionsHistory/PoolActionsHistory.const'
+import { PoolActionsHistoryFilter } from '../../components/poolActionsHistory/PoolActionsHistoryFilter'
 import { Filter } from '../../components/poolActionsHistory/types'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { liveData } from '../../helpers/rx/liveData'
@@ -87,19 +88,31 @@ export const PoolHistory: React.FC<Props> = ({ className, poolAsset }) => {
     [loadActionsHistory]
   )
 
+  const currentFilter = requestParams.type || 'ALL'
+
   const openRuneExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+
+  const headerContent = useMemo(
+    () => (
+      <PoolActionsHistoryFilter
+        availableFilters={HISTORY_FILTERS}
+        currentFilter={currentFilter}
+        onFilterChanged={setFilter}
+        disabled={!RD.isSuccess(historyPage)}
+      />
+    ),
+    [currentFilter, historyPage, setFilter]
+  )
 
   return (
     <PoolActionsHistory
       className={className}
+      headerContent={headerContent}
       currentPage={requestParams.page + 1}
       actionsPageRD={historyPage}
       prevActionsPage={prevActionsPage.current}
       openExplorerTxUrl={openRuneExplorerTxUrl}
       changePaginationHandler={setCurrentPage}
-      currentFilter={requestParams.type || 'ALL'}
-      availableFilters={HISTORY_FILTERS}
-      setFilter={setFilter}
     />
   )
 }

--- a/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
+++ b/src/renderer/views/wallet/PoolActionsHistory/PoolActionsHistoryView.tsx
@@ -13,6 +13,7 @@ import * as RxOp from 'rxjs/operators'
 import { PoolActionsHistory } from '../../../components/poolActionsHistory'
 import { DEFAULT_PAGE_SIZE } from '../../../components/poolActionsHistory/PoolActionsHistory.const'
 import { Filter } from '../../../components/poolActionsHistory/types'
+import { WalletPoolActionsHistoryHeader } from '../../../components/poolActionsHistory/WalletPoolActionsHistoryHeader'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useMidgardContext } from '../../../contexts/MidgardContext'
 import { liveData } from '../../../helpers/rx/liveData'
@@ -99,17 +100,38 @@ export const PoolActionsHistoryView: React.FC<{ className?: string }> = ({ class
     [loadActionsHistory]
   )
 
+  const currentFilter = requestParams.type || 'ALL'
+
+  const openViewblockUrlHandler = useCallback(async () => {
+    // TODO (@asgdx-team): As part of #1811 - Get viewblock url using THORChain client
+    // const addressUrl = client.getExplorerAddressUrl(address)
+    // const addressUrl = url&txsType={type}
+    console.log('currentFilter', currentFilter)
+    return true
+  }, [currentFilter])
+
+  const headerContent = useMemo(
+    () => (
+      <WalletPoolActionsHistoryHeader
+        availableFilters={HISTORY_FILTERS}
+        currentFilter={currentFilter}
+        setFilter={setFilter}
+        openViewblockUrl={openViewblockUrlHandler}
+        disabled={!RD.isSuccess(historyPage)}
+      />
+    ),
+    [currentFilter, historyPage, openViewblockUrlHandler, setFilter]
+  )
+
   return (
     <PoolActionsHistory
+      headerContent={headerContent}
       className={className}
       currentPage={requestParams.page + 1}
       actionsPageRD={historyPage}
       prevActionsPage={prevActionsPage.current}
       openExplorerTxUrl={openExplorerTxUrl}
       changePaginationHandler={setCurrentPage}
-      currentFilter={requestParams.type || 'ALL'}
-      setFilter={setFilter}
-      availableFilters={HISTORY_FILTERS}
     />
   )
 }


### PR DESCRIPTION
- [x] Refactor of view + component structures to prepare changes we will add in #1811
- [x] Hiding header of `PoolActionsHistoryView`
- [x] Show selected `Filter` in header of dropdown 
- [x] Extract `getTxTypeI18n` to `actionsHelper`

There are just small visible changes for users with this PR, changes are mainly for view / component structure.

https://user-images.githubusercontent.com/61792675/135659888-03d12945-fd36-468e-b44b-119f534bfa93.mp4


Part of #1811