### PR TITLE
Quick fix: `wallettype` label in `InteractivView`

### DIFF
--- a/src/renderer/components/interact/Interact.tsx
+++ b/src/renderer/components/interact/Interact.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../shared/api/types'
+import { isLedgerWallet } from '../../../shared/utils/guard'
 import { WalletType } from '../../../shared/wallet/types'
 import * as Styled from './Interact.styles'
 
@@ -15,7 +16,14 @@ type Props = {
   customContent: JSX.Element
 }
 
-export const Interact: React.FC<Props> = ({ bondContent, unbondContent, leaveContent, customContent, network }) => {
+export const Interact: React.FC<Props> = ({
+  bondContent,
+  unbondContent,
+  leaveContent,
+  customContent,
+  network,
+  walletType
+}) => {
   const intl = useIntl()
 
   const tabs = useMemo(
@@ -69,7 +77,9 @@ export const Interact: React.FC<Props> = ({ bondContent, unbondContent, leaveCon
         <div>
           <Styled.HeaderTitleWrapper>
             <Styled.HeaderTitle>{intl.formatMessage({ id: 'deposit.interact.title' })}</Styled.HeaderTitle>
-            <Styled.WalletTypeLabel>{intl.formatMessage({ id: 'ledger.title' })}</Styled.WalletTypeLabel>
+            {isLedgerWallet(walletType) && (
+              <Styled.WalletTypeLabel>{intl.formatMessage({ id: 'ledger.title' })}</Styled.WalletTypeLabel>
+            )}
           </Styled.HeaderTitleWrapper>
           <Styled.HeaderSubtitle>{intl.formatMessage({ id: 'deposit.interact.subtitle' })}</Styled.HeaderSubtitle>
         </div>


### PR DESCRIPTION
Fix #1858