### PR TITLE
Improve WalletHistory

### DIFF
--- a/src/renderer/components/AccountAddressSelector/AccountAddressSelector.styles.tsx
+++ b/src/renderer/components/AccountAddressSelector/AccountAddressSelector.styles.tsx
@@ -6,14 +6,14 @@ import { palette } from 'styled-theme'
 import { AssetIcon as AssetIconUI } from '../uielements/assets/assetIcon/AssetIcon'
 import { WalletTypeLabel as WalletTypeLabelUI } from '../uielements/common/Common.styles'
 
-export const DropdownSelectorWrapper = styled.div`
+export const DropdownSelectorWrapper = styled.div<{ disabled: boolean }>`
   display: flex;
   flex-direction: row;
   align-items: center;
   border: 1px solid ${palette('primary', 0)};
   border-radius: 5px;
   padding-left: 7px;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 
   & .anticon-caret-down {
     transition: transform 0.3s;
@@ -52,14 +52,16 @@ export const CaretDownOutlined = styled(CaretDownOutlinedUI)`
 
 export const Menu = styled(MenuUI)`
   background-color: ${palette('background', 0)};
+
   & .ant-dropdown-menu-item {
     &:hover,
     &:focus,
     &:active {
-      background: ${palette('background', 0)};
+      background: ${palette('background', 2)};
     }
+
     &-selected {
-      background: ${palette('gray', 1)};
+      background: ${palette('background', 2)};
     }
   }
 `
@@ -75,7 +77,12 @@ export const MenuItemWrapper = styled.div<{ highlighted: boolean }>`
   align-items: center;
   font-size: 14px;
   padding: 5px;
-  background-color: ${(props) => (props.highlighted ? palette('background', 2) : palette('background', 0))};
+  background-color: ${(props) => (props.highlighted ? palette('background', 2) : 'inherit')};
+
+  &:hover,
+  &:active {
+    background-color: palette('background', 2);
+  }
 `
 
 export const AssetIcon = styled(AssetIconUI)`

--- a/src/renderer/components/AccountAddressSelector/AccountAddressSelector.tsx
+++ b/src/renderer/components/AccountAddressSelector/AccountAddressSelector.tsx
@@ -24,6 +24,7 @@ type Props = {
   size?: IconSize
   network: Network
   onChangeAddress?: (address: WalletAddress) => void
+  disabled?: boolean
 }
 
 export const AccountAddressSelector: React.FC<Props> = (props) => {
@@ -32,7 +33,8 @@ export const AccountAddressSelector: React.FC<Props> = (props) => {
     addresses,
     size = 'small',
     network,
-    onChangeAddress = FP.constVoid
+    onChangeAddress = FP.constVoid,
+    disabled = false
   } = props
 
   const intl = useIntl()
@@ -86,8 +88,8 @@ export const AccountAddressSelector: React.FC<Props> = (props) => {
   )
 
   return (
-    <Dropdown overlay={menu} trigger={['click']}>
-      <Styled.DropdownSelectorWrapper>{renderSelectedAddress}</Styled.DropdownSelectorWrapper>
+    <Dropdown overlay={menu} trigger={['click']} disabled={disabled}>
+      <Styled.DropdownSelectorWrapper disabled={disabled}>{renderSelectedAddress}</Styled.DropdownSelectorWrapper>
     </Dropdown>
   )
 }

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.styles.ts
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryFilter.styles.ts
@@ -16,17 +16,17 @@ export const Menu = styled(A.Menu)`
     }
 
     &-selected {
-      background: ${palette('gray', 1)};
+      background: ${palette('background', 2)};
     }
   }
 `
 
 export const FilterButton = styled(Button).attrs({ typevalue: 'outline' })`
   & .anticon-caret-down {
-    transition: transform 0.3s;
-    transform: translateY(0px);
     width: 14px;
     height: 14px;
+    transition: transform 0.3s;
+    transform: translateY(0px);
     position: absolute !important;
     right: 7px;
 

--- a/src/renderer/components/poolActionsHistory/WalletPoolActionsHistoryHeader.tsx
+++ b/src/renderer/components/poolActionsHistory/WalletPoolActionsHistoryHeader.tsx
@@ -26,7 +26,7 @@ export const WalletPoolActionsHistoryHeader: React.FC<Props> = (props) => {
   const {
     network,
     addresses,
-    selectedAddress,
+    selectedAddress: oSelectedAddress,
     availableFilters,
     currentFilter,
     setFilter,
@@ -47,8 +47,9 @@ export const WalletPoolActionsHistoryHeader: React.FC<Props> = (props) => {
         <AccountAddressSelector
           addresses={addresses}
           network={network}
-          selectedAddress={selectedAddress}
+          selectedAddress={oSelectedAddress}
           onChangeAddress={onWalletAddressChanged}
+          disabled={disabled}
         />
       </Styled.FilterContainer>
       <Styled.LinkContainer>

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
 
-import * as RD from '@devexperts/remote-data-ts'
 import { Row } from 'antd'
 import * as H from 'history'
 import { useObservableState } from 'observable-hooks'
@@ -11,7 +10,7 @@ import { AssetsNav } from '../../components/wallet/assets'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
-import { useMidgardHistoryActions } from '../../hooks/useMidgardHistoryActions'
+import { triggerStream } from '../../helpers/stateHelper'
 import { RedirectRouteState } from '../../routes/types'
 import * as walletRoutes from '../../routes/wallet'
 import { hasImportedKeystore, isLocked } from '../../services/wallet/util'
@@ -39,9 +38,7 @@ export const WalletView: React.FC = (): JSX.Element => {
   } = useMidgardContext()
   const { reloadNodesInfo } = useThorchainContext()
 
-  const historyActions = useMidgardHistoryActions(10)
-
-  const { historyPage: historyPageRD, reloadHistory } = historyActions
+  const reloadHistory = triggerStream()
 
   // Important note:
   // DON'T set `INITIAL_KEYSTORE_STATE` as default value
@@ -105,23 +102,14 @@ export const WalletView: React.FC = (): JSX.Element => {
             </Styled.WalletSettingsWrapper>
           </Route>
           <Route path={walletRoutes.history.template}>
-            {reloadButton(reloadHistory, RD.isPending(historyPageRD))}
+            {reloadButton(reloadHistory.trigger)}
             <AssetsNav />
-            <Styled.WalletHistoryView historyActions={historyActions} />
+            <Styled.WalletHistoryView reloadHistory={reloadHistory} />
           </Route>
         </Switch>
       </>
     ),
-    [
-      reloadButton,
-      reloadBalances,
-      reloadNodesInfo,
-      reloadHistory,
-      historyPageRD,
-      historyActions,
-      reloadCombineSharesByAddresses,
-      reloadAllPools
-    ]
+    [reloadButton, reloadBalances, reloadNodesInfo, reloadHistory, reloadCombineSharesByAddresses, reloadAllPools]
   )
 
   const renderWalletRoute = useCallback(

--- a/src/renderer/views/wallet/history/WalletHistoryView.tsx
+++ b/src/renderer/views/wallet/history/WalletHistoryView.tsx
@@ -18,24 +18,26 @@ import { useChainContext } from '../../../contexts/ChainContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
 import { eqString } from '../../../helpers/fp/eq'
 import { ordWalletAddressByChain } from '../../../helpers/fp/ord'
+import { TriggerStream } from '../../../helpers/stateHelper'
+import { useMidgardHistoryActions } from '../../../hooks/useMidgardHistoryActions'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenAddressUrl } from '../../../hooks/useOpenAddressUrl'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { ENABLED_CHAINS } from '../../../services/const'
-import { WalletHistoryActions } from './WalletHistoryView.types'
 
 const HISTORY_FILTERS: Filter[] = ['ALL', 'SWITCH', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']
 
 export type Props = {
   className?: string
-  historyActions: WalletHistoryActions
+  reloadHistory: TriggerStream
 }
-export const WalletHistoryView: React.FC<Props> = ({ className, historyActions }) => {
+export const WalletHistoryView: React.FC<Props> = ({ className, reloadHistory }) => {
   const { network } = useNetwork()
 
   const { addressByChain$ } = useChainContext()
 
-  const { requestParams, loadHistory, historyPage, prevHistoryPage, setFilter, setAddress, setPage } = historyActions
+  const { requestParams, loadHistory, historyPage, prevHistoryPage, setFilter, setAddress, setPage } =
+    useMidgardHistoryActions(10, reloadHistory)
 
   const openExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
 
@@ -100,7 +102,7 @@ export const WalletHistoryView: React.FC<Props> = ({ className, historyActions }
           )
         )
       ),
-    [addresses, requestParams]
+    [addresses, requestParams.addresses]
   )
 
   const openAddressUrl = useOpenAddressUrl(THORChain)

--- a/src/renderer/views/wallet/history/WalletHistoryView.types.tsx
+++ b/src/renderer/views/wallet/history/WalletHistoryView.types.tsx
@@ -1,6 +1,0 @@
-import { UseMidgardHistoryActions } from '../../../hooks/useMidgardHistoryActions'
-
-export type WalletHistoryActions = Pick<
-  UseMidgardHistoryActions,
-  'requestParams' | 'loadHistory' | 'historyPage' | 'prevHistoryPage' | 'setFilter' | 'setAddress' | 'setPage'
->

--- a/src/renderer/views/wallet/history/index.ts
+++ b/src/renderer/views/wallet/history/index.ts
@@ -1,2 +1,1 @@
 export * from './WalletHistoryView'
-export * from './WalletHistoryView.types'


### PR DESCRIPTION
- [x] `useMidgardHistoryActions` accepts optional `TriggerStream`. With that, one less (unneeded) request for `actions` endpoint we had before by entering `Wallet` (but not WalletHistory) 
- [x] Improve styles

Part of #1811