### PR TITLE
Restructure walletAddress / walletIndex data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.0 (2021-10-27)
+# 0.5.0 (2021-10-28)
 
 ## Add
 
@@ -20,6 +20,7 @@
 - Update AssetData|Menu|Select components to show wallet type [#1867](https://github.com/thorchain/asgardex-electron/pull/1867)
 - [Header] Make rune price visible for smaller window sizes [#1880](https://github.com/thorchain/asgardex-electron/pull/1880)
 - [Header] Tooltip to explain VOLUME (24h) [#1885](https://github.com/thorchain/asgardex-electron/pull/1885)
+- [ERC] Update whitelist (incl. icon support for ETH.THOR, ETH.FOX) [#1894](https://github.com/thorchain/asgardex-electron/issues/1894), [#1896](https://github.com/thorchain/asgardex-electron/issues/1896)
 
 ## Fix
 

--- a/src/main/api/ledger/binance/address.ts
+++ b/src/main/api/ledger/binance/address.ts
@@ -24,7 +24,7 @@ export const getAddress = async (
     if (pk) {
       // get address from pubkey
       const address = crypto.getAddressFromPublicKey(pk.toString('hex'), prefix)
-      return E.right({ address, chain: BNBChain, type: 'ledger' })
+      return E.right({ address, chain: BNBChain, type: 'ledger', walletIndex })
     } else {
       return E.left({
         errorId: LedgerErrorId.INVALID_PUBKEY,

--- a/src/main/api/ledger/thorchain/address.ts
+++ b/src/main/api/ledger/thorchain/address.ts
@@ -27,7 +27,7 @@ export const getAddress = async (
         msg: `Getting 'bech32Address' from Ledger's THORChain App failed`
       })
     }
-    return E.right({ address: bech32Address, chain: THORChain, type: 'ledger' })
+    return E.right({ address: bech32Address, chain: THORChain, type: 'ledger', walletIndex })
   } catch (error) {
     return E.left({
       errorId: LedgerErrorId.GET_ADDRESS_FAILED,

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -101,6 +101,7 @@ const defaultProps: SwapProps = {
     ),
   approveFee$: () => Rx.of(RD.success(baseAmount(10000000))),
   targetWalletAddress: O.some('wallet-address'),
+  targetLedgerAddress: O.some('ledger-address'),
   onChangePath: (path) => console.log('change path', path),
   network: 'testnet',
   slipTolerance: 5,

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1409,7 +1409,7 @@ export const Swap = ({
                     <Styled.CheckButton
                       checked={useTargetAssetLedger}
                       clickHandler={() => setUseTargetAssetLedger(() => !useTargetAssetLedger)}
-                      disabled={O.isSome(oTargetLedgerAddress)}>
+                      disabled={O.isNone(oTargetLedgerAddress)}>
                       {intl.formatMessage({ id: 'ledger.title' })}
                     </Styled.CheckButton>
                   </Styled.AssetSelectContainer>

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1252,11 +1252,8 @@ export const Swap = ({
       )
       // whenever target address has been changed,
       // update state of `useTargetAssetLedger`
+      // which will update `targetWalletAddress` / `setEditableTargetWalletAddress` within another `useEffect` handler
       setUseTargetAssetLedger(useLedger)
-
-      // update state of target addresses
-      // setTargetWalletAddress(O.some(address))
-      // setEditableTargetWalletAddress(O.some(address))
     },
     [oTargetLedgerAddress]
   )
@@ -1307,8 +1304,6 @@ export const Swap = ({
 
   return (
     <Styled.Container>
-      <div>oTargetLedgerAddress {JSON.stringify(oTargetLedgerAddress, null, 2)}</div>
-      <div>oTargetWalletAddress {JSON.stringify(oTargetWalletAddress, null, 2)}</div>
       <Styled.ContentContainer>
         <Styled.Header>
           {FP.pipe(

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -662,12 +662,13 @@ export const Swap = ({
               // same chain and use its walletAddress as this is a single common wallet
               A.findFirst(({ asset }) => eqChain.equals(asset.chain, availableAsset.chain)),
               // And set available balance amount as Zero Value as user does not have any balances for this asset at all
-              O.map((balance) => [
+              O.map(({ walletType, walletAddress, walletIndex }) => [
                 {
-                  walletType: balance.walletType,
+                  walletType,
                   asset: availableAsset,
-                  walletAddress: balance.walletAddress,
-                  amount: ZERO_BASE_AMOUNT
+                  walletAddress,
+                  amount: ZERO_BASE_AMOUNT,
+                  walletIndex
                 }
               ])
             )

--- a/src/renderer/components/uielements/assets/assetCard/AssetCard.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetCard/AssetCard.stories.tsx
@@ -1,29 +1,25 @@
 import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
-import { bn, AssetBNB, assetAmount, assetToBase, baseAmount, AssetBTC, AssetRuneNative } from '@xchainjs/xchain-util'
+import { bn, AssetBNB, assetAmount, assetToBase, AssetBTC } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/Option'
 
 import { ZERO_BASE_AMOUNT } from '../../../../const'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { AssetCard, Props as AssetCardProps } from './AssetCard'
 
-const balanceBNB: WalletBalance = {
-  walletType: 'keystore',
-  amount: baseAmount('1'),
+const balanceBNB: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
-  walletAddress: ''
-}
+  walletAddress: 'bnb-address'
+})
 
-const balanceBTC: WalletBalance = {
-  ...balanceBNB,
-  asset: AssetBTC
-}
+const balanceBTC: WalletBalance = mockWalletBalance({
+  asset: AssetBTC,
+  walletAddress: 'btc-address'
+})
 
-const balanceRuneNative: WalletBalance = {
-  ...balanceBNB,
-  asset: AssetRuneNative
-}
+const balanceRuneNative: WalletBalance = mockWalletBalance()
 
 const balances = [balanceBNB, balanceBTC, balanceRuneNative]
 

--- a/src/renderer/components/uielements/assets/assetInfo/AssetInfo.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetInfo/AssetInfo.stories.tsx
@@ -5,6 +5,7 @@ import { AssetRuneNative, assetToBase, assetAmount } from '@xchainjs/xchain-util
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { AssetInfo } from './AssetInfo'
 
 export const AssetInfoStory: Story<{
@@ -20,12 +21,9 @@ export const AssetInfoStory: Story<{
       )}
       asset={O.some(AssetRuneNative)}
       assetsWB={O.some([
-        {
-          walletType: 'keystore',
-          asset: AssetRuneNative,
-          amount: assetToBase(assetAmount(balance)),
-          walletAddress: ''
-        }
+        mockWalletBalance({
+          amount: assetToBase(assetAmount(balance))
+        })
       ])}
       network="testnet"
     />

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.stories.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
-import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn } from '@xchainjs/xchain-util'
+import { AssetBNB, AssetBTC, bn } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 
 import { Network } from '../../../../../shared/api/types'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { AssetMenu } from './AssetMenu'
 
@@ -14,23 +15,18 @@ const priceIndex = {
   BTC: bn(3)
 }
 
-const balanceBNB: WalletBalance = {
+const balanceBNB: WalletBalance = mockWalletBalance({
   walletType: 'ledger',
-  amount: baseAmount('1'),
   asset: AssetBNB,
-  walletAddress: ''
-}
+  walletAddress: 'bnb-ledger-address'
+})
 
-const balanceBTC: WalletBalance = {
-  ...balanceBNB,
-  walletType: 'keystore',
-  asset: AssetBTC
-}
+const balanceBTC: WalletBalance = mockWalletBalance({
+  asset: AssetBTC,
+  walletAddress: 'btc-address'
+})
 
-const balanceRuneNative: WalletBalance = {
-  ...balanceBNB,
-  asset: AssetRuneNative
-}
+const balanceRuneNative: WalletBalance = mockWalletBalance()
 
 const balances = [balanceBNB, balanceBTC, balanceRuneNative]
 

--- a/src/renderer/components/uielements/assets/assetSelect/AssetSelect.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetSelect/AssetSelect.stories.tsx
@@ -1,31 +1,27 @@
 import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
-import { AssetBNB, AssetBTC, AssetRuneNative, baseAmount, bn } from '@xchainjs/xchain-util'
+import { AssetBNB, AssetBTC, bn } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 
 import { Network } from '../../../../../shared/api/types'
 import { WalletType } from '../../../../../shared/wallet/types'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { AssetSelect } from './AssetSelect'
 
-const balanceBNB: WalletBalance = {
+const balanceBNB: WalletBalance = mockWalletBalance({
   walletType: 'ledger',
-  amount: baseAmount('1'),
   asset: AssetBNB,
-  walletAddress: ''
-}
+  walletAddress: 'bnb-ledger-address'
+})
 
-const balanceBTC: WalletBalance = {
-  ...balanceBNB,
-  asset: AssetBTC
-}
+const balanceBTC: WalletBalance = mockWalletBalance({
+  asset: AssetBTC,
+  walletAddress: 'btc-address'
+})
 
-const balanceRuneNative: WalletBalance = {
-  ...balanceBNB,
-  walletType: 'keystore',
-  asset: AssetRuneNative
-}
+const balanceRuneNative: WalletBalance = mockWalletBalance()
 
 const balances = [balanceBNB, balanceBTC, balanceRuneNative]
 

--- a/src/renderer/components/uielements/button/CheckButton.tsx
+++ b/src/renderer/components/uielements/button/CheckButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 
 import * as FP from 'fp-ts/function'
 
@@ -15,10 +15,6 @@ export const CheckButton: React.FC<Props> = (props): JSX.Element => {
   const { clickHandler = FP.constVoid, disabled, checked, className, children } = props
 
   const [isChecked, setChecked] = useState(checked)
-
-  useEffect(() => {
-    setChecked(checked)
-  }, [checked])
 
   const onClickHandler = useCallback(() => {
     setChecked(() => !isChecked)

--- a/src/renderer/components/wallet/account/AccountSelector.stories.tsx
+++ b/src/renderer/components/wallet/account/AccountSelector.stories.tsx
@@ -4,15 +4,14 @@ import { storiesOf } from '@storybook/react'
 import { assetAmount, AssetBNB, assetToBase, assetToString } from '@xchainjs/xchain-util'
 
 import { ASSETS_MAINNET } from '../../../../shared/mock/assets'
+import { mockWalletBalance } from '../../../helpers/test/testWalletHelper'
 import { WalletBalance } from '../../../services/wallet/types'
 import { AccountSelector } from './index'
 
-const balanceBNB: WalletBalance = {
-  walletType: 'keystore',
-  amount: assetToBase(assetAmount(1)),
+const balanceBNB: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
-  walletAddress: ''
-}
+  walletAddress: 'bnb-ledger-address'
+})
 
 storiesOf('Wallet/AccountSelector', module)
   .add('default', () => {
@@ -23,7 +22,8 @@ storiesOf('Wallet/AccountSelector', module)
           walletType: 'keystore',
           asset,
           amount: assetToBase(assetAmount(1)),
-          walletAddress: `${assetToString(asset)} wallet`
+          walletAddress: `${assetToString(asset)} wallet`,
+          walletIndex: 0
         }))}
         network="testnet"
       />

--- a/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.stories.tsx
@@ -3,34 +3,28 @@ import React from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { BaseStory } from '@storybook/addons'
 import { TxHash } from '@xchainjs/xchain-client'
-import { assetAmount, AssetBNB, AssetRune67C, AssetRuneNative, assetToBase } from '@xchainjs/xchain-util'
+import { assetAmount, AssetBNB, AssetRune67C, assetToBase } from '@xchainjs/xchain-util'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 
 import { ZERO_BASE_AMOUNT } from '../../../const'
+import { mockWalletBalance } from '../../../helpers/test/testWalletHelper'
 import { OpenExplorerTxUrl } from '../../../services/clients'
 import { WalletBalance, WalletBalances } from '../../../services/wallet/types'
 import { AssetDetails } from './index'
 
-const bnbBalance: WalletBalance = {
-  walletType: 'keystore',
+const bnbBalance: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
   amount: assetToBase(assetAmount(1.1)),
   walletAddress: 'BNB address'
-}
+})
 
-const runeBnbBalance: WalletBalance = {
-  walletType: 'keystore',
+const runeBnbBalance: WalletBalance = mockWalletBalance({
   asset: AssetRune67C,
   amount: assetToBase(assetAmount(2.2)),
   walletAddress: 'BNB.Rune address'
-}
+})
 
-const runeNativeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(0)),
-  walletAddress: 'Rune native address'
-}
+const runeNativeBalance: WalletBalance = mockWalletBalance()
 
 const runeBalanceEmpty: WalletBalance = { ...runeBnbBalance, amount: ZERO_BASE_AMOUNT }
 const bnbBalanceEmpty: WalletBalance = { ...bnbBalance, amount: ZERO_BASE_AMOUNT }

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -55,13 +55,15 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletType: 'keystore',
           amount: baseAmount('1000000'),
           asset: AssetBNB,
-          walletAddress: 'BNB wallet address'
+          walletAddress: 'BNB wallet address',
+          walletIndex: 0
         },
         {
           walletType: 'keystore',
           amount: baseAmount('300000000'),
           asset: AssetRune67C,
-          walletAddress: 'BNB wallet address'
+          walletAddress: 'BNB wallet address',
+          walletIndex: 0
         }
       ])
     }
@@ -77,7 +79,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletType: 'keystore',
           amount: baseAmount('1000000'),
           asset: AssetBTC,
-          walletAddress: 'BNB wallet address'
+          walletAddress: 'BNB wallet address',
+          walletIndex: 0
         }
       ])
     }
@@ -93,7 +96,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletType: 'keystore',
           amount: baseAmount('300000000'),
           asset: AssetETH,
-          walletAddress: 'ETH wallet address'
+          walletAddress: 'ETH wallet address',
+          walletIndex: 0
         }
       ])
     }
