### PR TITLE
Test latest `eq` helpers

### DIFF
--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -16,11 +16,14 @@ import * as O from 'fp-ts/lib/Option'
 
 import { LedgerErrorId } from '../../../shared/api/types'
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
+import { WalletAddress } from '../../../shared/wallet/types'
+import { SymDepositAddresses } from '../../services/chain/types'
 import { PoolAddress, PoolShare } from '../../services/midgard/types'
 import { INITIAL_LEDGER_ADDRESS_MAP } from '../../services/wallet/const'
 import { ApiError, ErrorId, LedgerAddressMap } from '../../services/wallet/types'
 import { AssetWithAmount } from '../../types/asgardex'
 import { PricePool } from '../../views/pools/Pools.types'
+import { mockWalletAddress } from '../test/testWalletHelper'
 import {
   eqAsset,
   eqBaseAmount,
@@ -40,7 +43,10 @@ import {
   eqAssetAmount,
   eqPricePool,
   eqOString,
-  eqLedgerAddressMap
+  eqLedgerAddressMap,
+  eqWalletAddress,
+  eqOWalletAddress,
+  eqSymDepositAddresses
 } from './eq'
 
 describe('helpers/fp/eq', () => {
@@ -438,6 +444,67 @@ describe('helpers/fp/eq', () => {
       expect(eqLedgerAddressMap.equals(b, a)).toBeFalsy()
       expect(eqLedgerAddressMap.equals(a, c)).toBeFalsy()
       expect(eqLedgerAddressMap.equals(c, b)).toBeFalsy()
+    })
+  })
+
+  describe('eqWalletAddress', () => {
+    const a: WalletAddress = mockWalletAddress()
+
+    it('is equal', () => {
+      expect(eqWalletAddress.equals(a, a)).toBeTruthy()
+    })
+
+    it('is not equal', () => {
+      expect(eqWalletAddress.equals(a, { ...a, address: 'another' })).toBeFalsy()
+      expect(eqWalletAddress.equals(a, { ...a, type: 'ledger' })).toBeFalsy()
+      expect(eqWalletAddress.equals(a, { ...a, chain: BNBChain })).toBeFalsy()
+      expect(eqWalletAddress.equals(a, { ...a, walletIndex: 1 })).toBeFalsy()
+    })
+  })
+
+  describe('eqOWalletAddress', () => {
+    const a: WalletAddress = mockWalletAddress()
+
+    it('is equal', () => {
+      expect(eqOWalletAddress.equals(O.some(a), O.some(a))).toBeTruthy()
+      expect(eqOWalletAddress.equals(O.none, O.none)).toBeTruthy()
+    })
+
+    it('is not equal', () => {
+      expect(eqOWalletAddress.equals(O.some(a), O.some({ ...a, address: 'another' }))).toBeFalsy()
+      expect(eqOWalletAddress.equals(O.some(a), O.some({ ...a, type: 'ledger' }))).toBeFalsy()
+      expect(eqOWalletAddress.equals(O.some(a), O.some({ ...a, chain: BNBChain }))).toBeFalsy()
+      expect(eqOWalletAddress.equals(O.some(a), O.some({ ...a, walletIndex: 1 }))).toBeFalsy()
+    })
+  })
+
+  describe('eqSymDepositAddresses', () => {
+    const rune: WalletAddress = mockWalletAddress()
+    const oRune: O.Option<WalletAddress> = O.some(rune)
+    const asset: WalletAddress = mockWalletAddress({ chain: BNBChain })
+    const oAsset: O.Option<WalletAddress> = O.some(asset)
+    const addresses: SymDepositAddresses = { rune: oRune, asset: oAsset }
+
+    it('are equal', () => {
+      expect(eqSymDepositAddresses.equals(addresses, addresses)).toBeTruthy()
+    })
+
+    it('are not equal', () => {
+      expect(
+        eqSymDepositAddresses.equals(addresses, { asset: oAsset, rune: O.some({ ...rune, address: 'another' }) })
+      ).toBeFalsy()
+      expect(
+        eqSymDepositAddresses.equals(addresses, { asset: oAsset, rune: O.some({ ...rune, type: 'ledger' }) })
+      ).toBeFalsy()
+      expect(
+        eqSymDepositAddresses.equals(addresses, { asset: oAsset, rune: O.some({ ...rune, chain: BNBChain }) })
+      ).toBeFalsy()
+      expect(
+        eqSymDepositAddresses.equals(addresses, { asset: oAsset, rune: O.some({ ...rune, walletIndex: 1 }) })
+      ).toBeFalsy()
+      expect(eqSymDepositAddresses.equals(addresses, { asset: oAsset, rune: O.none })).toBeFalsy()
+      expect(eqSymDepositAddresses.equals(addresses, { asset: O.none, rune: oRune })).toBeFalsy()
+      expect(eqSymDepositAddresses.equals(addresses, { asset: O.none, rune: O.none })).toBeFalsy()
     })
   })
 })

--- a/src/renderer/helpers/test/testWalletHelper.ts
+++ b/src/renderer/helpers/test/testWalletHelper.ts
@@ -1,9 +1,10 @@
-import { AssetRuneNative, baseAmount } from '@xchainjs/xchain-util'
+import { AssetRuneNative, baseAmount, THORChain } from '@xchainjs/xchain-util'
 
+import { WalletAddress } from '../../../shared/wallet/types'
 import { WalletBalance } from '../../services/wallet/types'
 
 /**
- * Helper to create mock instances of `WalletBalances
+ * Helper to create mock instances of `WalletBalances`
  *
  * It returns following `WalletBalances` by default
  * ```ts
@@ -22,6 +23,28 @@ export const mockWalletBalance = (overrides?: Partial<WalletBalance>): WalletBal
   amount: baseAmount(1),
   asset: AssetRuneNative,
   walletAddress: 'wallet-address',
+  walletIndex: 0,
+  ...overrides
+})
+
+/**
+ * Helper to create mock instances of `WalletAddress`
+ *
+ * It returns following `WalletAddress` by default
+ * ```ts
+ *  {
+ *    address: 'wallet-address'
+ *    type: 'keystore',
+ *    chain: THORChain,
+ *    walletIndex: 0
+ * }
+ * ```
+ * Pass any values you want to override
+ */
+export const mockWalletAddress = (overrides?: Partial<WalletAddress>): WalletAddress => ({
+  address: 'wallet-address',
+  type: 'keystore',
+  chain: THORChain,
   walletIndex: 0,
   ...overrides
 })


### PR DESCRIPTION
Tests for `eqWalletAddress`, `eqOWalletAddress`, `eqSymDepositAddresses`

![Screenshot from 2021-11-16 15-12-44](https://user-images.githubusercontent.com/61792675/142002990-c0eba198-c241-4bf4-9c5b-73f86639ade1.png)



Part of #1937