### PR TITLE
Quick fix: Move file helpers into `main`

### DIFF
--- a/scripts/generateERC20Whitelist.ts
+++ b/scripts/generateERC20Whitelist.ts
@@ -13,7 +13,7 @@ import * as T from 'fp-ts/Task'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 
-import { writeFile, readFile } from '../src/renderer/helpers/fpHelpers'
+import { writeFile, readFile } from '../src/main/utils/file'
 import { ERC20Whitelist, erc20WhitelistIO } from '../src/renderer/services/thorchain/types'
 
 const WHITELIST_URL =

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -1,0 +1,25 @@
+import * as TE from 'fp-ts/lib/TaskEither'
+import * as fs from 'fs-extra'
+
+/**
+ * Reads a file.
+ *
+ * Borrowed from https://github.com/gcanti/fp-ts-node/blob/master/src/fs.ts
+ * Note: `fp-ts-node` is not available on npm
+ */
+export const readFile: (path: string, encoding: string) => TE.TaskEither<Error, string> = TE.taskify<
+  string,
+  string,
+  Error,
+  string
+>(fs.readFile)
+
+/**
+ * Writes a file.
+ * If the parent directory does not exist, it will be created.
+ *
+ * Borrowed from https://github.com/gcanti/fp-ts-node/blob/master/src/fs.ts
+ * Note: `fp-ts-node` is not available on npm
+ */
+export const writeFile: (path: string, data: string, options?: fs.WriteFileOptions) => TE.TaskEither<Error, void> =
+  TE.taskify<string, string, fs.WriteFileOptions | undefined, Error, void>(fs.outputFile)

--- a/src/renderer/helpers/fpHelpers.ts
+++ b/src/renderer/helpers/fpHelpers.ts
@@ -3,8 +3,6 @@ import { Lazy } from 'fp-ts/function'
 import { sequenceS, sequenceT } from 'fp-ts/lib/Apply'
 import * as A from 'fp-ts/lib/Array'
 import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as fs from 'fs-extra'
 
 /**
  * Sequence
@@ -33,26 +31,3 @@ export const rdAltOnPending =
     }
     return rd
   }
-
-/**
- * Reads a file.
- *
- * Borrowed from https://github.com/gcanti/fp-ts-node/blob/master/src/fs.ts
- * Note: `fp-ts-node` is not available on npm
- */
-export const readFile: (path: string, encoding: string) => TE.TaskEither<Error, string> = TE.taskify<
-  string,
-  string,
-  Error,
-  string
->(fs.readFile)
-
-/**
- * Writes a file.
- * If the parent directory does not exist, it will be created.
- *
- * Borrowed from https://github.com/gcanti/fp-ts-node/blob/master/src/fs.ts
- * Note: `fp-ts-node` is not available on npm
- */
-export const writeFile: (path: string, data: string, options?: fs.WriteFileOptions) => TE.TaskEither<Error, void> =
-  TE.taskify<string, string, fs.WriteFileOptions | undefined, Error, void>(fs.outputFile)


### PR DESCRIPTION
`fs-extra` can't run in `renderer`.

Part of #1815