@@ -109,7 +113,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletType: 'keystore',
           amount: baseAmount('1000000'),
           asset: AssetRuneNative,
-          walletAddress: 'BNB wallet address'
+          walletAddress: 'BNB wallet address',
+          walletIndex: 0
         }
       ])
     }
@@ -125,7 +130,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletType: 'keystore',
           amount: baseAmount('1000000'),
           asset: AssetLTC,
-          walletAddress: 'LTC wallet address'
+          walletAddress: 'LTC wallet address',
+          walletIndex: 0
         }
       ])
     }

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
@@ -319,7 +319,7 @@ export const AssetsTableCollapsable: React.FC<Props> = (props): JSX.Element => {
   // Panel
   const renderPanel = useCallback(
     (
-      { chain, walletType, walletIndex, walletAddress: oWalletAddress, balances: balancesRD }: ChainBalance,
+      { chain, walletType, walletAddress: oWalletAddress, balances: balancesRD, walletIndex }: ChainBalance,
       key: number
     ) => {
       /**
@@ -397,7 +397,7 @@ export const AssetsTableCollapsable: React.FC<Props> = (props): JSX.Element => {
             index: key,
             oWalletAddress,
             walletType,
-            walletIndex: walletIndex ? walletIndex : 0
+            walletIndex
           })}
         </Panel>
       )

--- a/src/renderer/components/wallet/txs/send/Send.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.stories.tsx
@@ -23,6 +23,7 @@ import { BNB_TRANSFER_FEES } from '../../../../../shared/mock/fees'
 import { RDStatus, getMockRDValueFactory } from '../../../../../shared/mock/rdByStatus'
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { WalletType } from '../../../../../shared/wallet/types'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/binance/types'
 import { WalletBalances } from '../../../../services/clients'
 import { ErrorId, TxHashRD, WalletBalance } from '../../../../services/wallet/types'
@@ -43,40 +44,35 @@ const defaultProps = {
   errorActionHandler: () => console.log('error action')
 }
 
-const bnbAsset: WalletBalance = {
-  walletType: 'keystore',
+const bnbAsset: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
   amount: assetToBase(assetAmount(12.3)),
   walletAddress: 'AssetBNB wallet address'
-}
+})
 
-const btcBalance: WalletBalance = {
-  walletType: 'keystore',
+const btcBalance: WalletBalance = mockWalletBalance({
   asset: AssetBTC,
   amount: assetToBase(assetAmount(23.45, BTC_DECIMAL)),
   walletAddress: 'btc wallet address'
-}
+})
 
-const runeAsset: WalletBalance = {
-  walletType: 'keystore',
+const runeAsset: WalletBalance = mockWalletBalance({
   asset: AssetRune67C,
   amount: assetToBase(assetAmount(34.56)),
   walletAddress: 'AssetRune67C wallet address'
-}
+})
 
-const ethBalance: WalletBalance = {
-  walletType: 'keystore',
+const ethBalance: WalletBalance = mockWalletBalance({
   asset: AssetETH,
   amount: assetToBase(assetAmount(45.67)),
   walletAddress: 'AssetETH wallet address'
-}
+})
 
-const ltcBalance: WalletBalance = {
-  walletType: 'keystore',
+const ltcBalance: WalletBalance = mockWalletBalance({
   asset: AssetLTC,
   amount: assetToBase(assetAmount(56.78)),
   walletAddress: 'AssetLTC wallet address'
-}
+})
 
 const SendFormsComponents = {
   SendFormBNB: {

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.stories.tsx
@@ -4,33 +4,23 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
 import { BCH_DECIMAL } from '@xchainjs/xchain-bitcoincash'
 import { FeeRates, Fees, FeeType } from '@xchainjs/xchain-client'
-import {
-  assetAmount,
-  AssetBCH,
-  AssetRuneNative,
-  assetToBase,
-  baseAmount,
-  formatBaseAmount
-} from '@xchainjs/xchain-util'
+import { assetAmount, AssetBCH, assetToBase, baseAmount, formatBaseAmount } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormBCH as Component, Props as ComponentProps } from './SendFormBCH'
 
-const bchBalance: WalletBalance = {
-  walletType: 'keystore',
+const bchBalance: WalletBalance = mockWalletBalance({
   asset: AssetBCH,
   amount: assetToBase(assetAmount(1.23, BCH_DECIMAL)),
-  walletAddress: 'btc wallet address'
-}
+  walletAddress: 'bch wallet address'
+})
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(2, BCH_DECIMAL)),
-  walletAddress: 'rune wallet address'
-}
+const runeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(2, BCH_DECIMAL))
+})
 
 const fees: Fees = {
   type: FeeType.FlatFee,

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
@@ -14,23 +14,22 @@ import {
 } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/binance/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormBNB, Props as SendFormBNBProps } from './SendFormBNB'
 
-const bnbBalance: WalletBalance = {
-  walletType: 'keystore',
+const bnbBalance: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
   amount: assetToBase(assetAmount(123)),
   walletAddress: 'AssetBNB wallet address'
-}
+})
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
+const runeBalance: WalletBalance = mockWalletBalance({
   asset: AssetRune67C,
   amount: assetToBase(assetAmount(234)),
   walletAddress: 'AssetRune67C wallet address'
-}
+})
 
 const defaultProps: SendFormBNBProps = {
   walletType: 'keystore',

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
@@ -4,33 +4,24 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
 import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
 import { Address, FeeRates, Fees, FeeType } from '@xchainjs/xchain-client'
-import {
-  assetAmount,
-  AssetBTC,
-  AssetRuneNative,
-  assetToBase,
-  baseAmount,
-  formatBaseAmount
-} from '@xchainjs/xchain-util'
+import { assetAmount, AssetBTC, assetToBase, baseAmount, formatBaseAmount } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { THORCHAIN_DECIMAL } from '../../../../helpers/assetHelper'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormBTC as Component, Props as ComponentProps } from './SendFormBTC'
 
-const btcBalance: WalletBalance = {
-  walletType: 'keystore',
+const btcBalance: WalletBalance = mockWalletBalance({
   asset: AssetBTC,
   amount: assetToBase(assetAmount(1.23, BTC_DECIMAL)),
   walletAddress: 'btc wallet address'
-}
+})
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(2, BTC_DECIMAL)),
-  walletAddress: 'rune wallet address'
-}
+const runeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
+})
 
 const fees: Fees = {
   type: FeeType.FlatFee,

--- a/src/renderer/components/wallet/txs/send/SendFormETH.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormETH.stories.tsx
@@ -4,28 +4,25 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
 import { Fees, FeeType, TxParams } from '@xchainjs/xchain-client'
 import { ETH_DECIMAL } from '@xchainjs/xchain-ethereum'
-import { assetAmount, AssetETH, AssetRuneNative, assetToBase } from '@xchainjs/xchain-util'
+import { assetAmount, AssetETH, assetToBase } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { THORCHAIN_DECIMAL } from '../../../../helpers/assetHelper'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/ethereum/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormETH } from './index'
 import { Props as SendFormETHProps } from './SendFormETH'
 
-const ethBalance: WalletBalance = {
-  walletType: 'keystore',
+const ethBalance: WalletBalance = mockWalletBalance({
   asset: AssetETH,
   amount: assetToBase(assetAmount(1.23, ETH_DECIMAL)),
   walletAddress: 'AssetETH wallet address'
-}
+})
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL)),
-  walletAddress: 'rune wallet address'
-}
+const runeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
+})
 
 const fees: Fees = {
   type: FeeType.PerByte,

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
@@ -4,33 +4,23 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
 import { Fees, FeeRates, FeeType } from '@xchainjs/xchain-client'
 import { LTC_DECIMAL } from '@xchainjs/xchain-litecoin'
-import {
-  assetAmount,
-  AssetLTC,
-  AssetRuneNative,
-  assetToBase,
-  baseAmount,
-  formatBaseAmount
-} from '@xchainjs/xchain-util'
+import { assetAmount, AssetLTC, assetToBase, baseAmount, formatBaseAmount } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormLTC as Component, Props as ComponentProps } from './SendFormLTC'
 
-const ltcBalance: WalletBalance = {
-  walletType: 'keystore',
+const ltcBalance: WalletBalance = mockWalletBalance({
   asset: AssetLTC,
   amount: assetToBase(assetAmount(1.23, LTC_DECIMAL)),
-  walletAddress: 'btc wallet address'
-}
+  walletAddress: 'ltc wallet address'
+})
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(2, LTC_DECIMAL)),
-  walletAddress: 'rune wallet address'
-}
+const runeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(2, LTC_DECIMAL))
+})
 
 const fees: Fees = {
   type: FeeType.FlatFee,

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
@@ -4,7 +4,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
 import {
   assetAmount,
-  AssetRuneNative,
   assetToBase,
   assetToString,
   baseAmount,
@@ -13,16 +12,14 @@ import {
 } from '@xchainjs/xchain-util'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { SendTxParams } from '../../../../services/binance/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormTHOR as Component, Props as ComponentProps } from './SendFormTHOR'
 
-const runeBalance: WalletBalance = {
-  walletType: 'keystore',
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(2)),
-  walletAddress: 'rune wallet address'
-}
+const runeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(2))
+})
 
 const defaultProps: ComponentProps = {
   walletType: 'keystore',

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.stories.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.stories.tsx
@@ -2,15 +2,7 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
-import {
-  assetAmount,
-  AssetBNB,
-  AssetRune67C,
-  AssetRuneNative,
-  assetToBase,
-  baseAmount,
-  BNBChain
-} from '@xchainjs/xchain-util'
+import { assetAmount, AssetBNB, AssetRune67C, assetToBase, baseAmount, BNBChain } from '@xchainjs/xchain-util'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
@@ -18,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { BNB_DECIMAL } from '../../../../helpers/assetHelper'
+import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
 import { INITIAL_UPGRADE_RUNE_STATE } from '../../../../services/chain/const'
 import { UpgradeRuneParams, UpgradeRuneTxState, UpgradeRuneTxState$ } from '../../../../services/chain/types'
 import { ErrorId } from '../../../../services/wallet/types'
@@ -32,29 +25,21 @@ const mockTxState$ = (states: UpgradeRuneTxState[]): UpgradeRuneTxState$ =>
     RxOp.startWith(INITIAL_UPGRADE_RUNE_STATE)
   )
 
-const bnbBalance: WalletBalance = {
-  walletType: 'keystore',
-  walletIndex: 0,
+const bnbBalance: WalletBalance = mockWalletBalance({
   asset: AssetBNB,
   amount: assetToBase(assetAmount(1001)),
   walletAddress: 'BNB address'
-}
+})
 
-const runeBnbBalance: WalletBalance = {
-  walletType: 'keystore',
-  walletIndex: 0,
+const runeBnbBalance: WalletBalance = mockWalletBalance({
   asset: AssetRune67C,
   amount: assetToBase(assetAmount(2002)),
   walletAddress: 'BNB.Rune address'
-}
+})
 
-const runeNativeBalance: WalletBalance = {
-  walletType: 'keystore',
-  walletIndex: 0,
-  asset: AssetRuneNative,
-  amount: assetToBase(assetAmount(0)),
-  walletAddress: 'Rune native address'
-}
+const runeNativeBalance: WalletBalance = mockWalletBalance({
+  amount: assetToBase(assetAmount(0))
+})
 
 const getBalances = (balances: WalletBalances) => NEA.fromArray<WalletBalance>(balances)
 

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -404,7 +404,8 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
               walletType,
               amount: assetToBase(assetAmount(0)),
               asset: runeAsset.asset,
-              walletAddress: ''
+              walletAddress: '',
+              walletIndex
             }}
             walletBalances={[]}
             network={network}
@@ -457,6 +458,7 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
     [
       walletType,
       runeAsset.asset,
+      walletIndex,
       network,
       form,
       runeNativeAddress,

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -185,7 +185,8 @@ export const eqAddress: Eq.Eq<Address> = eqString
 export const eqWalletAddress = Eq.struct<WalletAddress>({
   address: eqString,
   type: eqString,
-  chain: eqChain
+  chain: eqChain,
+  walletIndex: eqNumber
 })
 
 export const eqLedgerAddressRD = RD.getEq<LedgerError, WalletAddress>(eqLedgerError, eqWalletAddress)

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -181,6 +181,7 @@ const eqLedgerError = Eq.struct<LedgerError>({
 export const eqWalletType: Eq.Eq<WalletType> = eqString
 
 export const eqAddress: Eq.Eq<Address> = eqString
+export const eqOAddress: Eq.Eq<O.Option<Address>> = eqOString
 
 export const eqWalletAddress = Eq.struct<WalletAddress>({
   address: eqString,

--- a/src/renderer/helpers/walletHelper.test.ts
+++ b/src/renderer/helpers/walletHelper.test.ts
@@ -1,12 +1,4 @@
-import {
-  assetToBase,
-  AssetRuneNative,
-  AssetBNB,
-  AssetLTC,
-  assetAmount,
-  BNBChain,
-  THORChain
-} from '@xchainjs/xchain-util'
+import { assetToBase, AssetRuneNative, AssetBNB, AssetLTC, assetAmount } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -18,7 +10,6 @@ import { eqWalletBalances } from './fp/eq'
 import { mockWalletBalance } from './test/testWalletHelper'
 import {
   filterWalletBalancesByAssets,
-  getAddressFromBalancesByChain,
   getAssetAmountByAsset,
   getBnbAmountFromBalances,
   getLtcAmountFromBalances,
@@ -153,29 +144,6 @@ describe('walletHelper', () => {
     it('returns none if BNB wallet address is not available', () => {
       const balances: WalletBalances = NEA.fromReadonlyNonEmptyArray([BOLT_WB, BNB_WB])
       const result = getWalletByAddress(balances, RUNE_WB.walletAddress)
-      expect(result).toBeNone()
-    })
-  })
-
-  describe('getAddressFromBalancesByChain', () => {
-    it('address of BOLT keystore ', () => {
-      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB])
-      const result = getAddressFromBalancesByChain({ balances, chain: BNBChain, walletType: 'keystore' })
-      expect(O.toNullable(result)).toEqual('bolt-address')
-    })
-    it('address of THOR keystore ', () => {
-      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB])
-      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'keystore' })
-      expect(O.toNullable(result)).toEqual('thor-address')
-    })
-    it('address of THOR ledger ', () => {
-      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BOLT_WB, BNB_WB, RUNE_LEDGER_WB])
-      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'ledger' })
-      expect(O.toNullable(result)).toEqual('thor-ledger-address')
-    })
-    it('no address of THOR ledger ', () => {
-      const balances = NEA.fromReadonlyNonEmptyArray([RUNE_WB, BNB_WB])
-      const result = getAddressFromBalancesByChain({ balances, chain: THORChain, walletType: 'ledger' })
       expect(result).toBeNone()
     })
   })

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -1,17 +1,15 @@
 import { Address } from '@xchainjs/xchain-client'
-import { Asset, AssetAmount, baseToAsset, Chain } from '@xchainjs/xchain-util'
+import { Asset, AssetAmount, baseToAsset } from '@xchainjs/xchain-util'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
-import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/Option'
 
-import { isLedgerWallet } from '../../shared/utils/guard'
 import { WalletAddress, WalletType } from '../../shared/wallet/types'
 import { ZERO_ASSET_AMOUNT } from '../const'
 import { WalletBalances } from '../services/clients'
 import { NonEmptyWalletBalances, WalletBalance } from '../services/wallet/types'
 import { isBnbAsset, isEthAsset, isLtcAsset, isRuneNativeAsset } from './assetHelper'
-import { eqAddress, eqAsset, eqChain, eqWalletType } from './fp/eq'
+import { eqAddress, eqAsset, eqWalletType } from './fp/eq'
 
 /**
  * Tries to find an `AssetAmount` of an `Asset`
@@ -130,44 +128,8 @@ export const addressFromOptionalWalletAddress = (
   oWalletAddress: O.Option<Pick<WalletAddress, 'address'>>
 ): O.Option<Address> => FP.pipe(oWalletAddress, O.map(addressFromWalletAddress))
 
-export const getAddressFromBalancesByChain = ({
-  balances,
-  chain,
-  walletType
-}: {
-  balances: NonEmptyWalletBalances
-  chain: Chain
-  walletType: WalletType
-}): O.Option<Address> =>
-  FP.pipe(
-    balances,
-    A.findFirst(
-      ({ asset, walletType: balanceWalletType }) =>
-        eqChain.equals(chain, asset.chain) && eqWalletType.equals(walletType, balanceWalletType)
-    ),
-    O.map(({ walletAddress }) => walletAddress)
-  )
-
 export const getWalletByAddress = (walletBalances: WalletBalances, address: Address): O.Option<WalletBalance> =>
   FP.pipe(
     walletBalances,
     A.findFirst(({ walletAddress }) => eqAddress.equals(walletAddress, address))
-  )
-
-export const isLedgerAddressInBalances = ({
-  balances,
-  address,
-  asset
-}: {
-  balances: WalletBalances
-  address: Address
-  asset: Asset
-}): boolean =>
-  FP.pipe(
-    NEA.fromArray(balances),
-    O.chain((balances) => getWalletBalanceByAddressAndAsset({ balances, address, asset })),
-    O.fold(
-      () => false,
-      ({ walletType }) => isLedgerWallet(walletType)
-    )
   )

--- a/src/renderer/services/clients/address.ts
+++ b/src/renderer/services/clients/address.ts
@@ -22,7 +22,16 @@ export const addressUI$: (client$: XChainClient$, chain: Chain) => WalletAddress
       )
     ),
     RxOp.distinctUntilChanged(eqOString.equals),
-    RxOp.map(FP.flow(O.map<Address, WalletAddress>((address) => ({ address, chain, type: 'keystore' })))),
+    RxOp.map(
+      FP.flow(
+        O.map<Address, WalletAddress>((address) => ({
+          address,
+          chain,
+          type: 'keystore',
+          walletIndex: 0 /* As long as we don't have HD wallets introduced, keystore will be always 0 */
+        }))
+      )
+    ),
     RxOp.shareReplay(1)
   )
 

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -41,13 +41,11 @@ import { hasImportedKeystore } from './util'
 export const createBalancesService = ({
   keystore$,
   network$,
-  getLedgerAddress$,
-  getWalletIndex$
+  getLedgerAddress$
 }: {
   keystore$: KeystoreState$
   network$: Network$
   getLedgerAddress$: GetLedgerAddressHandler
-  getWalletIndex$: (chain: Chain) => Rx.Observable<number>
 }): BalancesService => {
   // reload all balances
   const reloadBalances: FP.Lazy<void> = () => {
@@ -207,6 +205,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: THORChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances
     }))
   )
