### PR TITLE
Fix: [Ledger] walletIndex get lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Pools] Disable manage button while wallet locked [#1877](https://github.com/thorchain/asgardex-electron/pull/1877)
 - Fix 24h volume [#1883](https://github.com/thorchain/asgardex-electron/pull/1883)
 - Fix outdated links [#1884](https://github.com/thorchain/asgardex-electron/pull/1884)
+- [Ledger] walletIndex get lost while veryfiying address on device [#1908](https://github.com/thorchain/asgardex-electron/issues/1908)
 
 ## Internal
 

--- a/src/main/api/ledger/address.ts
+++ b/src/main/api/ledger/address.ts
@@ -11,7 +11,7 @@ import { getAddress as getTHORAddress, verifyAddress as verifyTHORAddress } from
 export const getAddress = async ({
   chain,
   network,
-  walletIndex = 0
+  walletIndex
 }: IPCLedgerAdddressParams): Promise<E.Either<LedgerError, WalletAddress>> => {
   try {
     let res: E.Either<LedgerError, WalletAddress>
@@ -39,7 +39,7 @@ export const getAddress = async ({
   }
 }
 
-export const verifyLedgerAddress = async ({ chain, network, walletIndex = 0 }: IPCLedgerAdddressParams) => {
+export const verifyLedgerAddress = async ({ chain, network, walletIndex }: IPCLedgerAdddressParams) => {
   const transport = await TransportNodeHidSingleton.open()
   switch (chain) {
     case THORChain:

--- a/src/main/api/ledger/transaction.ts
+++ b/src/main/api/ledger/transaction.ts
@@ -17,7 +17,7 @@ export const sendTx = async ({
   amount,
   asset,
   memo,
-  walletIndex = 0
+  walletIndex
 }: IPCLedgerSendTxParams): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const transport = await TransportNodeHidSingleton.open()

--- a/src/renderer/components/wallet/settings/WalletSettings.tsx
+++ b/src/renderer/components/wallet/settings/WalletSettings.tsx
@@ -42,7 +42,7 @@ type Props = {
   removeKeystore: FP.Lazy<void>
   exportKeystore: (runeNativeAddress: string, selectedNetwork: Network) => void
   addLedgerAddress: (chain: Chain, walletIndex: number) => void
-  verifyLedgerAddress: (chain: Chain, walletIndex?: number) => void
+  verifyLedgerAddress: (chain: Chain, walletIndex: number) => void
   removeLedgerAddress: (chain: Chain) => void
   phrase: O.Option<string>
   clickAddressLinkHandler: (chain: Chain, address: Address) => void
@@ -83,7 +83,7 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
   const [showRemoveWalletModal, setShowRemoveWalletModal] = useState(false)
   const [showQRModal, setShowQRModal] = useState<O.Option<{ asset: Asset; address: Address }>>(O.none)
   const closeQrModal = useCallback(() => setShowQRModal(O.none), [setShowQRModal])
-  const [walletIndex, setWalletIndex] = useState<Record<Chain, number>>({
+  const [walletIndexMap, setWalletIndexMap] = useState<Record<Chain, number>>({
     [BNBChain]: 0,
     [BTCChain]: 0,
     [BCHChain]: 0,
@@ -125,20 +125,18 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
     (chain: Chain, { type: walletType, address: addressRD }: WalletAddressAsync) => {
       const renderAddLedger = (chain: Chain, loading: boolean) => (
         <Styled.AddLedgerContainer>
-          <Styled.AddLedgerButton loading={loading} onClick={() => addLedgerAddress(chain, walletIndex[chain])}>
+          <Styled.AddLedgerButton loading={loading} onClick={() => addLedgerAddress(chain, walletIndexMap[chain])}>
             <Styled.AddLedgerIcon /> {intl.formatMessage({ id: 'ledger.add.device' })}
           </Styled.AddLedgerButton>
           {(isBnbChain(chain) || isThorChain(chain)) && (
             <>
               <Styled.IndexLabel>{intl.formatMessage({ id: 'setting.wallet.index' })}</Styled.IndexLabel>
               <Styled.WalletIndexInput
-                value={walletIndex[chain].toString()}
+                value={walletIndexMap[chain].toString()}
                 pattern="[0-9]+"
-                onChange={(value) =>
-                  value !== null && +value >= 0 && setWalletIndex({ ...walletIndex, [chain]: +value })
-                }
+                onChange={(value) => value !== null && setWalletIndexMap({ ...walletIndexMap, [chain]: +value })}
                 style={{ width: 60 }}
-                onPressEnter={() => addLedgerAddress(chain, walletIndex[chain])}
+                onPressEnter={() => addLedgerAddress(chain, walletIndexMap[chain])}
               />
               <InfoIcon tooltip={intl.formatMessage({ id: 'setting.wallet.index.info' })} />
             </>
@@ -174,7 +172,7 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
                             chain
                           })
                         )
-                        verifyLedgerAddress(chain, walletIndex[chain])
+                        verifyLedgerAddress(chain, walletIndexMap[chain])
                       }}
                     />
                   )}
@@ -194,7 +192,7 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
       removeLedgerAddress,
       selectedNetwork,
       verifyLedgerAddress,
-      walletIndex
+      walletIndexMap
     ]
   )
 
@@ -295,6 +293,7 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
         onSuccess={removeWallet}
       />
       {renderQRCodeModal}
+      <div>walletIndex {JSON.stringify(walletIndexMap, null, 2)}</div>
       <Styled.Row gutter={[16, 16]}>
         <Col span={24}>
           {renderVerifyAddressModal(addressToVerify)}

--- a/src/renderer/components/wallet/settings/WalletSettings.tsx
+++ b/src/renderer/components/wallet/settings/WalletSettings.tsx
@@ -293,7 +293,6 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
         onSuccess={removeWallet}
       />
       {renderQRCodeModal}
-      <div>walletIndex {JSON.stringify(walletIndexMap, null, 2)}</div>
       <Styled.Row gutter={[16, 16]}>
         <Col span={24}>
           {renderVerifyAddressModal(addressToVerify)}

--- a/src/renderer/services/thorchain/interact.ts
+++ b/src/renderer/services/thorchain/interact.ts
@@ -27,7 +27,12 @@ import { InteractParams, InteractState, InteractState$ } from './types'
  */
 export const createInteractService$ =
   (
-    depositTx$: (_: DepositParam & { walletType: WalletType; walletIndex: number }) => LiveData<ApiError, string>,
+    depositTx$: (
+      _: DepositParam & {
+        walletType: WalletType
+        walletIndex: number /* override walletIndex of DepositParam to avoid 'undefined' */
+      }
+    ) => LiveData<ApiError, string>,
     getTxStatus: (txHash: string, assetAddress: O.Option<Address>) => TxLD
   ) =>
   ({ walletType, walletIndex, amount, memo }: InteractParams): InteractState$ => {

--- a/src/renderer/services/thorchain/transaction.ts
+++ b/src/renderer/services/thorchain/transaction.ts
@@ -27,7 +27,13 @@ import { TransactionService } from './types'
 export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
   const common = C.createTransactionService(client$)
 
-  const depositLedgerTx = ({ network, params }: { network: Network; params: DepositParam }) => {
+  const depositLedgerTx = ({
+    network,
+    params
+  }: {
+    network: Network
+    params: DepositParam & { walletIndex: number /* override walletIndex of DepositParam to avoid 'undefined' */ }
+  }) => {
     const depositLedgerTxParams: IPCLedgerDepositTxParams = {
       chain: THORChain,
       network,
@@ -87,7 +93,16 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       RxOp.startWith(RD.pending)
     )
 
-  const sendPoolTx = ({ walletType, walletIndex, asset, amount, memo }: DepositParam & { walletType: WalletType }) =>
+  const sendPoolTx = ({
+    walletType,
+    walletIndex,
+    asset,
+    amount,
+    memo
+  }: DepositParam & {
+    walletType: WalletType
+    walletIndex: number /* override walletIndex of DepositParam to avoid 'undefined' */
+  }) =>
     FP.pipe(
       network$,
       RxOp.switchMap((network) => {

--- a/src/renderer/services/thorchain/types.ts
+++ b/src/renderer/services/thorchain/types.ts
@@ -33,7 +33,12 @@ export type SendTxParams = {
 }
 
 export type TransactionService = {
-  sendPoolTx$: (params: DepositParam & { walletType: WalletType; walletIndex: number }) => TxHashLD
+  sendPoolTx$: (
+    params: DepositParam & {
+      walletType: WalletType
+      walletIndex: number /* override walletIndex of DepositParam to avoid 'undefined' */
+    }
+  ) => TxHashLD
 } & C.TransactionService<SendTxParams>
 
 export type InteractParams = {

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -156,7 +156,7 @@ export const createBalancesService = ({
     }
   })
 
-  const getChainBalance$ = (chain: Chain, walletType: WalletType, walletIndex = 0): WalletBalancesLD => {
+  const getChainBalance$ = (chain: Chain, walletType: WalletType, walletIndex: number): WalletBalancesLD => {
     const chainService = getServiceByChain(chain, walletType, walletIndex)
     const reload$ = FP.pipe(
       chainService.reloadBalances$,
@@ -199,13 +199,13 @@ export const createBalancesService = ({
    */
   const thorChainBalance$: ChainBalance$ = Rx.combineLatest([
     THOR.addressUI$,
-    getChainBalance$(THORChain, 'keystore')
+    getChainBalance$(THORChain, 'keystore', 0) // walletIndex=0 (as long as we don't support HD wallets for keystore)
   ]).pipe(
     RxOp.map(([oWalletAddress, balances]) => ({
       walletType: 'keystore',
       chain: THORChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
       balances
     }))
   )
@@ -271,13 +271,13 @@ export const createBalancesService = ({
    */
   const litecoinBalance$: ChainBalance$ = Rx.combineLatest([
     LTC.addressUI$,
-    getChainBalance$(LTCChain, 'keystore')
+    getChainBalance$(LTCChain, 'keystore', 0) // walletIndex=0 (as long as we don't support HD wallets for keystore)
   ]).pipe(
     RxOp.map(([oWalletAddress, balances]) => ({
       walletType: 'keystore',
       chain: LTCChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore for keystore
       balances
     }))
   )
@@ -287,13 +287,13 @@ export const createBalancesService = ({
    */
   const bchChainBalance$: ChainBalance$ = Rx.combineLatest([
     BCH.addressUI$,
-    getChainBalance$(BCHChain, 'keystore')
+    getChainBalance$(BCHChain, 'keystore', 0) // walletIndex=0 (as long as we don't support HD wallets for keystore)
   ]).pipe(
     RxOp.map(([oWalletAddress, balances]) => ({
       walletType: 'keystore',
       chain: BCHChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
       balances
     }))
   )
@@ -308,14 +308,14 @@ export const createBalancesService = ({
    */
   const bnbChainBalance$: ChainBalance$ = Rx.combineLatest([
     BNB.addressUI$,
-    getChainBalance$(BNBChain, 'keystore'),
+    getChainBalance$(BNBChain, 'keystore', 0), // walletIndex=0 (as long as we don't support HD wallets for keystore)
     network$
   ]).pipe(
     RxOp.map(([oWalletAddress, balances, network]) => ({
       walletType: 'keystore',
       chain: BNBChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
       balances: FP.pipe(
         balances,
         RD.map((assets) => sortBalances(assets, [AssetBNB.ticker, getBnbRuneAsset(network).ticker]))
@@ -328,18 +328,18 @@ export const createBalancesService = ({
    */
   const btcChainBalance$: ChainBalance$ = Rx.combineLatest([
     BTC.addressUI$,
-    getChainBalance$(BTCChain, 'keystore')
+    getChainBalance$(BTCChain, 'keystore', 0) // walletIndex=0 (as long as we don't support HD wallets for keystore)
   ]).pipe(
     RxOp.map(([oWalletAddress, balances]) => ({
       walletType: 'keystore',
       chain: BTCChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
       balances
     }))
   )
 
-  const ethBalances$ = getChainBalance$(ETHChain, 'keystore')
+  const ethBalances$ = getChainBalance$(ETHChain, 'keystore', 0) // walletIndex=0 (as long as we don't support HD wallets for keystore)
 
   /**
    * Transforms ETH data (address + `WalletBalance`) into `ChainBalance`
@@ -349,7 +349,7 @@ export const createBalancesService = ({
       walletType: 'keystore',
       chain: ETHChain,
       walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets
+      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
       balances
     }))
   )

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -53,7 +53,7 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
       RxOp.map((addressMap) => addressMap[network])
     )
 
-  const verifyLedgerAddress = (chain: Chain, network: Network, walletIndex = 0): void =>
+  const verifyLedgerAddress = (chain: Chain, network: Network, walletIndex: number): void =>
     window.apiHDWallet.verifyLedgerAddress({ chain, network, walletIndex })
 
   /**

--- a/src/renderer/services/wallet/transaction.ts
+++ b/src/renderer/services/wallet/transaction.ts
@@ -36,7 +36,7 @@ export const resetTxsPage: ResetTxsPageHandler = () => setLoadTxsProps(INITIAL_L
  */
 export const getTxs$: (walletAddress: O.Option<string>, walletIndex: number) => TxsPageLD = (
   walletAddress = O.none,
-  walletIndex = 0 /* TODO (@asgdx-team) Will we still use `0` as default by introducing HD wallets in the future */
+  walletIndex
 ) =>
   Rx.combineLatest([selectedAsset$, loadTxsProps$]).pipe(
     RxOp.switchMap(([oAsset, { limit, offset }]) =>

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -140,8 +140,7 @@ export type GetLedgerAddressHandler = (chain: Chain, network: Network) => Ledger
 export type LedgerService = {
   askLedgerAddress$: (chain: Chain, network: Network, walletIndex: number) => LedgerAddressLD
   getLedgerAddress$: GetLedgerAddressHandler
-  // getWalletIndex$: (chain: Chain) => Rx.Observable<number>
-  verifyLedgerAddress: (chain: Chain, network: Network, walletIndex?: number) => void
+  verifyLedgerAddress: (chain: Chain, network: Network, walletIndex: number) => void
   removeLedgerAddress: (chain: Chain, network: Network) => void
   dispose: FP.Lazy<void>
 }

--- a/src/renderer/views/wallet/WalletSettingsView.tsx
+++ b/src/renderer/views/wallet/WalletSettingsView.tsx
@@ -73,14 +73,14 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     removeAddress: removeLedgerBnbAddress
   } = useLedger(BNBChain)
 
-  const addLedgerAddressHandler = (chain: Chain, walletIndex = 0) => {
+  const addLedgerAddressHandler = (chain: Chain, walletIndex: number) => {
     if (isThorChain(chain)) return askLedgerThorAddress(walletIndex)
     if (isBnbChain(chain)) return askLedgerBnbAddress(walletIndex)
 
     return FP.constVoid
   }
 
-  const verifyLedgerAddressHandler = (chain: Chain, walletIndex = 0) => {
+  const verifyLedgerAddressHandler = (chain: Chain, walletIndex: number) => {
     if (isThorChain(chain)) return verifyLedgerThorAddress(walletIndex)
     if (isBnbChain(chain)) return verifyLedgerBnbAddress(walletIndex)
 

--- a/src/shared/api/io.ts
+++ b/src/shared/api/io.ts
@@ -81,7 +81,7 @@ export const ipcLedgerSendTxParamsIO = t.type({
   asset: t.union([assetIO, t.undefined]),
   amount: baseAmountIO,
   memo: t.union([t.string, t.undefined]),
-  walletIndex: t.union([t.number, t.undefined])
+  walletIndex: t.number
 })
 
 export type IPCLedgerSendTxParams = t.TypeOf<typeof ipcLedgerSendTxParamsIO>
@@ -92,7 +92,7 @@ export const ipcLedgerDepositTxParamsIO = t.type({
   asset: t.union([assetIO, t.undefined]),
   amount: baseAmountIO,
   memo: t.string,
-  walletIndex: t.union([t.number, t.undefined])
+  walletIndex: t.number
 })
 
 export type IPCLedgerDepositTxParams = t.TypeOf<typeof ipcLedgerDepositTxParamsIO>


### PR DESCRIPTION
while veryfiying address on device

- [x] Update statte handling in `WalletSettings`
- [x] Avoid default values of `walletIndex = 0` to make `walletIndex` always required
- [x] Override `walletIndex` of xchain's `DepositParam` to avoid 'undefined'

Fix #1908 