### PR TITLE
Enable release zip packaging for macOS

### DIFF
--- a/.electronbuildrc
+++ b/.electronbuildrc
@@ -10,7 +10,7 @@
     "output": "release"
   },
   "mac": {
-    "target": ["dmg"],
+    "target": ["dmg", "zip"],
     "category": "public.app-category.finance",
     "hardenedRuntime": true,
     "gatekeeperAssess": false,


### PR DESCRIPTION
In order for electron updater to be able to download new release in the format it supports which is `zip`