@@ -231,17 +230,17 @@ export const createBalancesService = ({
               // just return `ChainBalance` w/ initial (empty) balances
               Rx.of<ChainBalance>({
                 walletType: 'ledger',
-                walletIndex: 0,
                 chain,
                 walletAddress: O.none,
-                balances: RD.initial
+                balances: RD.initial,
+                walletIndex: 0
               }),
-            ({ address }) =>
+            ({ address, walletIndex }) =>
               // Load balances by given Ledger address
               // and put it's RD state into `balances` of `ChainBalance`
               FP.pipe(
-                Rx.combineLatest([getBalanceByAddress$(address, 'ledger'), getWalletIndex$(chain)]),
-                RxOp.map<[WalletBalancesRD, number], ChainBalance>(([balances, walletIndex]) => ({
+                getBalanceByAddress$(address, 'ledger'),
+                RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
                   walletType: 'ledger',
                   walletIndex,
                   chain,
@@ -270,6 +269,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: LTCChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances
     }))
   )
@@ -285,6 +285,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: BCHChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances
     }))
   )
@@ -306,6 +307,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: BNBChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances: FP.pipe(
         balances,
         RD.map((assets) => sortBalances(assets, [AssetBNB.ticker, getBnbRuneAsset(network).ticker]))
@@ -324,6 +326,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: BTCChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances
     }))
   )
