### PR TITLE
Use latest electron version with certificate related fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "chalk": "^4.1.2",
     "concurrently": "^6.2.2",
     "cross-env": "^7.0.3",
-    "electron": "^15.0.0",
+    "electron": "^15.1.1",
     "electron-builder": "^22.11.7",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8916,10 +8916,10 @@ electron-updater@^4.3.9:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.0.0.tgz#b1b6244b1cffddf348c27c54b1310b3a3680246e"
-  integrity sha512-LlBjN5nCJoC7EDrgfDQwEGSGSAo/o08nSP5uJxN2m+ZtNA69SxpnWv4yPgo1K08X/iQPoGhoZu6C8LYYlk1Dtg==
+electron@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.1.1.tgz#cd3eaaaf62aa30c0f2d28ba28c5b62bd5ee2c325"
+  integrity sha512-ogVGNWL38KegiqAhUdgjWoKPOufTqDb+cNIqQF/WpVxgauNjzXEk/RNEk7qlw946B/g2dHpzpHeUhi+D/4EcIg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
> Fixed Let's Encrypt DST Root CA X3 certificate expiration.

^  via https://github.com/electron/electron/pull/31218 - see [Release notes (`Fixes`) for Electron@15.1.0](https://github.com/electron/electron/releases/tag/v15.1.0)

Close #1822