### PR TITLE
Fix swap limit to be 1e8 based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Add
 
 - [Ledger] Add liquidity using Ledger [#1926](https://github.com/thorchain/asgardex-electron/pull/1926), [#1927](https://github.com/thorchain/asgardex-electron/issues/1927) [#1936](https://github.com/thorchain/asgardex-electron/issues/1936)
+- [ADD] Update shares for Ledger [#1942](https://github.com/thorchain/asgardex-electron/pull/1942)
 - Restore previous windows dimensions with next start of ASGDX [#1879](https://github.com/thorchain/asgardex-electron/issues/1879)
 
 ## Update
@@ -14,6 +15,12 @@
 
 - Format date [#1873](https://github.com/thorchain/asgardex-electron/issues/1873)
 - [PoolDetail] Make tx explorer accessible for locked / not imported wallet users [#1871](https://github.com/thorchain/asgardex-electron/issues/1871)
+- Fix Tooltip styles [#1944](https://github.com/thorchain/asgardex-electron/pull/1944)
+- [Swap] Limits added to memo needs to be 1e8 [#1946](https://github.com/thorchain/asgardex-electron/issues/1946)
+
+## Internal
+
+- Test latest `eq` helpers [#1943](https://github.com/thorchain/asgardex-electron/pull/1943)
 
 # 0.5.0 (2021-10-31)
 

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -373,7 +373,7 @@ export const Swap = ({
           memo: getSwapMemo({
             asset: target,
             address,
-            limit: Utils.getSwapLimit(swapResultAmountMax1e8, slipTolerance)
+            limit: Utils.getSwapLimit1e8(swapResultAmountMax1e8, slipTolerance)
           }),
           walletType,
           sender: walletAddress,

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -268,7 +268,7 @@ describe('components/swap/utils', () => {
     })
   })
 
-  describe.only('getSwapLimit', () => {
+  describe('getSwapLimit', () => {
     it('100000000 * 10% slip = 90000000 => 89999999', () => {
       const amount = baseAmount(100000000)
       const slipTolerance = 10

--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -32,7 +32,7 @@ import {
   minBalanceToSwap,
   calcRefundFee,
   minAmountToSwapMax1e8,
-  getSwapLimit,
+  getSwapLimit1e8,
   maxAmountToSwapMax1e8,
   assetsInWallet,
   balancesToSwapFrom,
@@ -268,53 +268,65 @@ describe('components/swap/utils', () => {
     })
   })
 
-  describe('getSwapLimit', () => {
+  describe.only('getSwapLimit', () => {
     it('100000000 * 10% slip = 90000000 => 89999999', () => {
       const amount = baseAmount(100000000)
       const slipTolerance = 10
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(89999999))).toBeTruthy()
+    })
+    it('100 AssetAmount (6 decimal) * 10% slip = 90 => 89.99999999 AssetAmount', () => {
+      const amount = assetAmount(100, 6)
+      const slipTolerance = 10
+      const result = getSwapLimit1e8(assetToBase(amount), slipTolerance)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(89.99999999)))).toBeTruthy()
+    })
+    it('1 AssetAmount (18 decimal) * 10% slip = 90 => 0.899999999 AssetAmount ', () => {
+      const amount = assetAmount(1, 18)
+      const slipTolerance = 10
+      const result = getSwapLimit1e8(assetToBase(amount), slipTolerance)
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.89999999)))).toBeTruthy()
     })
     it('100000 * 5% slip = 95000 => 94999', () => {
       const amount = baseAmount(100000)
       const slipTolerance = 5
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(94999))).toBeTruthy()
     })
     it('100000 * 3% slip = 97000 => 96999', () => {
       const amount = baseAmount(100000)
       const slipTolerance = 3
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(96999))).toBeTruthy()
     })
     it('10000000 * 10% slip = 900000 => 8999999', () => {
       const amount = baseAmount(10000000)
       const slipTolerance = 10
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(8999999))).toBeTruthy()
     })
     it('1002111 * 10% slip = 901899 => 900999', () => {
       const amount = baseAmount(1002111)
       const slipTolerance = 10
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(900999))).toBeTruthy()
     })
     it('1009888 * 10% slip = 908899 => 907999', () => {
       const amount = baseAmount(1009888)
       const slipTolerance = 10
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(907999))).toBeTruthy()
     })
     it('100 * 5% slip = 95 => 999', () => {
       const amount = baseAmount(100)
       const slipTolerance = 5
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(999))).toBeTruthy()
     })
     it('1 * 5% slip = 0.05 => 999', () => {
       const amount = baseAmount(1)
       const slipTolerance = 5
-      const result = getSwapLimit(amount, slipTolerance)
+      const result = getSwapLimit1e8(amount, slipTolerance)
       expect(eqBaseAmount.equals(result, baseAmount(999))).toBeTruthy()
     })
   })

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -153,13 +153,17 @@ export const getSwapData = ({
 
 /**
  * Returns `BaseAmount` with asgardex identifier counted into the limit
+ * It's always `1e8` based (default by THORChain)
  */
-export const getSwapLimit = (swapResultAmountMax1e8: BaseAmount, slipTolerance: SlipTolerance): BaseAmount => {
+export const getSwapLimit1e8 = (swapResultAmountMax1e8: BaseAmount, slipTolerance: SlipTolerance): BaseAmount => {
   const swapLimit: BaseAmount = swapResultAmountMax1e8.times(1.0 - slipTolerance * 0.01)
+  const swapLimit1e8: BaseAmount = to1e8BaseAmount(swapLimit)
   const swapLimitWithIdentifier =
-    +swapLimit.amount().toString().slice(0, -3).concat(ASGARDEX_SWAP_IDENTIFIER.toString()) - 1000
+    +swapLimit1e8.amount().toString().slice(0, -3).concat(ASGARDEX_SWAP_IDENTIFIER.toString()) - 1000
+
   return baseAmount(
-    bn(swapLimitWithIdentifier <= ASGARDEX_SWAP_IDENTIFIER ? ASGARDEX_SWAP_IDENTIFIER : swapLimitWithIdentifier)
+    bn(swapLimitWithIdentifier <= ASGARDEX_SWAP_IDENTIFIER ? ASGARDEX_SWAP_IDENTIFIER : swapLimitWithIdentifier),
+    swapLimit1e8.decimal
   )
 }
 


### PR DESCRIPTION
Most important change (fix): https://github.com/thorchain/asgardex-electron/blob/fb8f29719562a30adcf32749eb8f90b81c655600/src/renderer/components/swap/Swap.utils.ts#L160

All other changes are just renaming `getSwapLimit` -> `getSwapLimit1e8`

Fix #1946 