@@ -338,6 +341,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: ETHChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets
       balances
     }))
   )

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -8,7 +8,6 @@ import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { Network } from '../../../shared/api/types'
 import { WalletType } from '../../../shared/wallet/types'
 import { getBnbRuneAsset } from '../../helpers/assetHelper'
 import { filterEnabledChains } from '../../helpers/chainHelper'
@@ -34,7 +33,7 @@ import {
   KeystoreState$,
   KeystoreState,
   ChainBalance,
-  LedgerAddressLD
+  GetLedgerAddressHandler
 } from './types'
 import { sortBalances } from './util'
 import { hasImportedKeystore } from './util'
@@ -47,7 +46,7 @@ export const createBalancesService = ({
 }: {
   keystore$: KeystoreState$
   network$: Network$
-  getLedgerAddress$: (chain: Chain, network: Network) => LedgerAddressLD
+  getLedgerAddress$: GetLedgerAddressHandler
   getWalletIndex$: (chain: Chain) => Rx.Observable<number>
 }): BalancesService => {
   // reload all balances

--- a/src/renderer/services/wallet/const.ts
+++ b/src/renderer/services/wallet/const.ts
@@ -22,39 +22,14 @@ export const INITIAL_LOAD_TXS_PROPS: LoadTxsParams = {
 export const EMPTY_LOAD_TXS_HANDLER: LoadTxsHandler = (_: LoadTxsParams) => {}
 
 export const INITIAL_LEDGER_ADDRESS_MAP: LedgerAddressMap = { mainnet: RD.initial, testnet: RD.initial }
-export const INITIAL_WALLET_INDEX = 0
 
 export const INITIAL_LEDGER_ADDRESSES_MAP: LedgerAddressesMap = {
-  [Chain.Binance]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.Bitcoin]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.BitcoinCash]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.Ethereum]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.Cosmos]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.Polkadot]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.Litecoin]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  },
-  [Chain.THORChain]: {
-    addresses: INITIAL_LEDGER_ADDRESS_MAP,
-    walletIndex: INITIAL_WALLET_INDEX
-  }
+  [Chain.Binance]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.Bitcoin]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.BitcoinCash]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.Ethereum]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.Cosmos]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.Polkadot]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.Litecoin]: INITIAL_LEDGER_ADDRESS_MAP,
+  [Chain.THORChain]: INITIAL_LEDGER_ADDRESS_MAP
 }

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -5,13 +5,7 @@ import { keystoreService, removeKeystore } from './keystore'
 import { createLedgerService } from './ledger'
 import { getTxs$, loadTxs, explorerUrl$, resetTxsPage } from './transaction'
 
