### PR TITLE
[Header] Make rune price visible for smaller windows

### DIFF
--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -107,6 +107,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
 
   const [menuVisible, setMenuVisible] = useState(false)
 
+  const isSmallMobileView = Grid.useBreakpoint()?.xs ?? false
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
   const isLargeDesktopView = Grid.useBreakpoint()?.xl ?? false
 
@@ -324,16 +325,18 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   {renderLogo}
                 </Row>
               </Col>
-              <Col flex={1}>
-                <Row>
-                  <HeaderStats
-                    runePrice={runePriceRD}
-                    reloadRunePrice={reloadRunePrice}
-                    volume24Price={volume24PriceRD}
-                    reloadVolume24Price={reloadVolume24Price}
-                  />
-                </Row>
-              </Col>
+              {!isSmallMobileView && (
+                <Col flex={1}>
+                  <Row>
+                    <HeaderStats
+                      runePrice={runePriceRD}
+                      reloadRunePrice={reloadRunePrice}
+                      volume24Price={volume24PriceRD}
+                      reloadVolume24Price={reloadVolume24Price}
+                    />
+                  </Row>
+                </Col>
+              )}
               <Col>
                 <Row align="middle" style={{ height: headerHeight, cursor: 'pointer' }} onClick={toggleMenu}>
                   {menuVisible ? (

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -107,7 +107,6 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
 
   const [menuVisible, setMenuVisible] = useState(false)
 
-  const isSmallMobileView = Grid.useBreakpoint()?.xs ?? false
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
   const isLargeDesktopView = Grid.useBreakpoint()?.xl ?? false
 
@@ -325,18 +324,16 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   {renderLogo}
                 </Row>
               </Col>
-              {!isSmallMobileView && (
-                <Col flex={1}>
-                  <Row>
-                    <HeaderStats
-                      runePrice={runePriceRD}
-                      reloadRunePrice={reloadRunePrice}
-                      volume24Price={volume24PriceRD}
-                      reloadVolume24Price={reloadVolume24Price}
-                    />
-                  </Row>
-                </Col>
-              )}
+              <Col flex={1}>
+                <Row>
+                  <HeaderStats
+                    runePrice={runePriceRD}
+                    reloadRunePrice={reloadRunePrice}
+                    volume24Price={volume24PriceRD}
+                    reloadVolume24Price={reloadVolume24Price}
+                  />
+                </Row>
+              </Col>
               <Col>
                 <Row align="middle" style={{ height: headerHeight, cursor: 'pointer' }} onClick={toggleMenu}>
                   {menuVisible ? (

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -290,7 +290,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
               <Col>
                 <Row justify="space-between" align="middle" style={{ height: headerHeight }}>
                   {renderLogo}
-                  {isLargeDesktopView && (
+                  {isDesktopView && (
                     <HeaderStats
                       runePrice={runePriceRD}
                       reloadRunePrice={reloadRunePrice}

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -290,14 +290,12 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
               <Col>
                 <Row justify="space-between" align="middle" style={{ height: headerHeight }}>
                   {renderLogo}
-                  {isDesktopView && (
-                    <HeaderStats
-                      runePrice={runePriceRD}
-                      reloadRunePrice={reloadRunePrice}
-                      volume24Price={volume24PriceRD}
-                      reloadVolume24Price={reloadVolume24Price}
-                    />
-                  )}
+                  <HeaderStats
+                    runePrice={runePriceRD}
+                    reloadRunePrice={reloadRunePrice}
+                    volume24Price={volume24PriceRD}
+                    reloadVolume24Price={reloadVolume24Price}
+                  />
                 </Row>
               </Col>
               <Col span="auto">
@@ -324,6 +322,16 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
               <Col>
                 <Row align="middle" style={{ height: headerHeight }}>
                   {renderLogo}
+                </Row>
+              </Col>
+              <Col>
+                <Row align="middle">
+                  <HeaderStats
+                    runePrice={runePriceRD}
+                    reloadRunePrice={reloadRunePrice}
+                    volume24Price={volume24PriceRD}
+                    reloadVolume24Price={reloadVolume24Price}
+                  />
                 </Row>
               </Col>
               <Col>

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -324,8 +324,8 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
                   {renderLogo}
                 </Row>
               </Col>
-              <Col>
-                <Row align="middle">
+              <Col flex={1}>
+                <Row>
                   <HeaderStats
                     runePrice={runePriceRD}
                     reloadRunePrice={reloadRunePrice}

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { baseToAsset, formatAssetAmountCurrency, currencySymbolByAsset } from '@xchainjs/xchain-util'
+import { Grid } from 'antd'
 import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
@@ -20,6 +21,8 @@ export type Props = {
 
 export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
   const { runePrice: runePriceRD, reloadRunePrice, volume24Price: volume24PriceRD, reloadVolume24Price } = props
+
+  const isSmallMobileView = Grid.useBreakpoint()?.xs ?? false
 
   const intl = useIntl()
 
@@ -97,10 +100,12 @@ export const HeaderStats: React.FC<Props> = (props): JSX.Element => {
         <Styled.Title>{intl.formatMessage({ id: 'common.price.rune' })}</Styled.Title>
         <Styled.Label loading={RD.isPending(runePriceRD) ? 'true' : 'false'}>{runePriceLabel}</Styled.Label>
       </Styled.Container>
-      <Styled.Container onClick={reloadVolume24PriceHandler} clickable={!RD.isPending(volume24PriceRD)}>
-        <Styled.Title>{intl.formatMessage({ id: 'common.volume24' })}</Styled.Title>
-        <Styled.Label loading={RD.isPending(volume24PriceRD) ? 'true' : 'false'}>{volume24PriceLabel}</Styled.Label>
-      </Styled.Container>
+      {!isSmallMobileView && (
+        <Styled.Container onClick={reloadVolume24PriceHandler} clickable={!RD.isPending(volume24PriceRD)}>
+          <Styled.Title>{intl.formatMessage({ id: 'common.volume24' })}</Styled.Title>
+          <Styled.Label loading={RD.isPending(volume24PriceRD) ? 'true' : 'false'}>{volume24PriceLabel}</Styled.Label>
+        </Styled.Container>
+      )}
     </Styled.Wrapper>
   )
 }


### PR DESCRIPTION
Desktop:
<img width="752" alt="Screenshot 2021-10-25 at 11 46 39" src="https://user-images.githubusercontent.com/87367763/138674044-74ba2029-f42d-4cc8-875e-93c6deb91b6a.png">

Mobile:
<img width="398" alt="Screenshot 2021-10-25 at 11 55 06" src="https://user-images.githubusercontent.com/87367763/138674946-c29a38c9-9ef4-4c23-866c-3057740c7e8d.png">


Closes #1878