### PR TITLE
Ledger's walletIndex get lost

### DIFF
--- a/src/main/api/ledger/binance/transaction.ts
+++ b/src/main/api/ledger/binance/transaction.ts
@@ -20,7 +20,7 @@ export const send = async ({
   amount,
   asset,
   memo,
-  walletIndex = 0
+  walletIndex
 }: {
   transport: Transport
   amount: BaseAmount
@@ -34,7 +34,9 @@ export const send = async ({
   try {
     const clientNetwork = toClientNetwork(network)
     const prefix = getPrefix(clientNetwork)
+    console.log('walletIndex:', walletIndex)
     const derivePath = getDerivePath(walletIndex)
+    console.log('derivePath:', derivePath)
 
     const app = new LedgerApp(transport)
     const client = new Client({ network: clientNetwork })

--- a/src/main/api/ledger/binance/transaction.ts
+++ b/src/main/api/ledger/binance/transaction.ts
@@ -34,9 +34,7 @@ export const send = async ({
   try {
     const clientNetwork = toClientNetwork(network)
     const prefix = getPrefix(clientNetwork)
-    console.log('walletIndex:', walletIndex)
     const derivePath = getDerivePath(walletIndex)
-    console.log('derivePath:', derivePath)
 
     const app = new LedgerApp(transport)
     const client = new Client({ network: clientNetwork })

--- a/src/main/api/ledger/thorchain/common.ts
+++ b/src/main/api/ledger/thorchain/common.ts
@@ -3,7 +3,7 @@ import { LedgerErrorType } from '@thorchain/ledger-thorchain'
 import { LedgerErrorId } from '../../../../shared/api/types'
 
 // TODO(@veado) Get path by using `xchain-thorchain`
-export const getDerivationPath = (walletIndex = 0) => [44, 931, 0, 0, walletIndex]
+export const getDerivationPath = (walletIndex: number) => [44, 931, 0, 0, walletIndex]
 
 export const fromLedgerErrorType = (error: number): LedgerErrorId => {
   switch (error) {

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -302,7 +302,10 @@ export const SymDeposit: React.FC<Props> = (props) => {
               // Decimal needs to be converted back for using orginal decimal of this asset (provided by `assetBalance`)
               asset: convertBaseAmountDecimal(assetAmountToDepositMax1e8, assetDecimal)
             },
-            memos
+            memos,
+            // TODO (@asgx-team) Get it from props when we support Ledger7
+            walletType: 'keystore',
+            walletIndex: 0
           }
         })
       ),

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -303,7 +303,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
               asset: convertBaseAmountDecimal(assetAmountToDepositMax1e8, assetDecimal)
             },
             memos,
-            // TODO (@asgx-team) Get it from props when we support Ledger7
+            // TODO (@asgx-team) Get it from props when we will support Ledger for sym. deposit
             walletType: 'keystore',
             walletIndex: 0
           }

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -351,7 +351,10 @@ export const Withdraw: React.FC<Props> = ({
     subscribeWithdrawState(
       withdraw$({
         network,
-        memo
+        memo,
+        // TODO (@asgdx-team) Get walletType|index from props when we introduce Ledger for withdrawing
+        walletType: 'keystore',
+        walletIndex: 0
       })
     )
   }, [closePasswordModal, subscribeWithdrawState, withdraw$, network, memo])

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -357,7 +357,7 @@ export const Swap = ({
     const oAddress: O.Option<Address> = useTargetAssetLedger ? oTargetLedgerAddress : oTargetWalletAddress
     return FP.pipe(
       sequenceTOption(assetsToSwap, oPoolAddress, oAddress, oSourceAssetWB),
-      O.map(([{ source, target }, poolAddress, address, { walletType, walletAddress }]) => {
+      O.map(([{ source, target }, poolAddress, address, { walletType, walletAddress, walletIndex }]) => {
         return {
           poolAddress,
           asset: source,
@@ -369,7 +369,8 @@ export const Swap = ({
             limit: Utils.getSwapLimit(swapResultAmountMax1e8, slipTolerance)
           }),
           walletType,
-          sender: walletAddress
+          sender: walletAddress,
+          walletIndex
         }
       })
     )
@@ -1292,6 +1293,8 @@ export const Swap = ({
 
   return (
     <Styled.Container>
+      <div>oSourceAssetWB {JSON.stringify(oSourceAssetWB, null, 2)}</div>
+      <div>oSwapParams {JSON.stringify(oSwapParams, null, 2)}</div>
       <Styled.ContentContainer>
         <Styled.Header>
           {FP.pipe(

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1293,8 +1293,6 @@ export const Swap = ({
 
   return (
     <Styled.Container>
-      <div>oSourceAssetWB {JSON.stringify(oSourceAssetWB, null, 2)}</div>
-      <div>oSwapParams {JSON.stringify(oSwapParams, null, 2)}</div>
       <Styled.ContentContainer>
         <Styled.Header>
           {FP.pipe(

--- a/src/renderer/components/wallet/assets/AssetDetails.tsx
+++ b/src/renderer/components/wallet/assets/AssetDetails.tsx
@@ -86,10 +86,12 @@ export const AssetDetails: React.FC<Props> = (props): JSX.Element => {
   const walletActionDepositClick = useCallback(() => {
     FP.pipe(
       oWalletAddress,
-      O.map((walletAddress) => walletRoutes.deposit.path({ walletType, walletAddress })),
+      O.map((walletAddress) =>
+        walletRoutes.deposit.path({ walletType, walletAddress, walletIndex: walletIndex.toString() })
+      ),
       O.map(history.push)
     )
-  }, [oWalletAddress, history.push, walletType])
+  }, [oWalletAddress, history.push, walletType, walletIndex])
 
   const isNonNativeRuneAsset: boolean = useMemo(
     () => AssetHelper.isNonNativeRuneAsset(asset, network),

--- a/src/renderer/components/wallet/txs/send/Send.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.stories.tsx
@@ -125,11 +125,13 @@ const defaultComponentProps = {
   balances,
   balance: bnbAsset,
   feesWithRates: RD.success({ fees, rates }),
-  onSubmit: ({ recipient, amount, asset, memo }: SendTxParams) =>
+  onSubmit: ({ recipient, amount, asset, memo, walletIndex, walletType }: SendTxParams) =>
     console.log(
       `to: ${recipient}, amount ${formatAssetAmount({ amount: baseToAsset(amount) })}, asset: ${assetToString(
         asset
-      )}, memo: ${memo}`
+      )}, memo: ${memo},
+      walletType: ${walletType},
+      walletIndex: ${walletIndex}`
     ),
 
   isLoading: false,

--- a/src/renderer/components/wallet/txs/send/Send.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.stories.tsx
@@ -24,7 +24,7 @@ import { RDStatus, getMockRDValueFactory } from '../../../../../shared/mock/rdBy
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { WalletType } from '../../../../../shared/wallet/types'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/binance/types'
+import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalances } from '../../../../services/clients'
 import { ErrorId, TxHashRD, WalletBalance } from '../../../../services/wallet/types'
 import { Send } from './Send'
@@ -125,14 +125,18 @@ const defaultComponentProps = {
   balances,
   balance: bnbAsset,
   feesWithRates: RD.success({ fees, rates }),
-  onSubmit: ({ recipient, amount, asset, memo, walletIndex, walletType }: SendTxParams) =>
-    console.log(
-      `to: ${recipient}, amount ${formatAssetAmount({ amount: baseToAsset(amount) })}, asset: ${assetToString(
-        asset
-      )}, memo: ${memo},
+  onSubmit: (p: SendTxParams) => {
+    const { recipient, amount, asset, memo, walletIndex, walletType, sender } = p
+    console.log(`
+      to: ${recipient},
+      amount ${formatAssetAmount({ amount: baseToAsset(amount) })},
+      asset: ${assetToString(asset)},
+      memo: ${memo},
+      sender: ${sender},
       walletType: ${walletType},
-      walletIndex: ${walletIndex}`
-    ),
+      walletIndex: ${walletIndex}
+      `)
+  },
 
   isLoading: false,
   addressValidation: (_: unknown) => true,

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.stories.tsx
@@ -37,6 +37,7 @@ const rates: FeeRates = {
 
 const defaultProps: ComponentProps = {
   walletType: 'keystore',
+  walletIndex: 0,
   balances: [bchBalance, runeBalance],
   balance: bchBalance,
   onSubmit: ({ recipient, amount, feeOption, memo }: SendTxParams) =>

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
@@ -49,6 +49,7 @@ export type FormValues = {
 
 export type Props = {
   walletType: WalletType
+  walletIndex: number
   balances: WalletBalances
   balance: WalletBalance
   onSubmit: (p: SendTxParams) => void
@@ -64,6 +65,7 @@ export type Props = {
 export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
   const {
     walletType,
+    walletIndex,
     balances,
     balance,
     onSubmit,
@@ -267,13 +269,14 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
 
     onSubmit({
       walletType,
+      walletIndex,
       recipient: form.getFieldValue('recipient'),
       asset: balance.asset,
       amount: assetToBase(assetAmount(form.getFieldValue('amount'))),
       feeOption: selectedFeeOptionKey,
       memo: form.getFieldValue('memo')
     })
-  }, [selectedFeeOptionKey, onSubmit, form, balance, walletType])
+  }, [onSubmit, walletType, walletIndex, form, balance.asset, selectedFeeOptionKey])
 
   const renderPwModal = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
@@ -15,7 +15,7 @@ import {
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/binance/types'
+import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormBNB, Props as SendFormBNBProps } from './SendFormBNB'
 
@@ -33,16 +33,17 @@ const runeBalance: WalletBalance = mockWalletBalance({
 
 const defaultProps: SendFormBNBProps = {
   walletType: 'keystore',
-  walletAddress: 'bnb-address',
   walletIndex: 0,
+  walletAddress: 'bnb-address',
   balances: [bnbBalance, runeBalance],
   balance: bnbBalance,
-  onSubmit: ({ recipient, amount, asset, memo }: SendTxParams) =>
+  onSubmit: ({ recipient, amount, asset, memo }: SendTxParams) => {
     console.log(
       `to: ${recipient}, amount ${formatAssetAmount({ amount: baseToAsset(amount) })}, asset: ${assetToString(
         asset
       )}, memo: ${memo}`
-    ),
+    )
+  },
 
   isLoading: false,
   addressValidation: (_: string) => true,

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -50,7 +50,7 @@ export type Props = {
   balances: WalletBalances
   balance: WalletBalance
   walletAddress: Address
-  walletIndex?: number
+  walletIndex: number
   onSubmit: (p: SendTxParams) => void
   isLoading: boolean
   sendTxStatusMsg: string
@@ -186,12 +186,12 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
 
     onSubmit({
       walletType,
+      walletIndex,
       sender: walletAddress,
       recipient: form.getFieldValue('recipient'),
       asset: balance.asset,
       amount: amountToSend,
-      memo: form.getFieldValue('memo'),
-      walletIndex: walletIndex
+      memo: form.getFieldValue('memo')
     })
   }, [onSubmit, walletType, walletAddress, form, balance.asset, amountToSend, walletIndex])
 

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
@@ -38,6 +38,7 @@ const rates: FeeRates = {
 
 const defaultProps: ComponentProps = {
   walletType: 'keystore',
+  walletIndex: 0,
   balances: [btcBalance, runeBalance],
   balance: btcBalance,
   onSubmit: ({ recipient, amount, feeOption, memo }: SendTxParams) =>

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -49,6 +49,7 @@ export type FormValues = {
 
 export type Props = {
   walletType: WalletType
+  walletIndex: number
   balances: WalletBalances
   balance: WalletBalance
   onSubmit: (p: SendTxParams) => void
@@ -64,6 +65,7 @@ export type Props = {
 export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
   const {
     walletType,
+    walletIndex,
     balances,
     balance,
     onSubmit,
@@ -267,13 +269,14 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
 
     onSubmit({
       walletType,
+      walletIndex,
       recipient: form.getFieldValue('recipient'),
       asset: balance.asset,
       amount: assetToBase(assetAmount(form.getFieldValue('amount'))),
       feeOption: selectedFeeOption,
       memo: form.getFieldValue('memo')
     })
-  }, [onSubmit, walletType, form, balance.asset, selectedFeeOption])
+  }, [onSubmit, walletType, walletIndex, form, balance.asset, selectedFeeOption])
 
   const renderPwModal = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormETH.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormETH.stories.tsx
@@ -9,7 +9,7 @@ import { assetAmount, AssetETH, assetToBase } from '@xchainjs/xchain-util'
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { THORCHAIN_DECIMAL } from '../../../../helpers/assetHelper'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/ethereum/types'
+import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormETH } from './index'
 import { Props as SendFormETHProps } from './SendFormETH'
@@ -33,6 +33,7 @@ const fees: Fees = {
 
 const defaultProps: SendFormETHProps = {
   walletType: 'keystore',
+  walletIndex: 0,
   balances: [ethBalance, runeBalance],
   balance: ethBalance,
   fees: RD.success(fees),

--- a/src/renderer/components/wallet/txs/send/SendFormETH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormETH.tsx
@@ -50,6 +50,7 @@ export type FormValues = {
 
 export type Props = {
   walletType: WalletType
+  walletIndex: number
   balances: WalletBalances
   balance: WalletBalance
   onSubmit: (p: SendTxParams) => void
@@ -64,6 +65,7 @@ export type Props = {
 export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
   const {
     walletType,
+    walletIndex,
     balances,
     balance,
     onSubmit,
@@ -289,6 +291,7 @@ export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
       O.map(([amount, recipient]) => {
         onSubmit({
           walletType,
+          walletIndex,
           recipient,
           asset: balance.asset,
           amount,
@@ -298,7 +301,7 @@ export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
         return true
       })
     )
-  }, [amountToSend, sendAddress, onSubmit, walletType, balance.asset, selectedFeeOption, form])
+  }, [amountToSend, sendAddress, onSubmit, walletType, walletIndex, balance.asset, selectedFeeOption, form])
 
   const renderPwModal = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
@@ -37,6 +37,7 @@ const rates: FeeRates = {
 
 const defaultProps: ComponentProps = {
   walletType: 'keystore',
+  walletIndex: 0,
   balances: [ltcBalance, runeBalance],
   balance: ltcBalance,
   onSubmit: ({ recipient, amount, feeOption, memo }: SendTxParams) =>

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
@@ -49,6 +49,7 @@ export type FormValues = {
 
 export type Props = {
   walletType: WalletType
+  walletIndex: number
   balances: WalletBalances
   balance: WalletBalance
   onSubmit: (p: SendTxParams) => void
@@ -64,6 +65,7 @@ export type Props = {
 export const SendFormLTC: React.FC<Props> = (props): JSX.Element => {
   const {
     walletType,
+    walletIndex,
     balances,
     balance,
     onSubmit,
@@ -264,13 +266,14 @@ export const SendFormLTC: React.FC<Props> = (props): JSX.Element => {
 
     onSubmit({
       walletType,
+      walletIndex,
       recipient: form.getFieldValue('recipient'),
       asset: balance.asset,
       amount: amountToSend,
       feeOption: selectedFeeOption,
       memo: form.getFieldValue('memo')
     })
-  }, [onSubmit, walletType, form, balance.asset, amountToSend, selectedFeeOption])
+  }, [onSubmit, walletType, walletIndex, form, balance.asset, amountToSend, selectedFeeOption])
 
   const renderPwModal = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/binance/types'
+import { SendTxParams } from '../../../../services/chain/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { SendFormTHOR as Component, Props as ComponentProps } from './SendFormTHOR'
 
@@ -23,6 +23,7 @@ const runeBalance: WalletBalance = mockWalletBalance({
 
 const defaultProps: ComponentProps = {
   walletType: 'keystore',
+  walletIndex: 0,
   balances: [runeBalance],
   balance: runeBalance,
   onSubmit: ({ recipient, amount, asset, memo }: SendTxParams) =>

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -47,6 +47,7 @@ export type FormValues = {
 
 export type Props = {
   walletType: WalletType
+  walletIndex: number
   balances: WalletBalances
   balance: WalletBalance
   onSubmit: (p: SendTxParams) => void
@@ -62,6 +63,7 @@ export type Props = {
 export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
   const {
     walletType,
+    walletIndex,
     balances,
     balance,
     onSubmit,
@@ -183,12 +185,13 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
 
     onSubmit({
       walletType,
+      walletIndex,
       recipient: form.getFieldValue('recipient'),
       asset: balance.asset,
       amount: amountToSend,
       memo: form.getFieldValue('memo')
     })
-  }, [onSubmit, form, balance.asset, amountToSend, walletType])
+  }, [onSubmit, form, balance.asset, amountToSend, walletType, walletIndex])
 
   const renderPwModal = useMemo(
     () =>

--- a/src/renderer/hooks/useLedger.ts
+++ b/src/renderer/hooks/useLedger.ts
@@ -19,7 +19,7 @@ export const useLedger = (chain: Chain) => {
   const { askLedgerAddress$, getLedgerAddress$, verifyLedgerAddress, removeLedgerAddress } = useWalletContext()
 
   const verifyAddress = useCallback(
-    (walletIndex = 0) => verifyLedgerAddress(chain, network, walletIndex),
+    (walletIndex) => verifyLedgerAddress(chain, network, walletIndex),
     [chain, verifyLedgerAddress, network]
   )
   const removeAddress = useCallback(() => removeLedgerAddress(chain, network), [chain, removeLedgerAddress, network])

--- a/src/renderer/routes/wallet/wallet.test.ts
+++ b/src/renderer/routes/wallet/wallet.test.ts
@@ -176,15 +176,15 @@ describe('Wallet routes', () => {
 
   describe('deposit route', () => {
     it('template', () => {
-      expect(deposit.template).toEqual('/wallet/assets/deposit/:walletType/:walletAddress')
+      expect(deposit.template).toEqual('/wallet/assets/deposit/:walletType/:walletAddress/:walletIndex')
     })
     it('path for keystore + any wallet address ', () => {
-      expect(deposit.path({ walletType: 'keystore', walletAddress: 'abc123' })).toEqual(
-        '/wallet/assets/deposit/keystore/abc123'
+      expect(deposit.path({ walletType: 'keystore', walletAddress: 'abc123', walletIndex: '1' })).toEqual(
+        '/wallet/assets/deposit/keystore/abc123/1'
       )
     })
     it('redirects for invalid values ', () => {
-      expect(deposit.path({ walletAddress: '', walletType: 'ledger' })).toEqual('/wallet/assets')
+      expect(deposit.path({ walletAddress: '', walletType: 'ledger', walletIndex: '0' })).toEqual('/wallet/assets')
     })
   })
 })

--- a/src/renderer/routes/wallet/wallet.ts
+++ b/src/renderer/routes/wallet/wallet.ts
@@ -52,12 +52,12 @@ export const poolShares: Route<void> = {
   }
 }
 
-export type DepositParams = { walletAddress: string; walletType: WalletType }
+export type DepositParams = { walletAddress: string; walletType: WalletType; walletIndex: string }
 export const deposit: Route<DepositParams> = {
-  template: `${assets.template}/deposit/:walletType/:walletAddress`,
-  path({ walletType, walletAddress }) {
+  template: `${assets.template}/deposit/:walletType/:walletAddress/:walletIndex`,
+  path({ walletType, walletAddress, walletIndex }) {
     if (walletAddress) {
-      return `${assets.template}/deposit/${walletType}/${walletAddress}`
+      return `${assets.template}/deposit/${walletType}/${walletAddress}/${walletIndex}`
     } else {
       // Redirect to assets route if passed param are invalid
       return assets.path()

--- a/src/renderer/services/binance/transaction.ts
+++ b/src/renderer/services/binance/transaction.ts
@@ -18,16 +18,8 @@ import { TransactionService } from './types'
 export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
   const common = C.createTransactionService(client$)
 
-  const sendLedgerTx = ({
-    network,
-    params,
-    walletIndex = 0
-  }: {
-    network: Network
-    params: SendTxParams
-    walletIndex?: number
-  }): TxHashLD => {
-    const { asset, amount, sender, recipient, memo } = params
+  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+    const { asset, amount, sender, recipient, memo, walletIndex } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: BNBChain,
       network,
@@ -59,11 +51,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       RxOp.startWith(RD.pending)
     )
   }
-  const sendTx = (params: SendTxParams, walletIndex?: number): TxHashLD =>
+  const sendTx = (params: SendTxParams): TxHashLD =>
     FP.pipe(
       network$,
       RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, walletIndex, params })
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/binance/types.ts
+++ b/src/renderer/services/binance/types.ts
@@ -54,6 +54,7 @@ export type SendTxParams = {
   amount: BaseAmount
   asset: Asset
   memo?: string
+  walletIndex: number
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -19,8 +19,8 @@ const reloadBalances = () => {
 }
 
 // State of balances loaded by Client
-const balances$ = (walletType: WalletType): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType })
+const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)

--- a/src/renderer/services/bitcoin/ledger.ts
+++ b/src/renderer/services/bitcoin/ledger.ts
@@ -12,9 +12,9 @@ import { LedgerService } from './types'
 
 const { get$: ledgerAddress$, set: setLedgerAddressRD } = observableState<LedgerAddressRD>(RD.initial)
 
-const retrieveLedgerAddress = (network: Network) =>
+const retrieveLedgerAddress = (network: Network, walletIndex: number) =>
   FP.pipe(
-    Rx.from(window.apiHDWallet.getLedgerAddress({ chain: BTCChain, network })),
+    Rx.from(window.apiHDWallet.getLedgerAddress({ chain: BTCChain, network, walletIndex })),
     map(RD.fromEither),
     startWith(RD.pending),
     catchError((error) => Rx.of(RD.failure(error)))

--- a/src/renderer/services/bitcoin/types.ts
+++ b/src/renderer/services/bitcoin/types.ts
@@ -26,6 +26,7 @@ export type SendTxParams = {
   amount: BaseAmount
   feeRate: number
   memo?: string
+  walletIndex: number
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/bitcoin/types.ts
+++ b/src/renderer/services/bitcoin/types.ts
@@ -38,7 +38,7 @@ export type FeesService = C.FeesService & {
 
 export type LedgerService = {
   ledgerAddress$: LedgerAddressLD
-  retrieveLedgerAddress: (network: Network) => void
+  retrieveLedgerAddress: (network: Network, walletIndex: number) => void
   removeLedgerAddress: () => void
   ledgerTxRD$: LedgerTxHashLD
   pushLedgerTx: (network: Network, params: LedgerBTCTxInfo) => Rx.Subscription

--- a/src/renderer/services/bitcoincash/balances.ts
+++ b/src/renderer/services/bitcoincash/balances.ts
@@ -19,7 +19,7 @@ const reloadBalances = () => {
 }
 
 // State of balances loaded by Client
-const balances$ = (walletType: WalletType): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType })
+const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/bitcoincash/types.ts
+++ b/src/renderer/services/bitcoincash/types.ts
@@ -23,6 +23,7 @@ export type SendTxParams = {
   amount: BaseAmount
   feeRate: number
   memo?: string
+  walletIndex: number
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -114,7 +114,8 @@ export const sendPoolTx$ = ({
         recipient,
         asset,
         amount,
-        memo
+        memo,
+        walletIndex
       })
 
     case THORChain:

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -35,13 +35,19 @@ const txFailure$ = (msg: string) =>
     })
   )
 
-export const sendTx$ = (
-  { walletType, asset, sender, recipient, amount, memo, feeOption = DEFAULT_FEE_OPTION }: SendTxParams,
-  walletIndex?: number
-): TxHashLD => {
+export const sendTx$ = ({
+  walletType,
+  asset,
+  sender,
+  recipient,
+  amount,
+  memo,
+  feeOption = DEFAULT_FEE_OPTION,
+  walletIndex
+}: SendTxParams): TxHashLD => {
   switch (asset.chain) {
     case BNBChain:
-      return BNB.sendTx({ walletType, sender, recipient, amount, asset, memo }, walletIndex)
+      return BNB.sendTx({ walletType, sender, recipient, amount, asset, memo, walletIndex })
 
     case BTCChain:
       return FP.pipe(
@@ -50,14 +56,14 @@ export const sendTx$ = (
           errorId: ErrorId.GET_FEES,
           msg: error?.message ?? error.toString()
         })),
-        liveData.chain(({ rates }) => BTC.sendTx({ recipient, amount, feeRate: rates[feeOption], memo }))
+        liveData.chain(({ rates }) => BTC.sendTx({ recipient, amount, feeRate: rates[feeOption], memo, walletIndex }))
       )
 
     case ETHChain:
-      return ETH.sendTx({ asset, recipient, amount, memo, feeOption })
+      return ETH.sendTx({ asset, recipient, amount, memo, feeOption, walletIndex })
 
     case THORChain:
-      return THOR.sendTx({ walletType, amount, asset, memo, recipient })
+      return THOR.sendTx({ walletType, amount, asset, memo, recipient, walletIndex })
 
     case CosmosChain:
       // not available yet
@@ -73,7 +79,7 @@ export const sendTx$ = (
           errorId: ErrorId.GET_FEES,
           msg: error?.message ?? error.toString()
         })),
-        liveData.chain(({ rates }) => BCH.sendTx({ recipient, amount, feeRate: rates[feeOption], memo }))
+        liveData.chain(({ rates }) => BCH.sendTx({ recipient, amount, feeRate: rates[feeOption], memo, walletIndex }))
       )
     case LTCChain:
       return FP.pipe(
@@ -83,7 +89,7 @@ export const sendTx$ = (
           msg: error?.message ?? error.toString()
         })),
         liveData.chain(({ rates }) => {
-          return LTC.sendTx({ recipient, amount, asset, memo, feeRate: rates[feeOption] })
+          return LTC.sendTx({ recipient, amount, asset, memo, feeRate: rates[feeOption], walletIndex })
         })
       )
   }

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -119,7 +119,7 @@ export const sendPoolTx$ = ({
       })
 
     case THORChain:
-      return THOR.sendPoolTx$({ walletType, amount, asset, memo })
+      return THOR.sendPoolTx$({ walletType, amount, asset, memo, walletIndex })
 
     default:
       return sendTx$({ sender, walletType, asset, recipient, amount, memo, feeOption, walletIndex })

--- a/src/renderer/services/chain/transaction/deposit.ts
+++ b/src/renderer/services/chain/transaction/deposit.ts
@@ -38,7 +38,14 @@ const { pools: midgardPoolsService, validateNode$ } = midgardService
  * @returns AsymDepositState$ - Observable state to reflect loading status. It provides all data we do need to display status in `TxModul`
  *
  */
-export const asymDeposit$ = ({ poolAddress, asset, amount, memo }: AsymDepositParams): AsymDepositState$ => {
+export const asymDeposit$ = ({
+  poolAddress,
+  asset,
+  amount,
+  memo,
+  walletType,
+  walletIndex
+}: AsymDepositParams): AsymDepositState$ => {
   // total of progress
   const total = O.some(100)
 
@@ -71,8 +78,8 @@ export const asymDeposit$ = ({ poolAddress, asset, amount, memo }: AsymDepositPa
       setState({ ...getState(), step: 2, deposit: RD.progress({ loaded: 50, total }) })
       // 2. send deposit tx
       return sendPoolTx$({
-        // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
+        walletIndex,
         router: poolAddress.router,
         asset,
         recipient: poolAddress.address,
@@ -161,7 +168,9 @@ export const symDeposit$ = ({
   poolAddress: poolAddresses,
   asset,
   amounts,
-  memos
+  memos,
+  walletIndex,
+  walletType
 }: SymDepositParams): SymDepositState$ => {
   // total of progress
   const total = O.some(100)
@@ -193,7 +202,8 @@ export const symDeposit$ = ({
       setState({ ...getState(), step: 2, deposit: RD.progress({ loaded: 40, total }) })
       return sendPoolTx$({
         // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
+        walletIndex,
         router: poolAddresses.router,
         asset,
         recipient: poolAddresses.address,
@@ -218,8 +228,8 @@ export const symDeposit$ = ({
     liveData.chain<ApiError, TxHash, TxHash>((_) => {
       setState({ ...getState(), step: 3, deposit: RD.progress({ loaded: 60, total }) })
       return sendPoolTx$({
-        // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
+        walletIndex,
         router: O.none, // no router for RUNE
         asset: AssetRuneNative,
         recipient: '', // no recipient for RUNE needed

--- a/src/renderer/services/chain/transaction/swap.ts
+++ b/src/renderer/services/chain/transaction/swap.ts
@@ -32,7 +32,8 @@ export const swap$ = ({
   amount,
   memo,
   walletType,
-  sender
+  sender,
+  walletIndex
 }: SwapTxParams): SwapState$ => {
   // total of progress
   const total = O.some(100)
@@ -72,7 +73,8 @@ export const swap$ = ({
         amount,
         memo,
         feeOption: ChainTxFeeOption.SWAP,
-        sender
+        sender,
+        walletIndex
       })
     }),
     liveData.chain((txHash) => {

--- a/src/renderer/services/chain/transaction/transfer.ts
+++ b/src/renderer/services/chain/transaction/transfer.ts
@@ -16,7 +16,7 @@ import { poolTxStatusByChain$, sendTx$ } from './common'
 /**
  * Send TX
  */
-export const transfer$: SendTxStateHandler = (params, walletIndex) => {
+export const transfer$: SendTxStateHandler = (params) => {
   // Observable state of `SendTxState`
   const {
     get$: getState$,
@@ -30,7 +30,7 @@ export const transfer$: SendTxStateHandler = (params, walletIndex) => {
 
   // All requests will be done in a sequence
   // to update `SendTxState` step by step
-  const requests$ = sendTx$(params, walletIndex).pipe(
+  const requests$ = sendTx$(params).pipe(
     liveData.chain((txHash) => {
       // Update state
       setState({

--- a/src/renderer/services/chain/transaction/withdraw.ts
+++ b/src/renderer/services/chain/transaction/withdraw.ts
@@ -28,7 +28,7 @@ const { pools: midgardPoolsService, validateNode$ } = midgardService
  * @returns WithdrawState$ - Observable state to reflect loading status. It provides all data we do need to display status in `TxModal`
  *
  */
-export const symWithdraw$ = ({ memo, network }: SymWithdrawParams): WithdrawState$ => {
+export const symWithdraw$ = ({ memo, network, walletType, walletIndex }: SymWithdrawParams): WithdrawState$ => {
   // total of progress
   const total = O.some(100)
 
@@ -52,8 +52,8 @@ export const symWithdraw$ = ({ memo, network }: SymWithdrawParams): WithdrawStat
     liveData.chain((_) => {
       setState({ ...getState(), step: 2, withdraw: RD.progress({ loaded: 50, total }) })
       return sendPoolTx$({
-        // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
+        walletIndex,
         router: O.none, // no router for RUNE
         asset: AssetRuneNative,
         recipient: '', // empty for RUNE txs
@@ -134,7 +134,14 @@ export const symWithdraw$ = ({ memo, network }: SymWithdrawParams): WithdrawStat
  * @returns WithdrawState$ - Observable state to reflect loading status. It provides all data we do need to display status in `TxModal`
  *
  */
-export const asymWithdraw$ = ({ poolAddress, asset, memo, network }: AsymWithdrawParams): WithdrawState$ => {
+export const asymWithdraw$ = ({
+  poolAddress,
+  asset,
+  memo,
+  network,
+  walletIndex,
+  walletType
+}: AsymWithdrawParams): WithdrawState$ => {
   // total of progress
   const total = O.some(100)
 
@@ -167,8 +174,8 @@ export const asymWithdraw$ = ({ poolAddress, asset, memo, network }: AsymWithdra
     liveData.chain((_) => {
       setState({ ...getState(), step: 2, withdraw: RD.progress({ loaded: 50, total }) })
       return sendTx$({
-        // TODO(@asgdx-team) Get `walletType` from props if we want to support other than keystore (e.g. Ledger)
-        walletType: 'keystore',
+        walletType,
+        walletIndex,
         asset,
         recipient: poolAddress.address, // it will be empty string for RUNE
         amount: smallestAmountToSent(asset.chain, network),

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -124,6 +124,7 @@ export type SwapTxParams = {
   readonly memo: string
   readonly walletType: WalletType
   readonly sender: Address
+  readonly walletIndex: number
 }
 
 export type SwapStateHandler = (p: SwapTxParams) => SwapState$

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -61,6 +61,8 @@ export type AsymDepositParams = {
   readonly asset: Asset
   readonly amount: BaseAmount
   readonly memo: string
+  readonly walletIndex: number
+  readonly walletType: WalletType
 }
 
 export type SymDepositAmounts = { rune: BaseAmount; asset: BaseAmount }
@@ -70,6 +72,8 @@ export type SymDepositParams = {
   readonly asset: Asset
   readonly amounts: SymDepositAmounts
   readonly memos: SymDepositMemo
+  readonly walletIndex: number
+  readonly walletType: WalletType
 }
 
 export type SendDepositTxParams = {
@@ -89,7 +93,7 @@ export type SendTxParams = {
   amount: BaseAmount
   memo: Memo
   feeOption?: FeeOption
-  walletIndex?: number
+  walletIndex: number
 }
 
 export type SendPoolTxParams = SendTxParams & {
@@ -243,6 +247,8 @@ export type WithdrawState$ = Rx.Observable<WithdrawState>
 export type SymWithdrawParams = {
   readonly memo: Memo
   readonly network: Network
+  readonly walletType: WalletType
+  readonly walletIndex: number
 }
 
 export type SymWithdrawStateHandler = (p: SymWithdrawParams) => WithdrawState$
@@ -252,6 +258,8 @@ export type AsymWithdrawParams = {
   readonly asset: Asset
   readonly memo: Memo
   readonly network: Network
+  readonly walletType: WalletType
+  readonly walletIndex: number
 }
 
 export type AsymWithdrawStateHandler = (p: AsymWithdrawParams) => WithdrawState$
@@ -302,4 +310,4 @@ export type SendTxState = {
 
 export type SendTxState$ = Rx.Observable<SendTxState>
 
-export type SendTxStateHandler = (p: SendTxParams, walletIndex?: number) => SendTxState$
+export type SendTxStateHandler = (p: SendTxParams) => SendTxState$

--- a/src/renderer/services/clients/balances.ts
+++ b/src/renderer/services/clients/balances.ts
@@ -27,14 +27,13 @@ const loadBalances$ = ({
   walletType,
   address,
   assets,
-  /* TODO (@asgdx-team) Check if we still can use `0` as default by introducing HD wallets in the future */
-  walletIndex = 0
+  walletIndex
 }: {
   client: XChainClient
   walletType: WalletType
   address?: Address
   assets?: Asset[]
-  walletIndex?: number
+  walletIndex: number
 }): WalletBalancesLD =>
   FP.pipe(
     address,
@@ -83,7 +82,7 @@ export const balances$: ({
   client$: XChainClient$
   trigger$: Rx.Observable<boolean>
   assets?: Asset[]
-  walletIndex?: number
+  walletIndex: number
 }) => WalletBalancesLD = ({ walletType, client$, trigger$, assets, walletIndex }) =>
   Rx.combineLatest([trigger$.pipe(debounceTime(300)), client$]).pipe(
     RxOp.switchMap(([_, oClient]) => {
@@ -109,8 +108,17 @@ export const balancesByAddress$: (
   client$: XChainClient$,
   trigger$: Rx.Observable<boolean>,
   assets?: Asset[]
-) => (address: string, walletType: WalletType) => WalletBalancesLD =
-  (client$, trigger$, assets) => (address, walletType) =>
+) => ({
+  address,
+  walletType,
+  walletIndex
+}: {
+  address: string
+  walletType: WalletType
+  walletIndex: number
+}) => WalletBalancesLD =
+  (client$, trigger$, assets) =>
+  ({ address, walletType, walletIndex }) =>
     Rx.combineLatest([trigger$.pipe(debounceTime(300)), client$]).pipe(
       RxOp.mergeMap(([_, oClient]) => {
         return FP.pipe(
@@ -119,7 +127,7 @@ export const balancesByAddress$: (
             // if a client is not available, "reset" state to "initial"
             () => Rx.of(RD.initial),
             // or start request and return state
-            (client) => loadBalances$({ client, address, walletType, assets })
+            (client) => loadBalances$({ client, address, walletType, assets, walletIndex })
           )
         )
       }),

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -54,7 +54,7 @@ export type WalletAddress$ = Rx.Observable<O.Option<WalletAddress>>
 export type TransactionService<T> = {
   txRD$: TxHashLD
   subscribeTx: (_: T) => Rx.Subscription
-  sendTx: (_: T, walletIndex?: number) => TxHashLD
+  sendTx: (_: T) => TxHashLD
   resetTx: () => void
   txs$: (_: TxsParams) => TxsPageLD
   tx$: (txHash: TxHash) => TxLD

--- a/src/renderer/services/ethereum/balances.ts
+++ b/src/renderer/services/ethereum/balances.ts
@@ -27,15 +27,20 @@ const reloadBalances = () => {
 }
 
 // State of balances loaded by Client
-const balances$: ({ walletType, network }: { walletType: WalletType; network: Network }) => C.WalletBalancesLD = ({
+const balances$: ({
   walletType,
-  network
-}) => {
+  network,
+  walletIndex
+}: {
+  walletType: WalletType
+  network: Network
+  walletIndex: number
+}) => C.WalletBalancesLD = ({ walletType, walletIndex, network }) => {
   // For testnet we limit requests by using pre-defined assets only
   // because `xchain-ethereum` does for each asset a single request
   const assets: Asset[] | undefined = network === 'testnet' ? ETHAssetsTestnet : undefined
   return FP.pipe(
-    C.balances$({ client$, trigger$: reloadBalances$, assets, walletType }),
+    C.balances$({ client$, trigger$: reloadBalances$, assets, walletType, walletIndex }),
     // Filter assets based on ERC20Whitelist (mainnet only)
     liveData.map(FP.flow(A.filter(({ asset }) => validAssetForETH(asset, network))))
   )

--- a/src/renderer/services/ethereum/types.ts
+++ b/src/renderer/services/ethereum/types.ts
@@ -30,6 +30,7 @@ export type SendTxParams = {
   amount: BaseAmount
   memo: Memo
   feeOption?: FeeOption
+  walletIndex: number
 }
 
 export type SendPoolTxParams = SendTxParams & {

--- a/src/renderer/services/litecoin/balances.ts
+++ b/src/renderer/services/litecoin/balances.ts
@@ -19,7 +19,7 @@ const reloadBalances = () => {
 }
 
 // State of balances loaded by Client
-const balances$ = (walletType: WalletType): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType })
+const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/litecoin/types.ts
+++ b/src/renderer/services/litecoin/types.ts
@@ -26,6 +26,7 @@ export type SendTxParams = {
   asset: Asset
   memo?: string
   feeRate: number
+  walletIndex: number
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/thorchain/balances.ts
+++ b/src/renderer/services/thorchain/balances.ts
@@ -22,8 +22,8 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 // Currently in ASGDX `AssetRuneNative` is supported only. Remove asset list if we want to get balances of all assets at THORChain.
-const balances$ = (walletType: WalletType): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, assets: [AssetRuneNative], walletType })
+const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, assets: [AssetRuneNative], walletType, walletIndex })
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)

--- a/src/renderer/services/thorchain/interact.ts
+++ b/src/renderer/services/thorchain/interact.ts
@@ -27,10 +27,10 @@ import { InteractParams, InteractState, InteractState$ } from './types'
  */
 export const createInteractService$ =
   (
-    depositTx$: (_: DepositParam & { walletType: WalletType }) => LiveData<ApiError, string>,
+    depositTx$: (_: DepositParam & { walletType: WalletType; walletIndex: number }) => LiveData<ApiError, string>,
     getTxStatus: (txHash: string, assetAddress: O.Option<Address>) => TxLD
   ) =>
-  ({ walletType, amount, memo }: InteractParams): InteractState$ => {
+  ({ walletType, walletIndex, amount, memo }: InteractParams): InteractState$ => {
     // total of progress
     const total = O.some(100)
 
@@ -51,6 +51,7 @@ export const createInteractService$ =
       // 1. send deposit tx
       depositTx$({
         walletType,
+        walletIndex,
         asset: AssetRuneNative,
         amount,
         memo

--- a/src/renderer/services/thorchain/transaction.ts
+++ b/src/renderer/services/thorchain/transaction.ts
@@ -107,7 +107,7 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       sender: params.sender,
       recipient: params.recipient,
       memo: params.memo,
-      walletIndex: 0
+      walletIndex: params.walletIndex
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/thorchain/types.ts
+++ b/src/renderer/services/thorchain/types.ts
@@ -29,6 +29,7 @@ export type SendTxParams = {
   amount: BaseAmount
   asset: Asset
   memo?: string
+  walletIndex: number
 }
 
 export type TransactionService = {

--- a/src/renderer/services/thorchain/types.ts
+++ b/src/renderer/services/thorchain/types.ts
@@ -33,11 +33,12 @@ export type SendTxParams = {
 }
 
 export type TransactionService = {
-  sendPoolTx$: (params: DepositParam & { walletType: WalletType }) => TxHashLD
+  sendPoolTx$: (params: DepositParam & { walletType: WalletType; walletIndex: number }) => TxHashLD
 } & C.TransactionService<SendTxParams>
 
 export type InteractParams = {
   readonly walletType: WalletType
+  readonly walletIndex: number
   readonly amount: BaseAmount
   readonly memo: string
 }

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -93,14 +93,14 @@ export const createBalancesService = ({
         return {
           reloadBalances: BTC.reloadBalances,
           resetReloadBalances: BTC.resetReloadBalances,
-          balances$: BTC.balances$(walletType),
+          balances$: BTC.balances$(walletType, walletIndex),
           reloadBalances$: BTC.reloadBalances$
         }
       case BCHChain:
         return {
           reloadBalances: BCH.reloadBalances,
           resetReloadBalances: BCH.resetReloadBalances,
-          balances$: BCH.balances$(walletType),
+          balances$: BCH.balances$(walletType, walletIndex),
           reloadBalances$: BCH.reloadBalances$
         }
       case ETHChain:
@@ -109,7 +109,7 @@ export const createBalancesService = ({
           resetReloadBalances: ETH.resetReloadBalances,
           balances$: FP.pipe(
             network$,
-            RxOp.switchMap((network) => ETH.balances$({ walletType, network }))
+            RxOp.switchMap((network) => ETH.balances$({ walletType, network, walletIndex }))
           ),
           reloadBalances$: ETH.reloadBalances$
         }
@@ -117,14 +117,14 @@ export const createBalancesService = ({
         return {
           reloadBalances: THOR.reloadBalances,
           resetReloadBalances: THOR.resetReloadBalances,
-          balances$: THOR.balances$(walletType),
+          balances$: THOR.balances$(walletType, walletIndex),
           reloadBalances$: THOR.reloadBalances$
         }
       case LTCChain:
         return {
           reloadBalances: LTC.reloadBalances,
           resetReloadBalances: LTC.resetReloadBalances,
-          balances$: LTC.balances$(walletType),
+          balances$: LTC.balances$(walletType, walletIndex),
           reloadBalances$: LTC.reloadBalances$
         }
       default:
@@ -215,7 +215,15 @@ export const createBalancesService = ({
    */
   const ledgerChainBalance$ = (
     chain: Chain,
-    getBalanceByAddress$: (address: Address, walletType: WalletType) => WalletBalancesLD
+    getBalanceByAddress$: ({
+      address,
+      walletType,
+      walletIndex
+    }: {
+      address: Address
+      walletType: WalletType
+      walletIndex: number
+    }) => WalletBalancesLD
   ): ChainBalance$ =>
     FP.pipe(
       network$,
@@ -239,7 +247,7 @@ export const createBalancesService = ({
               // Load balances by given Ledger address
               // and put it's RD state into `balances` of `ChainBalance`
               FP.pipe(
-                getBalanceByAddress$(address, 'ledger'),
+                getBalanceByAddress$({ address, walletType: 'ledger', walletIndex }),
                 RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
                   walletType: 'ledger',
                   walletIndex,

--- a/src/renderer/services/wallet/keystore.ts
+++ b/src/renderer/services/wallet/keystore.ts
@@ -43,7 +43,6 @@ const importKeystore$ = (keystore: CryptoKeystore, password: string): ImportKeys
     // delay to give UI some time to render
     RxOp.delay(200),
     RxOp.switchMap((phrase) => Rx.from(addKeystore(phrase, password))),
-    RxOp.map((v) => v),
     RxOp.map(RD.success),
     RxOp.catchError((error) => Rx.of(RD.failure(new Error(`Could not decrypt phrase from keystore: ${error}`)))),
     RxOp.startWith(RD.pending)

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -80,7 +80,7 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
   /**
    * Ask Ledger to get address from it
    */
-  const askLedgerAddress$ = (chain: Chain, network: Network, walletIndex = 0): LedgerAddressLD =>
+  const askLedgerAddress$ = (chain: Chain, network: Network, walletIndex: number): LedgerAddressLD =>
     FP.pipe(
       // remove address from memory
       removeLedgerAddress(chain, network),

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -50,8 +50,7 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
       ledgerAddresses$,
       RxOp.map((addressesMap) => addressesMap[chain]),
       RxOp.distinctUntilChanged(eqLedgerAddressMap.equals),
-      RxOp.map((addressMap) => addressMap[network]),
-      RxOp.map((v) => v)
+      RxOp.map((addressMap) => addressMap[network])
     )
 
   const verifyLedgerAddress = (chain: Chain, network: Network, walletIndex = 0): void =>

--- a/src/renderer/services/wallet/transaction.ts
+++ b/src/renderer/services/wallet/transaction.ts
@@ -34,7 +34,7 @@ export const resetTxsPage: ResetTxsPageHandler = () => setLoadTxsProps(INITIAL_L
 /**
  * Factory create a stream of `TxsPageRD` based on selected asset
  */
-export const getTxs$: (walletAddress: O.Option<string>, walletIndex?: number) => TxsPageLD = (
+export const getTxs$: (walletAddress: O.Option<string>, walletIndex: number) => TxsPageLD = (
   walletAddress = O.none,
   walletIndex = 0 /* TODO (@asgdx-team) Will we still use `0` as default by introducing HD wallets in the future */
 ) =>

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -30,7 +30,14 @@ import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 export const AssetDetailsView: React.FC = (): JSX.Element => {
   const intl = useIntl()
 
-  const { asset: routeAsset, walletAddress, walletType, walletIndex } = useParams<AssetDetailsParams>()
+  const {
+    asset: routeAsset,
+    walletAddress,
+    walletType,
+    walletIndex: walletIndexRoute
+  } = useParams<AssetDetailsParams>()
+
+  const walletIndex = parseInt(walletIndexRoute)
 
   const oRouteAsset: O.Option<Asset> = useMemo(() => O.fromNullable(assetFromString(routeAsset)), [routeAsset])
   const oWalletAddress = useMemo(
@@ -55,7 +62,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
 
   const { getTxs$, balancesState$, loadTxs, reloadBalancesByChain, setSelectedAsset, resetTxsPage } = useWalletContext()
 
-  const [txsRD] = useObservableState(() => getTxs$(oWalletAddress), RD.initial)
+  const [txsRD] = useObservableState(() => getTxs$(oWalletAddress, walletIndex), RD.initial)
   const { balances: oBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
 
   useEffect(() => {
@@ -139,7 +146,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
           (asset) => (
             <AssetDetails
               walletType={walletType}
-              walletIndex={parseInt(walletIndex)}
+              walletIndex={walletIndex}
               txsPageRD={txsRD}
               balances={walletBalances}
               asset={asset}

--- a/src/renderer/views/wallet/Interact/BondView.tsx
+++ b/src/renderer/views/wallet/Interact/BondView.tsx
@@ -24,11 +24,12 @@ import * as Styled from './InteractView.styles'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   walletAddress: string
   goToTransaction: (txHash: string) => void
 }
 
-export const BondView: React.FC<Props> = ({ walletType, walletAddress, goToTransaction }) => {
+export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddress, goToTransaction }) => {
   const { balancesState$ } = useWalletContext()
 
   const {
@@ -66,9 +67,9 @@ export const BondView: React.FC<Props> = ({ walletType, walletAddress, goToTrans
 
   const bondTx = useCallback(
     ({ amount, memo }: { amount: BaseAmount; memo: string }) => {
-      subscribeInteractState(interact$({ walletType, amount, memo }))
+      subscribeInteractState(interact$({ walletType, walletIndex, amount, memo }))
     },
-    [interact$, subscribeInteractState, walletType]
+    [interact$, subscribeInteractState, walletIndex, walletType]
   )
 
   const stepLabels = useMemo(

--- a/src/renderer/views/wallet/Interact/CustomView.tsx
+++ b/src/renderer/views/wallet/Interact/CustomView.tsx
@@ -18,10 +18,11 @@ import * as Styled from './InteractView.styles'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const CustomView: React.FC<Props> = ({ walletType, openExplorerTxUrl }) => {
+export const CustomView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -33,9 +34,9 @@ export const CustomView: React.FC<Props> = ({ walletType, openExplorerTxUrl }) =
 
   const customTx = useCallback(
     ({ amount, memo }: { amount: BaseAmount; memo: string }) => {
-      subscribeInteractState(interact$({ walletType, amount, memo }))
+      subscribeInteractState(interact$({ walletType, walletIndex, amount, memo }))
     },
-    [interact$, subscribeInteractState, walletType]
+    [interact$, subscribeInteractState, walletIndex, walletType]
   )
   const stepLabels = useMemo(
     () => [intl.formatMessage({ id: 'common.tx.sending' }), intl.formatMessage({ id: 'common.tx.checkResult' })],

--- a/src/renderer/views/wallet/Interact/InteractView.tsx
+++ b/src/renderer/views/wallet/Interact/InteractView.tsx
@@ -20,7 +20,9 @@ import { LeaveView } from './LeaveView'
 import { UnbondView } from './UnbondView'
 
 export const InteractView: React.FC = () => {
-  const { walletAddress, walletType } = useParams<walletRoutes.DepositParams>()
+  const { walletAddress, walletType, walletIndex: walletIndexRoute } = useParams<walletRoutes.DepositParams>()
+
+  const walletIndex = parseInt(walletIndexRoute)
 
   const { network$ } = useAppContext()
   const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
@@ -38,11 +40,22 @@ export const InteractView: React.FC = () => {
         <Interact
           walletType={walletType}
           bondContent={
-            <BondView walletType={walletType} walletAddress={walletAddress} goToTransaction={openExplorerTxUrl} />
+            <BondView
+              walletType={walletType}
+              walletIndex={walletIndex}
+              walletAddress={walletAddress}
+              goToTransaction={openExplorerTxUrl}
+            />
           }
-          leaveContent={<LeaveView walletType={walletType} openExplorerTxUrl={openExplorerTxUrl} />}
-          unbondContent={<UnbondView walletType={walletType} openExplorerTxUrl={openExplorerTxUrl} />}
-          customContent={<CustomView walletType={walletType} openExplorerTxUrl={openExplorerTxUrl} />}
+          leaveContent={
+            <LeaveView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
+          }
+          unbondContent={
+            <UnbondView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
+          }
+          customContent={
+            <CustomView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
+          }
           network={network}
         />
       </Styled.ContentContainer>

--- a/src/renderer/views/wallet/Interact/LeaveView.tsx
+++ b/src/renderer/views/wallet/Interact/LeaveView.tsx
@@ -19,10 +19,11 @@ import * as Styled from './InteractView.styles'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const LeaveView: React.FC<Props> = ({ walletType, openExplorerTxUrl }) => {
+export const LeaveView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -42,10 +43,10 @@ export const LeaveView: React.FC<Props> = ({ walletType, openExplorerTxUrl }) =>
          * @docs https://docs.thorchain.org/thornodes/leaving#leaving
          */
 
-        interact$({ walletType, amount: baseAmount(1), memo })
+        interact$({ walletType, walletIndex, amount: baseAmount(1), memo })
       )
     },
-    [interact$, subscribeInteractState, walletType]
+    [interact$, subscribeInteractState, walletIndex, walletType]
   )
 
   const stepLabels = useMemo(

--- a/src/renderer/views/wallet/Interact/UnbondView.tsx
+++ b/src/renderer/views/wallet/Interact/UnbondView.tsx
@@ -19,10 +19,11 @@ import * as Styled from './InteractView.styles'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const UnbondView: React.FC<Props> = ({ walletType, openExplorerTxUrl: goToTransaction }) => {
+export const UnbondView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl: goToTransaction }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -41,10 +42,10 @@ export const UnbondView: React.FC<Props> = ({ walletType, openExplorerTxUrl: goT
          * it does not matter which amount to send
          * @docs https://docs.thorchain.org/thornodes/leaving#unbonding
          */
-        interact$({ walletType, amount: baseAmount(1), memo })
+        interact$({ walletType, walletIndex, amount: baseAmount(1), memo })
       )
     },
-    [interact$, subscribeInteractState, walletType]
+    [interact$, subscribeInteractState, walletIndex, walletType]
   )
 
   const stepLabels = useMemo(

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -35,7 +35,9 @@ import { SendViewTHOR } from './SendViewTHOR'
 type Props = {}
 
 export const SendView: React.FC<Props> = (): JSX.Element => {
-  const { asset, walletAddress, walletType, walletIndex } = useParams<SendParams>()
+  const { asset, walletAddress, walletType, walletIndex: walletIndexRoute } = useParams<SendParams>()
+
+  const walletIndex = parseInt(walletIndexRoute)
   const intl = useIntl()
 
   const { network$ } = useAppContext()
@@ -82,7 +84,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             <SendViewBNB
               walletType={walletType}
               walletAddress={walletAddress}
-              walletIndex={parseInt(walletIndex)}
+              walletIndex={walletIndex}
               asset={asset}
               balances={balances}
               openExplorerTxUrl={openExplorerTxUrl}
@@ -94,6 +96,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           return (
             <SendViewBCH
               walletType={walletType}
+              walletIndex={walletIndex}
               asset={asset}
               balances={balances}
               openExplorerTxUrl={openExplorerTxUrl}
@@ -105,6 +108,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           return (
             <SendViewBTC
               walletType={walletType}
+              walletIndex={walletIndex}
               asset={asset}
               balances={balances}
               openExplorerTxUrl={openExplorerTxUrl}
@@ -116,6 +120,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           return (
             <SendViewETH
               walletType={walletType}
+              walletIndex={walletIndex}
               asset={asset}
               balances={balances}
               openExplorerTxUrl={openExplorerTxUrl}
@@ -127,6 +132,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           return (
             <SendViewTHOR
               walletType={walletType}
+              walletIndex={walletIndex}
               walletAddress={walletAddress}
               asset={asset}
               balances={balances}
@@ -139,6 +145,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           return (
             <SendViewLTC
               walletType={walletType}
+              walletIndex={walletIndex}
               asset={asset}
               balances={balances}
               openExplorerTxUrl={openExplorerTxUrl}
@@ -173,7 +180,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
               asset: assetToString(asset),
               walletAddress,
               walletType,
-              walletIndex: walletIndex ? walletIndex : '0'
+              walletIndex: walletIndexRoute
             })}
           />
           {renderSendView(asset)}

--- a/src/renderer/views/wallet/send/SendViewBCH.tsx
+++ b/src/renderer/views/wallet/send/SendViewBCH.tsx
@@ -26,6 +26,7 @@ import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
   openExplorerTxUrl: OpenExplorerTxUrl
@@ -34,7 +35,7 @@ type Props = {
 }
 
 export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
 
   const intl = useIntl()
   const history = useHistory()
@@ -75,6 +76,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
     (walletBalance: WalletBalance) => (
       <SendFormBCH
         walletType={walletType}
+        walletIndex={walletIndex}
         balances={FP.pipe(
           oBalances,
           O.getOrElse(() => [] as WalletBalances)
@@ -92,6 +94,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
     ),
     [
       walletType,
+      walletIndex,
       oBalances,
       isLoading,
       onSend,

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -70,9 +70,9 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
 
   const onSend = useCallback(
     (params: SendTxParams) => {
-      subscribeSendTxState(transfer$(params, walletIndex))
+      subscribeSendTxState(transfer$(params))
     },
-    [subscribeSendTxState, transfer$, walletIndex]
+    [subscribeSendTxState, transfer$]
   )
 
   const { fees$, reloadFees } = useBinanceContext()

--- a/src/renderer/views/wallet/send/SendViewBTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewBTC.tsx
@@ -26,6 +26,7 @@ import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
   openExplorerTxUrl: OpenExplorerTxUrl
@@ -34,7 +35,7 @@ type Props = {
 }
 
 export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
 
   const intl = useIntl()
   const history = useHistory()
@@ -76,6 +77,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
     (walletBalance: WalletBalance) => (
       <SendFormBTC
         walletType={walletType}
+        walletIndex={walletIndex}
         balances={FP.pipe(
           oBalances,
           O.getOrElse<WalletBalances>(() => [])
@@ -93,6 +95,7 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
     ),
     [
       walletType,
+      walletIndex,
       oBalances,
       isLoading,
       onSend,

--- a/src/renderer/views/wallet/send/SendViewETH.tsx
+++ b/src/renderer/views/wallet/send/SendViewETH.tsx
@@ -24,6 +24,7 @@ import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
   openExplorerTxUrl: OpenExplorerTxUrl
@@ -32,7 +33,7 @@ type Props = {
 }
 
 export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
 
   const intl = useIntl()
   const history = useHistory()
@@ -84,6 +85,7 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
     (walletBalance: WalletBalance) => (
       <SendFormETH
         walletType={walletType}
+        walletIndex={walletIndex}
         balance={walletBalance}
         balances={FP.pipe(
           oBalances,
@@ -98,7 +100,18 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
         network={network}
       />
     ),
-    [walletType, oBalances, feesRD, isLoading, onSend, sendTxStatusMsg, reloadFees, validatePassword$, network]
+    [
+      walletType,
+      walletIndex,
+      oBalances,
+      feesRD,
+      isLoading,
+      onSend,
+      sendTxStatusMsg,
+      reloadFees,
+      validatePassword$,
+      network
+    ]
   )
 
   const finishActionHandler = useCallback(() => {

--- a/src/renderer/views/wallet/send/SendViewLTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewLTC.tsx
@@ -26,6 +26,7 @@ import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
   openExplorerTxUrl: OpenExplorerTxUrl
@@ -34,7 +35,7 @@ type Props = {
 }
 
 export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
 
   const intl = useIntl()
   const history = useHistory()
@@ -76,6 +77,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
     (walletBalance: WalletBalance) => (
       <SendFormLTC
         walletType={walletType}
+        walletIndex={walletIndex}
         balances={FP.pipe(
           oBalances,
           O.getOrElse<WalletBalances>(() => [])
@@ -93,6 +95,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
     ),
     [
       walletType,
+      walletIndex,
       oBalances,
       isLoading,
       onSend,

--- a/src/renderer/views/wallet/send/SendViewTHOR.tsx
+++ b/src/renderer/views/wallet/send/SendViewTHOR.tsx
@@ -27,6 +27,7 @@ import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
+  walletIndex: number
   walletAddress: Address
   asset: Asset
   balances: O.Option<NonEmptyWalletBalances>
@@ -36,7 +37,16 @@ type Props = {
 }
 
 export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletAddress, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const {
+    walletType,
+    walletIndex,
+    walletAddress,
+    asset,
+    balances: oBalances,
+    openExplorerTxUrl,
+    validatePassword$,
+    network
+  } = props
 
   const intl = useIntl()
   const history = useHistory()
@@ -91,6 +101,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
     (balance: WalletBalance) => (
       <SendFormTHOR
         walletType={walletType}
+        walletIndex={walletIndex}
         balances={FP.pipe(
           oBalances,
           O.getOrElse<WalletBalances>(() => [])
@@ -108,6 +119,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
     ),
     [
       walletType,
+      walletIndex,
       oBalances,
       isLoading,
       onSend,

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -110,7 +110,7 @@ export type LedgerBTCTxInfo = Pick<TxParams, 'amount' | 'recipient'> & {
 
 export type LedgerTxParams = LedgerTHORTxParams | LedgerBNBTxParams
 
-export type IPCLedgerAdddressParams = { chain: Chain; network: Network; walletIndex?: number }
+export type IPCLedgerAdddressParams = { chain: Chain; network: Network; walletIndex: number }
 
 export type ApiHDWallet = {
   getLedgerAddress: (params: IPCLedgerAdddressParams) => Promise<Either<LedgerError, WalletAddress>>


### PR DESCRIPTION
- [x] Fixed / checked `Swap`, `Interactiv`, `Send`, `Deposit`, `Upgrade

Note: `walletIndex` is required on different places now (not optional as before)

Fix #1900 