-const {
-  askLedgerAddress$,
-  getLedgerAddress$,
-  // getWalletIndex$,
-  verifyLedgerAddress,
-  removeLedgerAddress
-} = createLedgerService({
+const { askLedgerAddress$, getLedgerAddress$, verifyLedgerAddress, removeLedgerAddress } = createLedgerService({
   keystore$: keystoreService.keystore$
 })
 
@@ -19,7 +13,6 @@ const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } 
   keystore$: keystoreService.keystore$,
   network$,
   getLedgerAddress$
-  // getWalletIndex$
 })
 
 /**

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -5,16 +5,21 @@ import { keystoreService, removeKeystore } from './keystore'
 import { createLedgerService } from './ledger'
 import { getTxs$, loadTxs, explorerUrl$, resetTxsPage } from './transaction'
 
-const { askLedgerAddress$, getLedgerAddress$, getWalletIndex$, verifyLedgerAddress, removeLedgerAddress } =
-  createLedgerService({
-    keystore$: keystoreService.keystore$
-  })
+const {
+  askLedgerAddress$,
+  getLedgerAddress$,
+  // getWalletIndex$,
+  verifyLedgerAddress,
+  removeLedgerAddress
+} = createLedgerService({
+  keystore$: keystoreService.keystore$
+})
 
 const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } = createBalancesService({
   keystore$: keystoreService.keystore$,
   network$,
-  getLedgerAddress$,
-  getWalletIndex$
+  getLedgerAddress$
+  // getWalletIndex$
 })
 
 /**

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -10,6 +10,7 @@ import { eqLedgerAddressMap } from '../../helpers/fp/eq'
 import { observableState } from '../../helpers/stateHelper'
 import { INITIAL_LEDGER_ADDRESSES_MAP } from './const'
 import {
+  GetLedgerAddressHandler,
   KeystoreState,
   KeystoreState$,
   LedgerAddressesMap,
@@ -55,12 +56,13 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
   /**
    * Get ledger address from memory
    */
