### PR TITLE
Update `AssetData|Menu|Select` components to show wallet type

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -228,6 +228,15 @@ export const Swap = ({
     [oWalletBalances, oSourceAsset]
   )
 
+  const oSourceAssetWT: O.Option<WalletType> = useMemo(
+    () =>
+      FP.pipe(
+        oSourceAssetWB,
+        O.map(({ walletType }) => walletType)
+      ),
+    [oSourceAssetWB]
+  )
+
   // User balance for source asset
   const sourceAssetAmount: BaseAmount = useMemo(
     () =>
@@ -1267,6 +1276,7 @@ export const Swap = ({
                   <Styled.AssetSelect
                     onSelect={setSourceAsset}
                     asset={asset}
+                    assetWalletType={O.toUndefined(oSourceAssetWT)}
                     balances={balancesToSwapFrom}
                     network={network}
                   />

--- a/src/renderer/components/uielements/assets/assetData/AssetData.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.stories.tsx
@@ -42,7 +42,7 @@ Default.storyName = 'default'
 
 const meta: Meta<Args> = {
   component: AssetData,
-  title: 'Components/AssetData',
+  title: 'Components/Assets/AssetData',
   argTypes: {
     network: {
       name: 'Network',

--- a/src/renderer/components/uielements/assets/assetData/AssetData.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.stories.tsx
@@ -3,43 +3,86 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 import { assetAmount, AssetBNB, AssetRuneNative, assetToBase } from '@xchainjs/xchain-util'
 
+import { Network } from '../../../../../shared/api/types'
+import { WalletType } from '../../../../../shared/wallet/types'
 import { AssetData } from './AssetData'
+import { AssetDataSize } from './AssetData.styles'
 
-const amount = assetToBase(assetAmount(2.49274))
-const price = assetToBase(assetAmount(217.92))
+type Args = {
+  noTicker: boolean
+  network: Network
+  noPrice: boolean
+  size: AssetDataSize
+  walletType: WalletType & 'undefined'
+}
 
-export const StoryAsset: Story = () => <AssetData asset={AssetBNB} network="testnet" />
-StoryAsset.storyName = 'asset'
+const Template: Story<Args> = ({ network, size, noTicker, noPrice, walletType }) => {
+  const amount = assetToBase(assetAmount(2.49274))
+  const price = noPrice ? undefined : assetToBase(assetAmount(217.92))
+  const priceAsset = noPrice ? undefined : AssetRuneNative
+  const wType = walletType !== 'undefined' ? walletType : undefined
 
-export const StoryAssetAmount: Story = () => <AssetData asset={AssetBNB} amount={amount} network="testnet" />
-StoryAssetAmount.storyName = 'asset + amount'
+  return (
+    <AssetData
+      asset={AssetBNB}
+      noTicker={noTicker}
+      amount={amount}
+      price={price}
+      priceAsset={priceAsset}
+      size={size}
+      network={network}
+      walletType={wType}
+    />
+  )
+}
 
-export const StoryNoTicker: Story = () => <AssetData asset={AssetBNB} amount={amount} noTicker network="testnet" />
-StoryNoTicker.storyName = 'amount, but no ticker'
+export const Default = Template.bind({})
 
-export const StoryPrice: Story = () => (
-  <AssetData asset={AssetBNB} amount={amount} price={price} priceAsset={AssetRuneNative} network="testnet" />
-)
-StoryPrice.storyName = 'price + amount'
+Default.storyName = 'default'
 
-export const StoryPriceNoTicker: Story = () => (
-  <AssetData asset={AssetBNB} amount={amount} price={price} priceAsset={AssetRuneNative} noTicker network="testnet" />
-)
-StoryPriceNoTicker.storyName = 'price + amount, but no ticker'
-
-export const StoryPriceOnly: Story = () => (
-  <AssetData asset={AssetBNB} price={price} priceAsset={AssetRuneNative} noTicker network="testnet" />
-)
-StoryPriceOnly.storyName = 'price - only'
-
-export const StoryBig: Story = () => (
-  <AssetData asset={AssetBNB} amount={amount} price={price} priceAsset={AssetRuneNative} size="big" network="testnet" />
-)
-StoryBig.storyName = 'big'
-
-const meta: Meta = {
+const meta: Meta<Args> = {
   component: AssetData,
   title: 'Components/AssetData',
+  argTypes: {
+    network: {
+      name: 'Network',
+      control: {
+        type: 'select',
+        options: ['mainnet', 'testnet']
+      },
+      defaultValue: 'mainnet'
+    },
+    noTicker: {
+      name: 'no ticker',
+      control: {
+        type: 'boolean'
+      },
+      defaultValue: false
+    },
+    noPrice: {
+      name: 'no price',
+      control: {
+        type: 'boolean'
+      },
+      defaultValue: true
+    },
+    size: {
+      name: 'Size',
+      control: {
+        type: 'select',
+        options: ['small', 'big']
+      },
+      defaultValue: 'small'
+    },
+    walletType: {
+      name: 'wallet type',
+      control: {
+        type: 'select',
+        options: ['ledger', 'keystore', 'undefined']
+      },
+      defaultValue: 'ledger'
+    }
+  },
   decorators: [
     (S: Story) => (
       <div

--- a/src/renderer/components/uielements/assets/assetData/AssetData.styles.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.styles.tsx
@@ -1,13 +1,14 @@
-import { Row, Col as ACol } from 'antd'
+import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
+import { WalletTypeLabel as WalletTypeLabelUI } from '../../common/Common.styles'
 import { Label as UILabel } from '../../label'
 import { AssetIcon as UIAssetIcon } from '../assetIcon'
 
 export type AssetDataSize = 'small' | 'big'
 
-export const Wrapper = styled(Row).attrs({
+export const Wrapper = styled(A.Row).attrs({
   align: 'middle'
 })`
   padding: 5px 0px;
@@ -53,10 +54,35 @@ export const PriceLabel = styled(UILabel).attrs({
   font-family: 'MainFontRegular';
 `
 
-export const Col = styled(ACol)`
+export const Col = styled(A.Col)`
   margin-right: 8px;
 
   &:last-child {
     margin: 0;
   }
+`
+
+export const AssetIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+  padding: 10px 0;
+
+  position: relative;
+`
+export const WalletTypeLabel = styled(WalletTypeLabelUI)`
+  /* position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%); */
+  font-size: 8px;
+  line-height: 12px;
+  /* align-self: flex-start; */
+  margin-left: 10px;
+`
+export const LabelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* align-items: center; */
+  align-items: flex-start;
 `

--- a/src/renderer/components/uielements/assets/assetData/AssetData.styles.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.styles.tsx
@@ -71,18 +71,12 @@ export const AssetIconContainer = styled.div`
   position: relative;
 `
 export const WalletTypeLabel = styled(WalletTypeLabelUI)`
-  /* position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%); */
   font-size: 8px;
   line-height: 12px;
-  /* align-self: flex-start; */
   margin-left: 10px;
 `
 export const LabelContainer = styled.div`
   display: flex;
   flex-direction: column;
-  /* align-items: center; */
   align-items: flex-start;
 `

--- a/src/renderer/components/uielements/assets/assetData/AssetData.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.tsx
@@ -62,7 +62,6 @@ export const AssetData: React.FC<Props> = (props): JSX.Element => {
           {walletType && isLedgerWallet(walletType) && (
             <Styled.WalletTypeLabel>{walletTypeToI18n(walletType, intl)}</Styled.WalletTypeLabel>
           )}
-          <Styled.WalletTypeLabel>Ledger</Styled.WalletTypeLabel>
         </Styled.LabelContainer>
       )}
       {assetAmount && (

--- a/src/renderer/components/uielements/assets/assetData/AssetData.tsx
+++ b/src/renderer/components/uielements/assets/assetData/AssetData.tsx
@@ -1,22 +1,27 @@
 import React from 'react'
 
 import { BaseAmount, formatAssetAmountCurrency, baseToAsset, baseAmount, Asset } from '@xchainjs/xchain-util'
+import { useIntl } from 'react-intl'
 
 import { Network } from '../../../../../shared/api/types'
+import { isLedgerWallet } from '../../../../../shared/utils/guard'
+import { WalletType } from '../../../../../shared/wallet/types'
+import { walletTypeToI18n } from '../../../../services/wallet/util'
 import { PricePoolAsset } from '../../../../views/pools/Pools.types'
 import * as Styled from './AssetData.styles'
 
 /**
  * AssetData - Component to show data of an asset:
  *
- * |------|-------------------|-------------------|------------------|
- * | icon | ticker (optional) | amount (optional) | price (optional) |
- * |------|-------------------|-------------------|------------------|
+ * |------|---------|-------------------|------------------|------------------------|
+ * | icon | ticker  | amount (optional) | price (optional) | wallet type (optional) |
+ * |------|---------|-------------------|------------------|------------------------|
  *
  */
 
 export type Props = {
   asset: Asset
+  walletType?: WalletType
   noTicker?: boolean
   amount?: BaseAmount
   price?: BaseAmount
@@ -25,38 +30,40 @@ export type Props = {
   // `className` is needed by `styled components`
   className?: string
   network: Network
-  noIcon?: boolean
 }
 
 export const AssetData: React.FC<Props> = (props): JSX.Element => {
   const {
     asset,
+    walletType,
     amount: assetAmount,
     noTicker = false,
     price = baseAmount(0),
     priceAsset,
     size = 'small',
     className,
-    network,
-    noIcon
+    network
   } = props
 
+  const intl = useIntl()
   const priceLabel = priceAsset
     ? formatAssetAmountCurrency({ amount: baseToAsset(price), asset: priceAsset, trimZeros: true })
     : ''
 
   return (
     <Styled.Wrapper className={className}>
-      {!noIcon && (
-        <Styled.Col>
-          <Styled.AssetIcon asset={asset} size={size} network={network} />
-        </Styled.Col>
-      )}
+      <Styled.AssetIconContainer>
+        <Styled.AssetIcon asset={asset} size={size} network={network} />
+      </Styled.AssetIconContainer>
       {!noTicker && (
-        <Styled.Col>
+        <Styled.LabelContainer>
           <Styled.TickerLabel>{asset.ticker}</Styled.TickerLabel>
           <Styled.ChainLabel>{asset.chain}</Styled.ChainLabel>
-        </Styled.Col>
+          {walletType && isLedgerWallet(walletType) && (
+            <Styled.WalletTypeLabel>{walletTypeToI18n(walletType, intl)}</Styled.WalletTypeLabel>
+          )}
+          <Styled.WalletTypeLabel>Ledger</Styled.WalletTypeLabel>
+        </Styled.LabelContainer>
       )}
       {assetAmount && (
         <Styled.Col>

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.stories.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
 import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
 
+import { Network } from '../../../../../shared/api/types'
 import { WalletBalance } from '../../../../services/wallet/types'
-import { AssetMenu, Props as AssetMenuProps } from './AssetMenu'
+import { AssetMenu } from './AssetMenu'
 
 const priceIndex = {
   RUNE: bn(1),
@@ -13,7 +15,7 @@ const priceIndex = {
 }
 
 const balanceBNB: WalletBalance = {
-  walletType: 'keystore',
+  walletType: 'ledger',
   amount: baseAmount('1'),
   asset: AssetBNB,
   walletAddress: ''
@@ -21,6 +23,7 @@ const balanceBNB: WalletBalance = {
 
 const balanceBTC: WalletBalance = {
   ...balanceBNB,
+  walletType: 'keystore',
   asset: AssetBTC
 }
 
@@ -31,33 +34,51 @@ const balanceRuneNative: WalletBalance = {
 
 const balances = [balanceBNB, balanceBTC, balanceRuneNative]
 
-const defaultProps: AssetMenuProps = {
-  withSearch: true,
-  asset: AssetBNB,
-  balances,
-  priceIndex,
-  searchDisable: [],
-  onSelect: (key) => console.log(key),
-  network: 'testnet'
+type Args = {
+  withSearch: boolean
+  network: Network
+  onSelect: FP.Lazy<void>
 }
 
-export const StoryWithSearch: Story = () => <AssetMenu {...defaultProps} />
+const Template: Story<Args> = ({ network, withSearch, onSelect }) => (
+  <AssetMenu
+    withSearch={withSearch}
+    asset={AssetBNB}
+    balances={balances}
+    priceIndex={priceIndex}
+    onSelect={onSelect}
+    searchDisable={[]}
+    network={network}
+  />
+)
 
-StoryWithSearch.storyName = 'with search'
+export const Default = Template.bind({})
 
-export const StoryWithoutSearch: Story = () => {
-  const props = {
-    ...defaultProps,
-    withSearch: false
-  }
-  return <AssetMenu {...props} />
-}
-
-StoryWithoutSearch.storyName = 'without search'
+Default.storyName = 'default'
 
 const meta: Meta = {
   component: AssetMenu,
   title: 'Components/Assets/AssetMenu',
+  argTypes: {
+    network: {
+      name: 'Network',
+      control: {
+        type: 'select',
+        options: ['mainnet', 'testnet']
+      },
+      defaultValue: 'mainnet'
+    },
+    withSearch: {
+      name: 'with search',
+      control: {
+        type: 'boolean'
+      },
+      defaultValue: false
+    },
+    onSelect: {
+      action: 'onSelect'
+    }
+  },
   decorators: [
     (S: Story) => (
       <div style={{ display: 'flex', padding: '20px' }}>

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
@@ -46,13 +46,13 @@ export const AssetMenu: React.FC<Props> = (props): JSX.Element => {
   )
 
   const cellRenderer = useCallback(
-    ({ asset, amount }: WalletBalance) => {
+    ({ asset, amount, walletType }: WalletBalance) => {
       const price = baseAmount(priceIndex[asset.ticker])
       const key = assetToString(asset)
       const node = (
         <Row align={'middle'} gutter={[8, 0]} onClick={() => onSelect(key)}>
           <Col>
-            <AssetData asset={asset} price={price} network={network} />
+            <AssetData asset={asset} price={price} network={network} walletType={walletType} />
           </Col>
           <Col>{formatAssetAmountCurrency({ amount: baseToAsset(amount), asset, decimal: 3 })}</Col>
         </Row>

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.stories.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
 import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
 
+import { Network } from '../../../../../shared/api/types'
+import { WalletType } from '../../../../../shared/wallet/types'
 import { WalletBalance } from '../../../../services/wallet/types'
-import { AssetSelect, Props as AssetSelectProps } from './AssetSelect'
+import { AssetSelect } from './AssetSelect'
 
 const balanceBNB: WalletBalance = {
-  walletType: 'keystore',
+  walletType: 'ledger',
   amount: baseAmount('1'),
   asset: AssetBNB,
   walletAddress: ''
@@ -20,31 +23,73 @@ const balanceBTC: WalletBalance = {
 
 const balanceRuneNative: WalletBalance = {
   ...balanceBNB,
+  walletType: 'keystore',
   asset: AssetRuneNative
 }
 
 const balances = [balanceBNB, balanceBTC, balanceRuneNative]
 
-const defaultProps: AssetSelectProps = {
-  asset: AssetBNB,
-  balances,
-  priceIndex: {
-    RUNE: bn(1),
-    BNB: bn(2),
-    BTC: bn(3)
-  },
-  onSelect: () => {},
-  withSearch: true,
-  network: 'testnet'
+const priceIndex = {
+  RUNE: bn(1),
+  BNB: bn(2),
+  BTC: bn(3)
 }
 
-export const Default: Story = () => <AssetSelect {...defaultProps} />
+type Args = {
+  withSearch: boolean
+  network: Network
+  assetWalletType: WalletType
+  onSelect: FP.Lazy<void>
+}
+
+const Template: Story<Args> = ({ network, withSearch, assetWalletType, onSelect }) => (
+  <AssetSelect
+    asset={AssetBNB}
+    assetWalletType={assetWalletType}
+    withSearch={withSearch}
+    balances={balances}
+    priceIndex={priceIndex}
+    onSelect={onSelect}
+    searchDisable={[]}
+    network={network}
+  />
+)
+
+export const Default = Template.bind({})
 
 Default.storyName = 'default'
 
 const meta: Meta = {
   component: AssetSelect,
   title: 'Components/Assets/AssetSelect',
+  argTypes: {
+    network: {
+      name: 'Network',
+      control: {
+        type: 'select',
+        options: ['mainnet', 'testnet']
+      },
+      defaultValue: 'mainnet'
+    },
+    withSearch: {
+      name: 'with search',
+      control: {
+        type: 'boolean'
+      },
+      defaultValue: false
+    },
+    assetWalletType: {
+      name: 'asset wallet type',
+      control: {
+        type: 'select',
+        options: ['ledger', 'keystore']
+      },
+      defaultValue: 'ledger'
+    },
+    onSelect: {
+      action: 'onSelect'
+    }
+  },
   decorators: [
     (S: Story) => (
       <div style={{ display: 'flex', padding: '20px' }}>

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.tsx
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.tsx
@@ -5,6 +5,7 @@ import { Dropdown } from 'antd'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../../../shared/api/types'
+import { WalletType } from '../../../../../shared/wallet/types'
 import { ordWalletBalanceByAsset } from '../../../../helpers/fp/ord'
 import { WalletBalances } from '../../../../services/clients'
 import { PriceDataIndex } from '../../../../services/midgard/types'
@@ -13,8 +14,9 @@ import { AssetMenu } from '../assetMenu'
 import * as Styled from './AssetSelect.styles'
 
 export type Props = {
-  balances: WalletBalances
   asset: Asset
+  assetWalletType?: WalletType
+  balances: WalletBalances
   priceIndex?: PriceDataIndex
   withSearch?: boolean
   searchDisable?: string[]
@@ -29,6 +31,7 @@ export type Props = {
 export const AssetSelect: React.FC<Props> = (props): JSX.Element => {
   const {
     asset,
+    assetWalletType,
     balances = [],
     priceIndex,
     withSearch = true,
@@ -97,7 +100,13 @@ export const AssetSelect: React.FC<Props> = (props): JSX.Element => {
       onClick={handleDropdownButtonClicked}>
       <Dropdown overlay={renderMenu} trigger={[]} visible={openDropdown} placement="bottomCenter">
         <>
-          <AssetData noTicker={!showAssetName} className={'asset-data'} asset={asset} network={network} />
+          <AssetData
+            noTicker={!showAssetName}
+            className={'asset-data'}
+            asset={asset}
+            walletType={assetWalletType}
+            network={network}
+          />
           <Styled.AssetDropdownButton>
             {!hideButton ? (
               <Styled.DropdownIconHolder>


### PR DESCRIPTION
- [x] Show 'Ledger' wallet type in `AssetData`
- [x] Update `Swap` to consider `walletType` for source asset
- [x] Update stories for `AssetData` + `AssetMenu` + `AssetSelect`

# Screen cast

## Storybook


https://user-images.githubusercontent.com/61792675/138075482-35ed995b-59da-494a-a5bc-dac87e6457fb.mp4



## ASGARDEX

(for demo purposes all wallet types are hard coded to `Ledger`)

![Peek 2021-10-20 11-50](https://user-images.githubusercontent.com/61792675/138072115-bb3e56ad-a892-4580-8f8b-c3e77ce3a752.gif)


Close #1866