### PR TITLE
Enable Ledger in Swap

### DIFF
--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -119,7 +119,11 @@ export const PoolTitle: React.FC<Props> = ({
                       event.preventDefault()
                       event.stopPropagation()
                       history.push(
-                        poolsRoutes.swap.path({ source: assetToString(asset), target: assetToString(AssetRuneNative) })
+                        poolsRoutes.swap.path({
+                          source: assetToString(asset),
+                          target: assetToString(AssetRuneNative),
+                          walletType: 'keystore' // use keystore wallet by default
+                        })
                       )
                     }}>
                     <SwapOutlined />

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -121,8 +121,7 @@ export const PoolTitle: React.FC<Props> = ({
                       history.push(
                         poolsRoutes.swap.path({
                           source: assetToString(asset),
-                          target: assetToString(AssetRuneNative),
-                          walletType: 'keystore' // use keystore wallet by default
+                          target: assetToString(AssetRuneNative)
                         })
                       )
                     }}>

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -40,7 +40,6 @@ const defaultProps: SwapProps = {
     { asset: AssetRuneNative, assetPrice: ONE_BN }
   ],
   assets: { inAsset: sourceAsset, outAsset: targetAsset },
-  walletType: 'keystore',
   poolAddress: O.some({
     chain: BNBChain,
     address: 'vault-address',

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -40,6 +40,7 @@ const defaultProps: SwapProps = {
     { asset: AssetRuneNative, assetPrice: ONE_BN }
   ],
   assets: { inAsset: sourceAsset, outAsset: targetAsset },
+  walletType: 'keystore',
   poolAddress: O.some({
     chain: BNBChain,
     address: 'vault-address',

--- a/src/renderer/components/swap/Swap.styles.tsx
+++ b/src/renderer/components/swap/Swap.styles.tsx
@@ -6,6 +6,7 @@ import { media } from '../../helpers/styleHelper'
 import { AssetInput as AssetInputBase } from '../uielements/assets/assetInput'
 import { AssetSelect as AssetSelectUI } from '../uielements/assets/assetSelect'
 import { Button as UIButton } from '../uielements/button'
+import { CheckButton as CheckButtonUI } from '../uielements/button/CheckButton'
 import { Label as UILabel } from '../uielements/label'
 
 const ICON_SIZE = 16
@@ -223,4 +224,16 @@ export const SubmitButton = styled(UIButton).attrs({
   min-width: 200px !important;
   padding: 0 30px;
   margin: 30px 0;
+`
+
+export const CheckButton = styled(CheckButtonUI)`
+  &.ant-btn {
+    font-size: 10px;
+  }
+`
+
+export const AssetSelectContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -108,7 +108,6 @@ export type SwapProps = {
   keystore: KeystoreState
   availableAssets: PoolAssetDetails
   assets: { inAsset: AssetWithDecimal; outAsset: AssetWithDecimal }
-  walletType: WalletType
   poolAddress: O.Option<PoolAddress>
   swap$: SwapStateHandler
   poolsData: PoolsDataMap
@@ -138,7 +137,6 @@ export const Swap = ({
   keystore,
   availableAssets,
   assets: { inAsset: sourceAssetWD, outAsset: targetAssetWD },
-  walletType,
   poolAddress: oPoolAddress,
   swap$,
   poolsData,
@@ -507,7 +505,7 @@ export const Swap = ({
   const [swapStartTime, setSwapStartTime] = useState<number>(0)
 
   const setSourceAsset = useCallback(
-    async ({ asset, walletType }: AssetWithWalletType) => {
+    async ({ asset }: AssetWithWalletType) => {
       // delay to avoid render issues while switching
       await delay(100)
 
@@ -517,8 +515,7 @@ export const Swap = ({
           onChangePath(
             swap.path({
               source: assetToString(asset),
-              target: assetToString(targetAsset),
-              walletType
+              target: assetToString(targetAsset)
             })
           )
         )
@@ -538,14 +535,13 @@ export const Swap = ({
           onChangePath(
             swap.path({
               source: assetToString(sourceAsset),
-              target: assetToString(asset),
-              walletType // stick with current wallet type
+              target: assetToString(asset)
             })
           )
         )
       )
     },
-    [oSourceAsset, onChangePath, walletType]
+    [oSourceAsset, onChangePath]
   )
 
   const minAmountToSwapMax1e8: BaseAmount = useMemo(
@@ -1188,8 +1184,7 @@ export const Swap = ({
         onChangePath(
           swap.path({
             target: assetToString(source),
-            source: assetToString(target),
-            walletType: 'keystore' // Switch to 'keystore by default
+            source: assetToString(target)
           })
         )
       )
@@ -1350,7 +1345,6 @@ export const Swap = ({
                     <Styled.AssetSelect
                       onSelect={setSourceAsset}
                       asset={asset}
-                      assetWalletType={walletType}
                       balances={balancesToSwapFrom}
                       network={network}
                     />

--- a/src/renderer/components/swap/Swap.types.ts
+++ b/src/renderer/components/swap/Swap.types.ts
@@ -1,7 +1,9 @@
-import { BaseAmount } from '@xchainjs/xchain-util'
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 
 export type SwapData = {
   readonly slip: BigNumber
   readonly swapResult: BaseAmount
 }
+
+export type AssetsToSwap = { source: Asset; target: Asset }

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -715,28 +715,45 @@ describe('components/swap/utils', () => {
   })
 
   describe('balancesToSwapFrom', () => {
-    const a: WalletBalance = {
+    const runeBalance: WalletBalance = {
       walletType: 'keystore',
       amount: baseAmount('1'),
       asset: AssetRuneNative,
       walletAddress: ''
     }
-    const b: WalletBalance = {
-      ...a,
+    const runeBalanceLedger: WalletBalance = {
+      ...runeBalance,
       walletType: 'ledger',
       amount: baseAmount('2')
     }
-    const c: WalletBalance = {
-      ...a,
+    const bnbBalance: WalletBalance = {
+      ...runeBalance,
       asset: AssetBNB
     }
 
-    it('no assets for no balances', () => {
+    it('RUNE ledger + Keystore ', () => {
       const result = balancesToSwapFrom({
         assetsToSwap: O.some({ source: AssetBNB, target: AssetRuneNative }),
-        walletBalances: [a, b, c]
+        walletBalances: [runeBalance, runeBalanceLedger, bnbBalance]
       })
       expect(result.length).toEqual(2)
+      // Keystore THOR.RUNE
+      expect(result[0].walletType).toEqual('keystore')
+      expect(eqAsset.equals(result[0].asset, AssetRuneNative)).toBeTruthy()
+      // Ledger THOR.RUNE
+      expect(result[1].walletType).toEqual('ledger')
+      expect(eqAsset.equals(result[1].asset, AssetRuneNative)).toBeTruthy()
+    })
+
+    it('RUNE ledger + Keystore ', () => {
+      const result = balancesToSwapFrom({
+        assetsToSwap: O.some({ source: AssetRuneNative, target: AssetBNB }),
+        walletBalances: [runeBalance, runeBalanceLedger, bnbBalance]
+      })
+      expect(result.length).toEqual(1)
+      // Keystore BNB.BNB
+      expect(result[0].walletType).toEqual('keystore')
+      expect(eqAsset.equals(result[0].asset, AssetBNB)).toBeTruthy()
     })
   })
 })

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -11,8 +11,6 @@ import {
   baseAmount,
   bn
 } from '@xchainjs/xchain-util'
-import * as FP from 'fp-ts/lib/function'
-import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
 
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
@@ -20,7 +18,7 @@ import { AssetBUSD74E, AssetUSDTERC20Testnet, ZERO_BASE_AMOUNT } from '../../con
 import { BNB_DECIMAL, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { eqAsset, eqBaseAmount } from '../../helpers/fp/eq'
 import { PoolsDataMap } from '../../services/midgard/types'
-import { NonEmptyWalletBalances, WalletBalance } from '../../services/wallet/types'
+import { WalletBalance } from '../../services/wallet/types'
 import {
   DEFAULT_SWAP_DATA,
   isRuneSwap,
@@ -701,27 +699,18 @@ describe('components/swap/utils', () => {
       ...a,
       asset: AssetBTC
     }
-    it('no assets for no balances', () => {
-      const result = assetsInWallet(O.none)
-      expect(result).toBeNone()
+    it('empty list of assets for empty balances', () => {
+      const result = assetsInWallet([])
+      expect(result).toEqual([])
     })
 
     it('filter out assets', () => {
-      const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([a, b, c])
-      const result = assetsInWallet(balances)
+      const assets = assetsInWallet([a, b, c])
 
-      FP.pipe(
-        result,
-        O.fold(
-          () => fail('no assets'),
-          (assets) => {
-            expect(assets.length).toEqual(3)
-            expect(eqAsset.equals(assets[0], AssetRuneNative)).toBeTruthy()
-            expect(eqAsset.equals(assets[1], AssetBNB)).toBeTruthy()
-            expect(eqAsset.equals(assets[2], AssetBTC)).toBeTruthy()
-          }
-        )
-      )
+      expect(assets.length).toEqual(3)
+      expect(eqAsset.equals(assets[0], AssetRuneNative)).toBeTruthy()
+      expect(eqAsset.equals(assets[1], AssetBNB)).toBeTruthy()
+      expect(eqAsset.equals(assets[2], AssetBTC)).toBeTruthy()
     })
   })
 

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -21,7 +21,6 @@ import { BNB_DECIMAL, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { eqAsset, eqBaseAmount } from '../../helpers/fp/eq'
 import { mockWalletBalance } from '../../helpers/test/testWalletHelper'
 import { PoolsDataMap } from '../../services/midgard/types'
-import { WalletBalance } from '../../services/wallet/types'
 import {
   DEFAULT_SWAP_DATA,
   isRuneSwap,
@@ -689,20 +688,10 @@ describe('components/swap/utils', () => {
     })
   })
   describe('assetsInWallet', () => {
-    const a: WalletBalance = {
-      walletType: 'keystore',
-      amount: baseAmount('1'),
-      asset: AssetRuneNative,
-      walletAddress: ''
-    }
-    const b: WalletBalance = {
-      ...a,
-      asset: AssetBNB
-    }
-    const c: WalletBalance = {
-      ...a,
-      asset: AssetBTC
-    }
+    const a = mockWalletBalance()
+    const b = mockWalletBalance({ asset: AssetBNB })
+    const c = mockWalletBalance({ asset: AssetBTC })
+
     it('empty list of assets for empty balances', () => {
       const result = assetsInWallet([])
       expect(result).toEqual([])

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -272,9 +272,6 @@ export const maxAmountToSwapMax1e8 = (assetAmountMax1e8: BaseAmount, feeAmount: 
   return maxAmountToSwap.gt(baseAmount(0)) ? maxAmountToSwap : baseAmount(0)
 }
 
-// export const assetsInWallet = (oWalletBalances: O.Option<NonEmptyWalletBalances>): O.Option<Asset[]> =>
-//   FP.pipe(oWalletBalances, O.map(A.map(({ asset }) => asset)))
-
 export const assetsInWallet: (_: WalletBalances) => Asset[] = FP.flow(A.map(({ asset }) => asset))
 
 export const balancesToSwapFrom = ({

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -316,7 +316,6 @@ export const hasLedgerInBalancesByAsset = (asset: Asset, balances: WalletBalance
     )
   )
 
-// TODO (@veado) Add a test
 export const hasLedgerInBalancesByChain = (chain: Chain, balances: WalletBalances): boolean =>
   FP.pipe(
     balances,

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -293,10 +293,10 @@ export const balancesToSwapFrom = ({
 
   return FP.pipe(
     assetsToSwap,
-    O.map(({ source, target }) =>
+    O.map(({ source }) =>
       FP.pipe(
         filteredBalances,
-        A.filter((balance) => !eqAsset.equals(balance.asset, source) && !eqAsset.equals(balance.asset, target))
+        A.filter((balance) => !eqAsset.equals(balance.asset, source))
       )
     ),
     O.getOrElse(() => walletBalances)

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -1,5 +1,5 @@
 import { getDoubleSwapOutput, getDoubleSwapSlip, getSwapOutput, getSwapSlip } from '@thorchain/asgardex-util'
-import { Asset, assetToString, bn, BaseAmount, baseAmount } from '@xchainjs/xchain-util'
+import { Asset, assetToString, bn, BaseAmount, baseAmount, Chain } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/Array'
 import * as E from 'fp-ts/Either'
@@ -15,7 +15,7 @@ import {
   max1e8BaseAmount,
   to1e8BaseAmount
 } from '../../helpers/assetHelper'
-import { eqAsset } from '../../helpers/fp/eq'
+import { eqAsset, eqChain } from '../../helpers/fp/eq'
 import { sequenceTOption } from '../../helpers/fpHelpers'
 import { priceFeeAmountForAsset } from '../../services/chain/fees/utils'
 import { SwapFees } from '../../services/chain/types'
@@ -303,12 +303,23 @@ export const balancesToSwapFrom = ({
   )
 }
 
-export const hasSourceAssetLedger = (asset: Asset, balances: WalletBalances): boolean =>
+export const hasLedgerInBalancesByAsset = (asset: Asset, balances: WalletBalances): boolean =>
   FP.pipe(
     balances,
     A.findFirst(
       ({ walletType, asset: balanceAsset }) => eqAsset.equals(asset, balanceAsset) && isLedgerWallet(walletType)
     ),
+    O.fold(
+      () => false,
+      () => true
+    )
+  )
+
+// TODO (@veado) Add a test
+export const hasLedgerInBalancesByChain = (chain: Chain, balances: WalletBalances): boolean =>
+  FP.pipe(
+    balances,
+    A.findFirst(({ walletType, asset }) => eqChain.equals(chain, asset.chain) && isLedgerWallet(walletType)),
     O.fold(
       () => false,
       () => true

--- a/src/renderer/components/uielements/assets/assetCard/AssetCard.tsx
+++ b/src/renderer/components/uielements/assets/assetCard/AssetCard.tsx
@@ -24,6 +24,7 @@ import { ordWalletBalanceByAsset } from '../../../../helpers/fp/ord'
 import { useClickOutside } from '../../../../hooks/useOutsideClick'
 import { PriceDataIndex } from '../../../../services/midgard/types'
 import { WalletBalances } from '../../../../services/wallet/types'
+import { AssetWithWalletType } from '../../../../types/asgardex'
 import { Slider } from '../../slider'
 import { AssetMenu } from '../assetMenu'
 import * as Styled from './AssetCard.styles'
@@ -90,7 +91,7 @@ export const AssetCard: React.FC<Props> = (props): JSX.Element => {
   useClickOutside<HTMLDivElement>(ref, () => setOpenDropdown(false))
 
   const handleChangeAsset = useCallback(
-    (asset: string | Asset) => {
+    ({ asset }: AssetWithWalletType) => {
       const targetAsset = typeof asset === 'string' ? assetFromString(asset) : asset
       if (targetAsset) {
         onChangeAsset(targetAsset)

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
@@ -7,6 +7,7 @@ import { Network } from '../../../../../shared/api/types'
 import { eqAsset } from '../../../../helpers/fp/eq'
 import { PriceDataIndex } from '../../../../services/midgard/types'
 import { WalletBalance, WalletBalances } from '../../../../services/wallet/types'
+import { AssetWithWalletType } from '../../../../types/asgardex'
 import { FilterMenu } from '../../filterMenu'
 import { AssetData } from '../assetData/AssetData'
 
@@ -21,7 +22,7 @@ export type Props = {
   priceIndex?: PriceDataIndex
   searchDisable: string[]
   withSearch: boolean
-  onSelect: (value: string) => void
+  onSelect: (value: AssetWithWalletType) => void
   closeMenu?: () => void
   searchPlaceholder?: string
   network: Network
@@ -35,7 +36,7 @@ export const AssetMenu: React.FC<Props> = (props): JSX.Element => {
     priceIndex = {},
     withSearch,
     searchDisable = [],
-    onSelect = () => {},
+    onSelect,
     closeMenu,
     network
   } = props
@@ -50,7 +51,7 @@ export const AssetMenu: React.FC<Props> = (props): JSX.Element => {
       const price = baseAmount(priceIndex[asset.ticker])
       const key = assetToString(asset)
       const node = (
-        <Row align={'middle'} gutter={[8, 0]} onClick={() => onSelect(key)}>
+        <Row align={'middle'} gutter={[8, 0]} onClick={() => onSelect({ asset, walletType })}>
           <Col>
             <AssetData asset={asset} price={price} network={network} walletType={walletType} />
           </Col>

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.styles.ts
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.styles.ts
@@ -6,7 +6,7 @@ import { transition } from '../../../../settings/style-util'
 
 export const AssetSelectWrapper = styled.button`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  padding: 5px 10px;
+  padding: 2px 10px;
   border: 0;
   background-color: ${palette('background', 0)};
   display: flex;

--- a/src/renderer/components/uielements/button/CheckButton.stories.tsx
+++ b/src/renderer/components/uielements/button/CheckButton.stories.tsx
@@ -14,7 +14,7 @@ type Args = {
 
 const Template: Story<Args> = ({ label, disabled, isChecked, onClicked }) => {
   return (
-    <CheckButton disabled={disabled} isChecked={isChecked} clickHandler={onClicked}>
+    <CheckButton disabled={disabled} checked={isChecked} clickHandler={onClicked}>
       {label}
     </CheckButton>
   )

--- a/src/renderer/components/uielements/button/CheckButton.tsx
+++ b/src/renderer/components/uielements/button/CheckButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 
 import * as FP from 'fp-ts/function'
 
@@ -7,24 +7,28 @@ import * as Styled from './CheckButton.styles'
 export type Props = {
   clickHandler?: FP.Lazy<void>
   disabled?: boolean
-  isChecked?: boolean
+  checked: boolean
   className?: string
 }
 
 export const CheckButton: React.FC<Props> = (props): JSX.Element => {
-  const { clickHandler = FP.constVoid, disabled, isChecked, className, children } = props
+  const { clickHandler = FP.constVoid, disabled, checked, className, children } = props
 
-  const [checked, setChecked] = useState(!!isChecked)
+  const [isChecked, setChecked] = useState(checked)
+
+  useEffect(() => {
+    setChecked(checked)
+  }, [checked])
 
   const onClickHandler = useCallback(() => {
-    setChecked(() => !checked)
+    setChecked(() => !isChecked)
     clickHandler && clickHandler()
-  }, [checked, clickHandler])
+  }, [isChecked, clickHandler])
 
   return (
-    <Styled.Button onClick={onClickHandler} disabled={disabled} checked={checked} className={className}>
+    <Styled.Button onClick={onClickHandler} disabled={disabled} checked={isChecked} className={className}>
       <Styled.ContentWrapper>
-        <Styled.CheckCircleOutlined checked={checked} />
+        <Styled.CheckCircleOutlined checked={isChecked} />
         {children}
       </Styled.ContentWrapper>
     </Styled.Button>

--- a/src/renderer/components/uielements/button/CheckButton.tsx
+++ b/src/renderer/components/uielements/button/CheckButton.tsx
@@ -8,10 +8,11 @@ export type Props = {
   clickHandler?: FP.Lazy<void>
   disabled?: boolean
   isChecked?: boolean
+  className?: string
 }
 
 export const CheckButton: React.FC<Props> = (props): JSX.Element => {
-  const { clickHandler = FP.constVoid, disabled, isChecked, children } = props
+  const { clickHandler = FP.constVoid, disabled, isChecked, className, children } = props
 
   const [checked, setChecked] = useState(!!isChecked)
 
@@ -21,7 +22,7 @@ export const CheckButton: React.FC<Props> = (props): JSX.Element => {
   }, [checked, clickHandler])
 
   return (
-    <Styled.Button onClick={onClickHandler} disabled={disabled} checked={checked}>
+    <Styled.Button onClick={onClickHandler} disabled={disabled} checked={checked} className={className}>
       <Styled.ContentWrapper>
         <Styled.CheckCircleOutlined checked={checked} />
         {children}

--- a/src/renderer/components/wallet/txs/TxForm.helpers.tsx
+++ b/src/renderer/components/wallet/txs/TxForm.helpers.tsx
@@ -1,3 +1,4 @@
+import { Address } from '@xchainjs/xchain-client'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
@@ -20,7 +21,7 @@ export const renderedWalletType = (oMatchedWalletType: O.Option<WalletType>) =>
     )
   )
 
-export const matchedWalletType = (balances: WalletBalances, recipientAddress: string): O.Option<WalletType> =>
+export const matchedWalletType = (balances: WalletBalances, recipientAddress: Address): O.Option<WalletType> =>
   FP.pipe(
     getWalletByAddress(balances, recipientAddress),
     O.map(({ walletType }) => walletType)

--- a/src/renderer/helpers/fp/array.test.ts
+++ b/src/renderer/helpers/fp/array.test.ts
@@ -1,6 +1,6 @@
-import { BNBChain, BTCChain, ETHChain, LTCChain } from '@xchainjs/xchain-util'
+import { AssetBNB, AssetBTC, AssetETH, AssetLTC, BNBChain, BTCChain, ETHChain, LTCChain } from '@xchainjs/xchain-util'
 
-import { unionChains } from './array'
+import { unionAssets, unionChains } from './array'
 
 describe('helpers/fp/array', () => {
   describe('unionChains', () => {
@@ -8,6 +8,13 @@ describe('helpers/fp/array', () => {
       const chainsA = [BNBChain, ETHChain, BTCChain]
       const chainsB = [BNBChain, BTCChain, LTCChain]
       expect(unionChains(chainsA)(chainsB)).toEqual([BNBChain, BTCChain, LTCChain, ETHChain])
+    })
+  })
+  describe('unionAssets', () => {
+    it('merges two lists of assets and removes duplicates', () => {
+      const assetsA = [AssetBNB, AssetETH, AssetBTC]
+      const assetsB = [AssetBNB, AssetBTC, AssetLTC]
+      expect(unionAssets(assetsA)(assetsB)).toEqual([AssetBNB, AssetBTC, AssetLTC, AssetETH])
     })
   })
 })

--- a/src/renderer/helpers/fp/array.ts
+++ b/src/renderer/helpers/fp/array.ts
@@ -1,8 +1,13 @@
 import * as A from 'fp-ts/lib/Array'
 
-import { eqChain } from './eq'
+import { eqAsset, eqChain } from './eq'
 
 /**
  * Merges array of `Chain` and removes duplications
  */
 export const unionChains = A.union(eqChain)
+
+/**
+ * Merges array of `Assets` and removes duplications
+ */
+export const unionAssets = A.union(eqAsset)

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -1,6 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { PoolData } from '@thorchain/asgardex-util'
-import { Balance } from '@xchainjs/xchain-client'
+import { Address, Balance } from '@xchainjs/xchain-client'
 import { Asset, AssetAmount, BaseAmount, Chain } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
@@ -11,7 +11,7 @@ import * as O from 'fp-ts/lib/Option'
 import * as S from 'fp-ts/lib/string'
 
 import { LedgerError } from '../../../shared/api/types'
-import { WalletAddress } from '../../../shared/wallet/types'
+import { WalletAddress, WalletType } from '../../../shared/wallet/types'
 import { DepositAssetFees, DepositFees, SwapFeesParams } from '../../services/chain/types'
 import { ApproveParams } from '../../services/ethereum/types'
 import { PoolAddress, PoolShare } from '../../services/midgard/types'
@@ -178,7 +178,9 @@ const eqLedgerError = Eq.struct<LedgerError>({
   msg: eqString
 })
 
-export const eqAddress = eqString
+export const eqWalletType: Eq.Eq<WalletType> = eqString
+
+export const eqAddress: Eq.Eq<Address> = eqString
 
 export const eqWalletAddress = Eq.struct<WalletAddress>({
   address: eqString,

--- a/src/renderer/helpers/test/testWalletHelper.ts
+++ b/src/renderer/helpers/test/testWalletHelper.ts
@@ -1,0 +1,27 @@
+import { AssetRuneNative, baseAmount } from '@xchainjs/xchain-util'
+
+import { WalletBalance } from '../../services/wallet/types'
+
+/**
+ * Helper to create mock instances of `WalletBalances
+ *
+ * It returns following `WalletBalances` by default
+ * ```ts
+ *  {
+ *    walletType: 'keystore',
+ *    amount: baseAmount(1),
+ *    asset: AssetRuneNative,
+ *    walletAddress: 'wallet-address'
+ *    walletIndex: 0
+ * }
+ * ```
+ * Pass any values you want to override
+ */
+export const mockWalletBalance = (overrides?: Partial<WalletBalance>): WalletBalance => ({
+  walletType: 'keystore',
+  amount: baseAmount(1),
+  asset: AssetRuneNative,
+  walletAddress: 'wallet-address',
+  walletIndex: 0,
+  ...overrides
+})

--- a/src/renderer/helpers/walletHelper.test.ts
+++ b/src/renderer/helpers/walletHelper.test.ts
@@ -1,4 +1,12 @@
-import { baseAmount, assetToBase, AssetRuneNative, AssetBNB, AssetLTC, assetAmount } from '@xchainjs/xchain-util'
+import {
+  assetToBase,
+  AssetRuneNative,
+  AssetBNB,
+  AssetLTC,
+  assetAmount,
+  BNBChain,
+  THORChain
+} from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -7,8 +15,10 @@ import { ASSETS_TESTNET } from '../../shared/mock/assets'
 import { NonEmptyWalletBalances, WalletBalance, WalletBalances } from '../services/wallet/types'
 import { isRuneNativeAsset } from './assetHelper'
 import { eqWalletBalances } from './fp/eq'
+import { mockWalletBalance } from './test/testWalletHelper'
 import {
   filterWalletBalancesByAssets,
+  getAddressFromBalancesByChain,
   getAssetAmountByAsset,
   getBnbAmountFromBalances,
   getLtcAmountFromBalances,
@@ -17,36 +27,26 @@ import {
 } from './walletHelper'
 
 describe('walletHelper', () => {
-  const RUNE_WB: WalletBalance = {
-    amount: baseAmount('12300000000'),
-    asset: AssetRuneNative,
-    walletAddress: 'rune native wallet address',
-    walletType: 'keystore'
-  }
-  const RUNE_LEDGER_WB: WalletBalance = {
-    ...RUNE_WB,
-    amount: assetToBase(assetAmount(23)),
+  const RUNE_WB = mockWalletBalance({ amount: assetToBase(assetAmount(1)), walletAddress: 'thor-address' })
+  const RUNE_LEDGER_WB = mockWalletBalance({
+    amount: assetToBase(assetAmount(2)),
+    walletAddress: 'thor-ledger-address',
     walletType: 'ledger'
-  }
-  const BOLT_WB: WalletBalance = {
-    amount: baseAmount('23400000000'),
-    asset: ASSETS_TESTNET.BOLT,
-    walletAddress: 'bolt wallet address',
-    walletType: 'keystore'
-  }
-  const BNB_WB: WalletBalance = {
-    amount: baseAmount('45600000000'),
-    asset: AssetBNB,
-    walletAddress: 'bnb wallet address',
-    walletType: 'keystore'
-  }
-
-  const LTC_WB: WalletBalance = {
-    amount: baseAmount('45300000000'),
-    asset: AssetLTC,
-    walletAddress: 'ltc wallet address',
-    walletType: 'keystore'
-  }
+  })
+  const BOLT_WB = mockWalletBalance({
+    amount: assetToBase(assetAmount(3)),
+    walletAddress: 'bolt-address',
+    asset: ASSETS_TESTNET.BOLT
+  })
+  const BNB_WB: WalletBalance = mockWalletBalance({
+    amount: assetToBase(assetAmount(4)),
+    walletAddress: 'bnb-address',
+    asset: AssetBNB
+  })
+  const LTC_WB = mockWalletBalance({
+    amount: assetToBase(assetAmount(5)),
+    asset: AssetLTC
+  })
 
   describe('amountByAsset', () => {
     it('returns amount of RUNE', () => {
@@ -54,10 +54,10 @@ describe('walletHelper', () => {
       expect(
         FP.pipe(
           result,
-          O.map((a) => a.amount().toNumber()),
-          O.getOrElse(() => NaN)
+          O.map((a) => a.amount().toString()),
+          O.getOrElse(() => '')
         )
-      ).toEqual(123)
+      ).toEqual('1')
     })
     it('returns None for an unknown asset', () => {
       const result = getAssetAmountByAsset([RUNE_WB, BNB_WB], ASSETS_TESTNET.FTM)
@@ -74,7 +74,7 @@ describe('walletHelper', () => {
       const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([RUNE_WB, BOLT_WB, BNB_WB])
       const result = O.toNullable(getWalletBalanceByAsset(balances, AssetBNB))
       expect(result?.asset.symbol).toEqual('BNB')
-      expect(result?.amount.amount().toString()).toEqual('45600000000')
+      expect(result?.amount.amount().toString()).toEqual('400000000')
     })
     it('returns none if BNB is not available', () => {
       const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([RUNE_WB, BOLT_WB])
@@ -94,8 +94,8 @@ describe('walletHelper', () => {
       expect(
         FP.pipe(
           result,
-          // Check transformation of `AssetAmount` to `BaseAmount`
-          O.map((a) => a.amount().isEqualTo('456')),
+          // Check transformation from `BaseAmount` to `AssetAmount`
+          O.map((a) => a.amount().isEqualTo(4)),
           O.getOrElse(() => false)
         )
       ).toBeTruthy()
@@ -112,8 +112,8 @@ describe('walletHelper', () => {
       expect(
         FP.pipe(
           result,
-          // Check transformation of `AssetAmount` to `BaseAmount`
-          O.map((a) => a.amount().isEqualTo('453')),
+          // Check transformation from `BaseAmount` to `AssetAmount`
+          O.map((a) => a.amount().isEqualTo('5')),
           O.getOrElse(() => false)
         )
       ).toBeTruthy()
@@ -153,6 +153,29 @@ describe('walletHelper', () => {
     it('returns none if BNB wallet address is not available', () => {
       const balances: WalletBalances = NEA.fromReadonlyNonEmptyArray([BOLT_WB, BNB_WB])
       const result = getWalletByAddress(balances, RUNE_WB.walletAddress)
+      expect(result).toBeNone()
+    })
+  })
+
+  describe('getAddressFromBalancesByChain', () => {
+    it('address of BOLT keystore ', () => {
+      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB])
+      const result = getAddressFromBalancesByChain({ balances, chain: BNBChain, walletType: 'keystore' })
+      expect(O.toNullable(result)).toEqual('bolt-address')
+    })
+    it('address of THOR keystore ', () => {
+      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB])
+      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'keystore' })
+      expect(O.toNullable(result)).toEqual('thor-address')
+    })
+    it('address of THOR ledger ', () => {
+      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB, RUNE_LEDGER_WB])
+      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'ledger' })
+      expect(O.toNullable(result)).toEqual('thor-ledger-address')
+    })
+    it('no address of THOR ledger ', () => {
+      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BNB_WB])
+      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'ledger' })
       expect(result).toBeNone()
     })
   })

--- a/src/renderer/helpers/walletHelper.test.ts
+++ b/src/renderer/helpers/walletHelper.test.ts
@@ -1,12 +1,4 @@
-import {
-  baseAmount,
-  assetToBase,
-  assetFromString,
-  AssetRuneNative,
-  AssetBNB,
-  AssetLTC,
-  assetAmount
-} from '@xchainjs/xchain-util'
+import { baseAmount, assetToBase, AssetRuneNative, AssetBNB, AssetLTC, assetAmount } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -36,7 +28,6 @@ describe('walletHelper', () => {
     amount: assetToBase(assetAmount(23)),
     walletType: 'ledger'
   }
-  const BNB = O.fromNullable(assetFromString('BNB.BNB'))
   const BOLT_WB: WalletBalance = {
     amount: baseAmount('23400000000'),
     asset: ASSETS_TESTNET.BOLT,
@@ -81,18 +72,18 @@ describe('walletHelper', () => {
   describe('getWalletBalanceByAsset', () => {
     it('returns amount of BNB', () => {
       const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([RUNE_WB, BOLT_WB, BNB_WB])
-      const result = O.toNullable(getWalletBalanceByAsset(balances, BNB))
+      const result = O.toNullable(getWalletBalanceByAsset(balances, AssetBNB))
       expect(result?.asset.symbol).toEqual('BNB')
       expect(result?.amount.amount().toString()).toEqual('45600000000')
     })
     it('returns none if BNB is not available', () => {
       const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([RUNE_WB, BOLT_WB])
-      const result = getWalletBalanceByAsset(balances, BNB)
+      const result = getWalletBalanceByAsset(balances, AssetBNB)
       expect(result).toBeNone()
     })
     it('returns none for empty lists of `AssetWB`', () => {
       const balances: O.Option<NonEmptyWalletBalances> = NEA.fromArray([])
-      const result = getWalletBalanceByAsset(balances, BNB)
+      const result = getWalletBalanceByAsset(balances, AssetBNB)
       expect(result).toBeNone()
     })
   })

--- a/src/renderer/helpers/walletHelper.test.ts
+++ b/src/renderer/helpers/walletHelper.test.ts
@@ -1,4 +1,12 @@
-import { baseAmount, assetFromString, AssetRuneNative, AssetBNB, AssetLTC } from '@xchainjs/xchain-util'
+import {
+  baseAmount,
+  assetToBase,
+  assetFromString,
+  AssetRuneNative,
+  AssetBNB,
+  AssetLTC,
+  assetAmount
+} from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -22,6 +30,11 @@ describe('walletHelper', () => {
     asset: AssetRuneNative,
     walletAddress: 'rune native wallet address',
     walletType: 'keystore'
+  }
+  const RUNE_LEDGER_WB: WalletBalance = {
+    ...RUNE_WB,
+    amount: assetToBase(assetAmount(23)),
+    walletType: 'ledger'
   }
   const BNB = O.fromNullable(assetFromString('BNB.BNB'))
   const BOLT_WB: WalletBalance = {
@@ -121,9 +134,17 @@ describe('walletHelper', () => {
   })
 
   describe('filterWalletBalancesByAssets', () => {
-    it('returns filted wallet balances by assets', () => {
-      const result = filterWalletBalancesByAssets([RUNE_WB, BOLT_WB, BNB_WB, LTC_WB], [AssetBNB, AssetLTC])
+    it('filters misc. assets', () => {
+      const result = filterWalletBalancesByAssets(
+        [RUNE_WB, RUNE_LEDGER_WB, BOLT_WB, BNB_WB, LTC_WB],
+        [AssetBNB, AssetLTC]
+      )
       expect(eqWalletBalances.equals(result, [BNB_WB, LTC_WB])).toBeTruthy()
+    })
+
+    it('filters rune keystore + ledger', () => {
+      const result = filterWalletBalancesByAssets([RUNE_WB, RUNE_LEDGER_WB, BOLT_WB, BNB_WB, LTC_WB], [AssetRuneNative])
+      expect(eqWalletBalances.equals(result, [RUNE_WB, RUNE_LEDGER_WB])).toBeTruthy()
     })
     it('returns empty array if no asset is available', () => {
       const result = filterWalletBalancesByAssets([RUNE_WB, BOLT_WB], [AssetLTC])

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -4,13 +4,12 @@ import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 
-import { WalletAddress } from '../../shared/wallet/types'
+import { WalletAddress, WalletType } from '../../shared/wallet/types'
 import { ZERO_ASSET_AMOUNT } from '../const'
 import { WalletBalances } from '../services/clients'
 import { NonEmptyWalletBalances, WalletBalance } from '../services/wallet/types'
 import { isBnbAsset, isEthAsset, isLtcAsset, isRuneNativeAsset } from './assetHelper'
-import { eqAddress, eqAsset } from './fp/eq'
-import { sequenceTOption } from './fpHelpers'
+import { eqAddress, eqAsset, eqWalletType } from './fp/eq'
 
 /**
  * Tries to find an `AssetAmount` of an `Asset`
@@ -27,14 +26,36 @@ export const getAssetAmountByAsset = (balances: WalletBalances, assetToFind: Ass
 
 export const getWalletBalanceByAsset = (
   oWalletBalances: O.Option<NonEmptyWalletBalances>,
-  oAsset: O.Option<Asset>
+  asset: Asset
 ): O.Option<WalletBalance> =>
   FP.pipe(
-    sequenceTOption(oWalletBalances, oAsset),
-    O.chain(([walletBalances, asset]) =>
+    oWalletBalances,
+    O.chain((walletBalances) =>
       FP.pipe(
         walletBalances,
         A.findFirst(({ asset: assetInList }) => eqAsset.equals(assetInList, asset))
+      )
+    )
+  )
+
+export const getWalletBalanceByAssetAndWalletType = ({
+  oWalletBalances,
+  asset,
+  walletType
+}: {
+  oWalletBalances: O.Option<NonEmptyWalletBalances>
+  asset: Asset
+  walletType: WalletType
+}): O.Option<WalletBalance> =>
+  FP.pipe(
+    oWalletBalances,
+    O.chain((walletBalances) =>
+      FP.pipe(
+        walletBalances,
+        A.findFirst(
+          ({ asset: assetInList, walletType: balanceWalletType }) =>
+            eqAsset.equals(assetInList, asset) && eqWalletType.equals(walletType, balanceWalletType)
+        )
       )
     )
   )

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -134,7 +134,6 @@ export const addressFromOptionalWalletAddress = (
   oWalletAddress: O.Option<Pick<WalletAddress, 'address'>>
 ): O.Option<Address> => FP.pipe(oWalletAddress, O.map(addressFromWalletAddress))
 
-// TODO (@veado) Add tests
 export const getAddressFromBalancesByChain = ({
   balances,
   chain,

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -1,5 +1,5 @@
 import { Address } from '@xchainjs/xchain-client'
-import { Asset, AssetAmount, baseToAsset } from '@xchainjs/xchain-util'
+import { Asset, AssetAmount, baseToAsset, Chain } from '@xchainjs/xchain-util'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
@@ -9,7 +9,7 @@ import { ZERO_ASSET_AMOUNT } from '../const'
 import { WalletBalances } from '../services/clients'
 import { NonEmptyWalletBalances, WalletBalance } from '../services/wallet/types'
 import { isBnbAsset, isEthAsset, isLtcAsset, isRuneNativeAsset } from './assetHelper'
-import { eqAddress, eqAsset, eqWalletType } from './fp/eq'
+import { eqAddress, eqAsset, eqChain, eqWalletType } from './fp/eq'
 
 /**
  * Tries to find an `AssetAmount` of an `Asset`
@@ -133,6 +133,25 @@ export const addressFromWalletAddress = ({ address }: Pick<WalletAddress, 'addre
 export const addressFromOptionalWalletAddress = (
   oWalletAddress: O.Option<Pick<WalletAddress, 'address'>>
 ): O.Option<Address> => FP.pipe(oWalletAddress, O.map(addressFromWalletAddress))
+
+// TODO (@veado) Add tests
+export const getAddressFromBalancesByChain = ({
+  balances,
+  chain,
+  walletType
+}: {
+  balances: NonEmptyWalletBalances
+  chain: Chain
+  walletType: WalletType
+}): O.Option<Address> =>
+  FP.pipe(
+    balances,
+    A.findFirst(
+      ({ asset, walletType: balanceWalletType }) =>
+        eqChain.equals(chain, asset.chain) && eqWalletType.equals(walletType, balanceWalletType)
+    ),
+    O.map(({ walletAddress }) => walletAddress)
+  )
 
 export const getWalletByAddress = (walletBalances: WalletBalances, address: Address): O.Option<WalletBalance> =>
   FP.pipe(

--- a/src/renderer/routes/pools/pools.test.ts
+++ b/src/renderer/routes/pools/pools.test.ts
@@ -24,18 +24,16 @@ describe('Pools routes', () => {
 
   describe('Swap routes', () => {
     it('template', () => {
-      expect(swap.template).toEqual('/pools/swap/:walletType/:source|:target')
+      expect(swap.template).toEqual('/pools/swap/:source|:target')
     })
     it('returns path by given source/target parameters', () => {
-      expect(swap.path({ source: 'BNB', target: 'RUNE', walletType: 'keystore' })).toEqual(
-        '/pools/swap/keystore/bnb|rune'
-      )
+      expect(swap.path({ source: 'BNB', target: 'RUNE' })).toEqual('/pools/swap/bnb|rune')
     })
     it('redirects to base path if source is empty', () => {
-      expect(swap.path({ source: '', target: 'RUNE', walletType: 'keystore' })).toEqual('/pools/swap')
+      expect(swap.path({ source: '', target: 'RUNE' })).toEqual('/pools/swap')
     })
     it('redirects to base path if target is empty', () => {
-      expect(swap.path({ source: 'bnb', target: '', walletType: 'keystore' })).toEqual('/pools/swap')
+      expect(swap.path({ source: 'bnb', target: '' })).toEqual('/pools/swap')
     })
   })
 

--- a/src/renderer/routes/pools/pools.test.ts
+++ b/src/renderer/routes/pools/pools.test.ts
@@ -24,16 +24,18 @@ describe('Pools routes', () => {
 
   describe('Swap routes', () => {
     it('template', () => {
-      expect(swap.template).toEqual('/pools/swap/:source|:target')
+      expect(swap.template).toEqual('/pools/swap/:walletType/:source|:target')
     })
     it('returns path by given source/target parameters', () => {
-      expect(swap.path({ source: 'BNB', target: 'RUNE' })).toEqual('/pools/swap/bnb|rune')
+      expect(swap.path({ source: 'BNB', target: 'RUNE', walletType: 'keystore' })).toEqual(
+        '/pools/swap/keystore/bnb|rune'
+      )
     })
     it('redirects to base path if source is empty', () => {
-      expect(swap.path({ source: '', target: 'RUNE' })).toEqual('/pools/swap')
+      expect(swap.path({ source: '', target: 'RUNE', walletType: 'keystore' })).toEqual('/pools/swap')
     })
     it('redirects to base path if target is empty', () => {
-      expect(swap.path({ source: 'bnb', target: '' })).toEqual('/pools/swap')
+      expect(swap.path({ source: 'bnb', target: '', walletType: 'keystore' })).toEqual('/pools/swap')
     })
   })
 

--- a/src/renderer/routes/pools/swap.ts
+++ b/src/renderer/routes/pools/swap.ts
@@ -1,3 +1,4 @@
+import { WalletType } from '../../../shared/wallet/types'
 import { Route } from '../types'
 import { base as poolsBase } from './base'
 
@@ -8,15 +9,16 @@ export const base: Route<void> = {
   }
 }
 
-export type SwapRouteParams = { source: string; target: string }
+export type SwapRouteParams = { source: string; walletType: WalletType; target: string }
 export const swap: Route<SwapRouteParams> = {
   /**
    * Use '|' 'cause asset symbols have '-' separator
+   * `walletType` - wallet type of the source
    */
-  template: `${base.template}/:source|:target`,
-  path: ({ source, target }) => {
-    if (source && target) {
-      return `${base.template}/${source.toLowerCase()}|${target.toLowerCase()}`
+  template: `${base.template}/:walletType/:source|:target`,
+  path: ({ source, target, walletType }) => {
+    if (!!source && !!target) {
+      return `${base.template}/${walletType}/${source.toLowerCase()}|${target.toLowerCase()}`
     }
     // Redirect to base route if passed params are empty
     return base.path()

--- a/src/renderer/routes/pools/swap.ts
+++ b/src/renderer/routes/pools/swap.ts
@@ -1,4 +1,3 @@
-import { WalletType } from '../../../shared/wallet/types'
 import { Route } from '../types'
 import { base as poolsBase } from './base'
 
@@ -9,16 +8,16 @@ export const base: Route<void> = {
   }
 }
 
-export type SwapRouteParams = { source: string; walletType: WalletType; target: string }
+export type SwapRouteParams = { source: string; target: string }
 export const swap: Route<SwapRouteParams> = {
   /**
    * Use '|' 'cause asset symbols have '-' separator
    * `walletType` - wallet type of the source
    */
-  template: `${base.template}/:walletType/:source|:target`,
-  path: ({ source, target, walletType }) => {
+  template: `${base.template}/:source|:target`,
+  path: ({ source, target }) => {
     if (!!source && !!target) {
-      return `${base.template}/${walletType}/${source.toLowerCase()}|${target.toLowerCase()}`
+      return `${base.template}/${source.toLowerCase()}|${target.toLowerCase()}`
     }
     // Redirect to base route if passed params are empty
     return base.path()

--- a/src/renderer/services/app/service.test.ts
+++ b/src/renderer/services/app/service.test.ts
@@ -1,13 +1,14 @@
 import { map, withLatestFrom } from 'rxjs/operators'
 
+import { envOrDefault } from '../../../shared/utils/env'
 import { network$, changeNetwork, onlineStatus$ } from './service'
 import { OnlineStatus } from './types'
 
 describe('services/app/service/', () => {
   describe('network$', () => {
-    it('returns mainnet by default', () => {
+    it('gets default network from env', () => {
       runObservable(({ expectObservable }) => {
-        expectObservable(network$).toBe('a', { a: 'mainnet' })
+        expectObservable(network$).toBe('a', { a: envOrDefault(process.env.REACT_APP_DEFAULT_NETWORK, 'mainnet') })
       })
     })
 

--- a/src/renderer/services/binance/transaction.ts
+++ b/src/renderer/services/binance/transaction.ts
@@ -21,21 +21,22 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendLedgerTx = ({
     network,
     params,
-    walletIndex
+    walletIndex = 0
   }: {
     network: Network
     params: SendTxParams
     walletIndex?: number
-  }) => {
+  }): TxHashLD => {
+    const { asset, amount, sender, recipient, memo } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: BNBChain,
       network,
-      asset: params.asset,
-      amount: params.amount,
-      sender: params.sender,
-      recipient: params.recipient,
-      memo: params.memo,
-      walletIndex: walletIndex ? walletIndex : 0
+      asset,
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletIndex
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 
@@ -58,7 +59,7 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       RxOp.startWith(RD.pending)
     )
   }
-  const sendTx = (params: SendTxParams, walletIndex?: number) =>
+  const sendTx = (params: SendTxParams, walletIndex?: number): TxHashLD =>
     FP.pipe(
       network$,
       RxOp.switchMap((network) => {

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -102,6 +102,7 @@ export const sendPoolTx$ = ({
 }: SendPoolTxParams): TxHashLD => {
   switch (asset.chain) {
     case ETHChain:
+      // TODO(@asgdx-team) Support `walletType`to provide Ledger & Co.
       return ETH.sendPoolTx$({
         router,
         recipient,
@@ -114,7 +115,6 @@ export const sendPoolTx$ = ({
       return THOR.sendPoolTx$({ walletType, amount, asset, memo })
 
     default:
-      // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
       return sendTx$({ sender, walletType, asset, recipient, amount, memo, feeOption, walletIndex })
   }
 }

--- a/src/renderer/services/chain/transaction/swap.ts
+++ b/src/renderer/services/chain/transaction/swap.ts
@@ -26,7 +26,14 @@ const { pools: midgardPoolsService, validateNode$ } = midgardService
  * @returns SwapState$ - Observable state to reflect loading status. It provides all data we do need to display status in `TxModul`
  *
  */
-export const swap$ = ({ poolAddress: poolAddresses, asset, amount, memo }: SwapTxParams): SwapState$ => {
+export const swap$ = ({
+  poolAddress: poolAddresses,
+  asset,
+  amount,
+  memo,
+  walletType,
+  sender
+}: SwapTxParams): SwapState$ => {
   // total of progress
   const total = O.some(100)
 
@@ -58,14 +65,14 @@ export const swap$ = ({ poolAddress: poolAddresses, asset, amount, memo }: SwapT
       setState({ ...getState(), step: 2, swapTx: RD.pending, swap: RD.progress({ loaded: 50, total }) })
       // 2. send swap tx
       return sendPoolTx$({
-        // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
         router: poolAddresses.router, // emtpy string for RuneNative
         asset,
         recipient: poolAddresses.address, // emtpy string for RuneNative
         amount,
         memo,
-        feeOption: ChainTxFeeOption.SWAP
+        feeOption: ChainTxFeeOption.SWAP,
+        sender
       })
     }),
     liveData.chain((txHash) => {

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -122,6 +122,8 @@ export type SwapTxParams = {
   readonly asset: Asset
   readonly amount: BaseAmount
   readonly memo: string
+  readonly walletType: WalletType
+  readonly sender: Address
 }
 
 export type SwapStateHandler = (p: SwapTxParams) => SwapState$

--- a/src/renderer/types/asgardex.ts
+++ b/src/renderer/types/asgardex.ts
@@ -1,6 +1,8 @@
 import { BaseAmount, Asset } from '@xchainjs/xchain-util'
 import { Option } from 'fp-ts/lib/Option'
 
+import { WalletType } from '../../shared/wallet/types'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FixmeType = any
 
@@ -12,6 +14,11 @@ export type Pair = {
 export type AssetWithAmount = {
   asset: Asset
   amount: BaseAmount
+}
+
+export type AssetWithWalletType = {
+  asset: Asset
+  walletType: WalletType
 }
 
 /**

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -111,8 +111,7 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
               event.stopPropagation()
               clickSwapHandler({
                 source: assetToString(pool.asset),
-                target: assetToString(pool.target),
-                walletType: 'keystore' /* select keystore wallet by default */
+                target: assetToString(pool.target)
               })
             }}>
             <SwapOutlined />

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -71,12 +71,11 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
 
   const selectedPricePool = useObservableState(selectedPricePool$, PoolHelpers.RUNE_PRICE_POOL)
 
-  const getSwapPath = poolsRoutes.swap.path
   const clickSwapHandler = useCallback(
     (p: SwapRouteParams) => {
-      history.push(getSwapPath(p))
+      history.push(poolsRoutes.swap.path(p))
     },
-    [getSwapPath, history]
+    [history]
   )
 
   const renderBtnPoolsColumn = useCallback(
@@ -110,7 +109,11 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()
-              clickSwapHandler({ source: assetToString(pool.asset), target: assetToString(pool.target) })
+              clickSwapHandler({
+                source: assetToString(pool.asset),
+                target: assetToString(pool.target),
+                walletType: 'keystore' /* select keystore wallet by default */
+              })
             }}>
             <SwapOutlined />
             {isDesktopView && intl.formatMessage({ id: 'common.swap' })}

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -41,7 +41,7 @@ import * as Styled from './SwapView.styles'
 type Props = {}
 
 export const SwapView: React.FC<Props> = (_): JSX.Element => {
-  const { source, target, walletType } = useParams<SwapRouteParams>()
+  const { source, target } = useParams<SwapRouteParams>()
   const intl = useIntl()
   const history = useHistory()
 
@@ -241,7 +241,6 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
                   validatePassword$={validatePassword$}
                   goToTransaction={openExplorerTxUrl}
                   assets={{ inAsset: sourceAsset, outAsset: targetAsset }}
-                  walletType={walletType}
                   poolAddress={selectedPoolAddress}
                   availableAssets={availableAssets}
                   poolsData={poolsData}

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -41,7 +41,7 @@ import * as Styled from './SwapView.styles'
 type Props = {}
 
 export const SwapView: React.FC<Props> = (_): JSX.Element => {
-  const { source, target } = useParams<SwapRouteParams>()
+  const { source, target, walletType } = useParams<SwapRouteParams>()
   const intl = useIntl()
   const history = useHistory()
 
@@ -241,6 +241,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
                   validatePassword$={validatePassword$}
                   goToTransaction={openExplorerTxUrl}
                   assets={{ inAsset: sourceAsset, outAsset: targetAsset }}
+                  walletType={walletType}
                   poolAddress={selectedPoolAddress}
                   availableAssets={availableAssets}
                   poolsData={poolsData}

--- a/src/renderer/views/wallet/send/SendViewBCH.tsx
+++ b/src/renderer/views/wallet/send/SendViewBCH.tsx
@@ -39,7 +39,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
+  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -52,7 +52,11 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
   const history = useHistory()
 
   const oWalletBalance = useMemo(
-    () => getWalletBalanceByAddressAndAsset(oBalances, walletAddress, asset),
+    () =>
+      FP.pipe(
+        oBalances,
+        O.chain((balances) => getWalletBalanceByAddressAndAsset({ balances, address: walletAddress, asset }))
+      ),
     [asset, oBalances, walletAddress]
   )
 

--- a/src/renderer/views/wallet/send/SendViewBTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewBTC.tsx
@@ -39,7 +39,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
+  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 

--- a/src/renderer/views/wallet/send/SendViewETH.tsx
+++ b/src/renderer/views/wallet/send/SendViewETH.tsx
@@ -37,7 +37,7 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
+  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 

--- a/src/renderer/views/wallet/send/SendViewLTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewLTC.tsx
@@ -39,7 +39,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, O.some(asset)), [oBalances, asset])
+  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
   const { transfer$ } = useChainContext()
 

--- a/src/renderer/views/wallet/send/SendViewTHOR.tsx
+++ b/src/renderer/views/wallet/send/SendViewTHOR.tsx
@@ -41,7 +41,14 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
   const history = useHistory()
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAddress(oBalances, walletAddress), [oBalances, walletAddress])
+  const oWalletBalance = useMemo(
+    () =>
+      FP.pipe(
+        oBalances,
+        O.chain((balances) => getWalletBalanceByAddress(balances, walletAddress))
+      ),
+    [oBalances, walletAddress]
+  )
 
   const { transfer$ } = useChainContext()
   const {


### PR DESCRIPTION
- [x] Enable Ledger in Swap
- [x] Update `swap$` to accept `sender`
- [x] Helpers `hasLedgerInBalancesByChain`, `balancesToSwapFrom`, `hasLedgerInBalancesByChain` in `Swap.utils` (incl. tests)
- [x] Helpers `getAddressFromBalancesByChain` in `walletHelper` incl. test
- [x] Simplified misc. helpers in `walletHelper` to avoid `O.Option` parameters
- [x] Handle `walletType` in `AssetSelect`
- [x] Fix `CheckButton` to set `checked` state from outside
- [x] `Eq` helper `unionAssets` (incl. test)
- [x] Test helper `mockWalletBalance`

Close #1773 
Close #1774
Close #1709
Closes  #1570