-  const getLedgerAddress$ = (chain: Chain, network: Network): LedgerAddressLD =>
+  const getLedgerAddress$: GetLedgerAddressHandler = (chain, network) =>
     FP.pipe(
       ledgerAddresses$,
       RxOp.map((addressesMap) => addressesMap[chain].addresses),
       RxOp.distinctUntilChanged(eqLedgerAddressMap.equals),
-      RxOp.map((addressMap) => addressMap[network])
+      RxOp.map((addressMap) => addressMap[network]),
+      RxOp.map((v) => v)
     )
 
   const getWalletIndex$ = (chain: Chain): Rx.Observable<number> =>

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -54,13 +54,6 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
       RxOp.map((v) => v)
     )
 
-  // const getWalletIndex$ = (chain: Chain): Rx.Observable<number> =>
-  //   FP.pipe(
-  //     ledgerAddresses$,
-  //     // RxOp.map((addressesMap) => addressesMap[chain])
-  //     RxOp.map((addressesMap) => addressesMap[chain])
-  //   )
-
   const verifyLedgerAddress = (chain: Chain, network: Network, walletIndex = 0): void =>
     window.apiHDWallet.verifyLedgerAddress({ chain, network, walletIndex })
 
@@ -126,9 +119,6 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
     getLedgerAddress$,
     verifyLedgerAddress,
     removeLedgerAddress,
-
-    // getWalletIndex$,
-
     dispose
   }
 }

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -58,7 +58,7 @@ export type WalletAccount = {
 
 export type WalletAccounts = WalletAccount[]
 
-export type WalletBalance = Balance & { walletAddress: Address; walletType: WalletType; walletIndex?: number }
+export type WalletBalance = Balance & { walletAddress: Address; walletType: WalletType; walletIndex: number }
 export type WalletBalances = WalletBalance[]
 
 /**
@@ -67,7 +67,7 @@ export type WalletBalances = WalletBalance[]
  */
 export type ChainBalance = {
   walletType: WalletType
-  walletIndex?: number
+  walletIndex: number
   walletAddress: O.Option<Address>
   chain: Chain
   balances: WalletBalancesRD
@@ -140,7 +140,7 @@ export type GetLedgerAddressHandler = (chain: Chain, network: Network) => Ledger
 export type LedgerService = {
   askLedgerAddress$: (chain: Chain, network: Network, walletIndex: number) => LedgerAddressLD
   getLedgerAddress$: GetLedgerAddressHandler
-  getWalletIndex$: (chain: Chain) => Rx.Observable<number>
+  // getWalletIndex$: (chain: Chain) => Rx.Observable<number>
   verifyLedgerAddress: (chain: Chain, network: Network, walletIndex?: number) => void
   removeLedgerAddress: (chain: Chain, network: Network) => void
   dispose: FP.Lazy<void>
@@ -170,11 +170,5 @@ export type LedgerAddressLD = LiveData<LedgerError, WalletAddress>
 export type LedgerAddressMap = Record<Network, LedgerAddressRD>
 export type LedgerAddressMap$ = Rx.Observable<LedgerAddressMap>
 
-export type LedgerAddressesAndWalletIndexMap = {
-  addresses: LedgerAddressMap
-  walletIndex: number
-}
-export type LedgerAddressesAndWalletIndexMap$ = Rx.Observable<LedgerAddressesAndWalletIndexMap>
-
-export type LedgerAddressesMap = Record<Chain, LedgerAddressesAndWalletIndexMap>
+export type LedgerAddressesMap = Record<Chain, LedgerAddressMap>
 export type LedgerAddressesMap$ = Rx.Observable<LedgerAddressesMap>

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -135,9 +135,11 @@ export type BalancesService = {
   dispose: FP.Lazy<void>
 }
 
+export type GetLedgerAddressHandler = (chain: Chain, network: Network) => LedgerAddressLD
+
 export type LedgerService = {
   askLedgerAddress$: (chain: Chain, network: Network, walletIndex: number) => LedgerAddressLD
-  getLedgerAddress$: (chain: Chain, network: Network) => LedgerAddressLD
+  getLedgerAddress$: GetLedgerAddressHandler
   getWalletIndex$: (chain: Chain) => Rx.Observable<number>
   verifyLedgerAddress: (chain: Chain, network: Network, walletIndex?: number) => void
   removeLedgerAddress: (chain: Chain, network: Network) => void

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -218,10 +218,10 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   const [oTargetLedgerAddress]: [O.Option<Address>, unknown] = useObservableState(
     () =>
       FP.pipe(
-        RD.toOption(targetAssetRD),
+        oRouteTarget,
         O.fold(
           () => Rx.of(RD.initial),
-          ({ asset }) => getLedgerAddress$(asset.chain, network)
+          ({ chain }) => getLedgerAddress$(chain, network)
         ),
         liveData.map(({ address }) => address),
         RxOp.switchMap((rdAddress) => Rx.of(RD.toOption(rdAddress)))

--- a/src/shared/mock/api.ts
+++ b/src/shared/mock/api.ts
@@ -77,7 +77,8 @@ export const apiUrl: ApiUrl = {
 
 // Mock `apiHDWallet`
 export const apiHDWallet: ApiHDWallet = {
-  getLedgerAddress: ({ chain }) => Promise.resolve(E.right({ chain, address: 'ledger_address', type: 'ledger' })),
+  getLedgerAddress: ({ chain }) =>
+    Promise.resolve(E.right({ chain, address: 'ledger_address', type: 'ledger', walletIndex: 0 })),
   verifyLedgerAddress: FP.constVoid,
   sendLedgerTx: () => Promise.resolve(E.right('tx_hash')),
   depositLedgerTx: () => Promise.resolve(E.right('tx_hash'))

--- a/src/shared/mock/wallet.ts
+++ b/src/shared/mock/wallet.ts
@@ -25,31 +25,37 @@ export const MOCK_WALLET_ADDRESSES: WalletAddresses = [
   {
     address: 'tbnb1ed04qgw3s69z90jskr3shpyn9mr0e59qdtsxqa',
     type: 'ledger',
-    chain: BNBChain
+    chain: BNBChain,
+    walletIndex: 0
   },
   {
     address: 'tthor13gym97tmw3axj3hpewdggy2cr288d3qffr8skg',
     type: 'ledger',
-    chain: THORChain
+    chain: THORChain,
+    walletIndex: 0
   },
   {
     address: '0x33292c1d02c432d323fb62c57fb327da45e1bdde',
     type: 'keystore',
-    chain: ETHChain
+    chain: ETHChain,
+    walletIndex: 0
   },
   {
     address: 'tb1qtephp596jhpwrawlp67junuk347zl2cwc56xml',
     type: 'keystore',
-    chain: BTCChain
+    chain: BTCChain,
+    walletIndex: 0
   },
   {
     address: 'qr20g55jd7x3dalp4qxjfgfvda0nwr8cfccrgxd0dw',
     type: 'keystore',
-    chain: BCHChain
+    chain: BCHChain,
+    walletIndex: 0
   },
   {
     address: 'tltc1qtephp596jhpwrawlp67junuk347zl2cwpucctk',
     type: 'keystore',
-    chain: LTCChain
+    chain: LTCChain,
+    walletIndex: 0
   }
 ]

--- a/src/shared/wallet/types.ts
+++ b/src/shared/wallet/types.ts
@@ -3,5 +3,5 @@ import { Chain } from '@xchainjs/xchain-util'
 
 export type WalletType = 'keystore' | 'ledger'
 
-export type WalletAddress = { address: Address; type: WalletType; chain: Chain }
+export type WalletAddress = { address: Address; type: WalletType; chain: Chain; walletIndex: number }
 export type WalletAddresses = WalletAddress[]


### PR DESCRIPTION
- [x] Swap component: Don't get Keystore/Ledger addresses from `WalletBalances` for target `Asset` (it can't be have zero `balances`. Instead get `targetWalletAddress` / `targetLedgerAddress` in `SwapView` from `WalletContext` 
- [x] Type changes:
   - Add `walletIndex` to `WalletAddress` 
   - Remove `walletIndex` from `LedgerAddressesMap` in favour for using `walletIndex` of `WalletAddress` 
- [x] Remove deprecated `getAddressFromBalancesByChain`, `isLedgerAddressInBalances` helpers

Fix #1891