### PR TITLE
[Deposit] Add UI for asset mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [Ledger] Add liquidity using Ledger [#1926](https://github.com/thorchain/asgardex-electron/pull/1926), [#1927](https://github.com/thorchain/asgardex-electron/issues/1927) [#1936](https://github.com/thorchain/asgardex-electron/issues/1936)
 - [ADD] Update shares for Ledger [#1942](https://github.com/thorchain/asgardex-electron/pull/1942)
 - Restore previous windows dimensions with next start of ASGDX [#1879](https://github.com/thorchain/asgardex-electron/issues/1879)
+- Show asset icon in TxDetail (wallet history + pool details)[#1955](https://github.com/thorchain/asgardex-electron/pull/1955)
+- [ADD] Check asset mismatch for Ledger + keystore [#1938](https://github.com/thorchain/asgardex-electron/issues/1938)
 
 ## Update
 

--- a/src/renderer/components/deposit/Deposit.tsx
+++ b/src/renderer/components/deposit/Deposit.tsx
@@ -83,8 +83,6 @@ export const Deposit: React.FC<Props> = (props) => {
     keystoreState,
     shares: poolSharesRD,
     poolDetail: poolDetailRD,
-    // TODO (@asgdx-team) Think how to handle different wallets
-    // walletAddress: Address
     runeWalletAddress,
     assetWalletAddress
   } = props

--- a/src/renderer/components/deposit/add/AssetMissmatchWarning.stories.tsx
+++ b/src/renderer/components/deposit/add/AssetMissmatchWarning.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import { Story, Meta } from '@storybook/react'
+import { AssetBNB, AssetRuneNative } from '@xchainjs/xchain-util'
+
+import { Network } from '../../../../shared/api/types'
+import { BNB_ADDRESS_TESTNET } from '../../../../shared/mock/address'
+import { AssetWithAddress, AssetsWithAddress } from '../../../types/asgardex'
+import { AssetMissmatchWarning as Component } from './AssetMissmatchWarning'
+
+const bnb: AssetWithAddress = { asset: AssetBNB, address: BNB_ADDRESS_TESTNET }
+const rune: AssetWithAddress = { asset: AssetRuneNative, address: 'tthor13gym97tmw3axj3hpewdggy2cr288d3qffr8skg' }
+
+const assets: AssetsWithAddress = [bnb, rune]
+
+type Args = {
+  network: Network
+}
+
+const Template: Story<Args> = ({ network }) => {
+  return <Component assetsWA={assets} network={network} />
+}
+
+export const Default = Template.bind({})
+
+Default.storyName = 'default'
+
+const meta: Meta<Args> = {
+  component: Component,
+  title: 'Components/Deposit/AssetMissmatch',
+  argTypes: {
+    network: {
+      name: 'Network',
+      control: {
+        type: 'select',
+        options: ['mainnet', 'testnet']
+      },
+      defaultValue: 'mainnet'
+    }
+  }
+}
+
+export default meta

--- a/src/renderer/components/deposit/add/AssetMissmatchWarning.stories.tsx
+++ b/src/renderer/components/deposit/add/AssetMissmatchWarning.stories.tsx
@@ -4,12 +4,12 @@ import { Story, Meta } from '@storybook/react'
 import { AssetBNB, AssetRuneNative } from '@xchainjs/xchain-util'
 
 import { Network } from '../../../../shared/api/types'
-import { BNB_ADDRESS_TESTNET } from '../../../../shared/mock/address'
+import { BNB_ADDRESS_TESTNET, RUNE_ADDRESS_TESTNET } from '../../../../shared/mock/address'
 import { AssetWithAddress, AssetsWithAddress } from '../../../types/asgardex'
 import { AssetMissmatchWarning as Component } from './AssetMissmatchWarning'
 
 const bnb: AssetWithAddress = { asset: AssetBNB, address: BNB_ADDRESS_TESTNET }
-const rune: AssetWithAddress = { asset: AssetRuneNative, address: 'tthor13gym97tmw3axj3hpewdggy2cr288d3qffr8skg' }
+const rune: AssetWithAddress = { asset: AssetRuneNative, address: RUNE_ADDRESS_TESTNET }
 
 const assets: AssetsWithAddress = [bnb, rune]
 
@@ -18,7 +18,7 @@ type Args = {
 }
 
 const Template: Story<Args> = ({ network }) => {
-  return <Component assetsWA={assets} network={network} />
+  return <Component assets={assets} network={network} />
 }
 
 export const Default = Template.bind({})
@@ -27,7 +27,7 @@ Default.storyName = 'default'
 
 const meta: Meta<Args> = {
   component: Component,
-  title: 'Components/Deposit/AssetMissmatch',
+  title: 'Components/Deposit/AssetMissmatchWarning',
   argTypes: {
     network: {
       name: 'Network',

--- a/src/renderer/components/deposit/add/AssetMissmatchWarning.styles.ts
+++ b/src/renderer/components/deposit/add/AssetMissmatchWarning.styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components'
+
+import { AssetAddress as UIAssetAddress } from '../../uielements/assets/assetAddress'
+
+export const AssetAddress = styled(UIAssetAddress)`
+  padding-top: 10px;
+  &:first-child {
+    padding-top: 0px;
+  }
+`
+
+export const AssetWarningAssetContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  height: 32px;
+  margin: 10px 0;
+
+  &:last-child {
+    margin: 0;
+  }
+
+  > div:first-child {
+    margin-right: 10px;
+  }
+`

--- a/src/renderer/components/deposit/add/AssetMissmatchWarning.tsx
+++ b/src/renderer/components/deposit/add/AssetMissmatchWarning.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 
-import { assetToString } from '@xchainjs/xchain-util'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../../shared/api/types'
@@ -8,13 +7,13 @@ import { AssetsWithAddress } from '../../../types/asgardex'
 import * as CStyled from './AssetMissmatchWarning.styles'
 import * as Styled from './Deposit.styles'
 
-export type PendingAssetsProps = {
+export type Props = {
   network: Network
-  assetsWA: AssetsWithAddress
+  assets: AssetsWithAddress
 }
 
-export const AssetMissmatchWarning: React.FC<PendingAssetsProps> = (props): JSX.Element => {
-  const { assetsWA, network } = props
+export const AssetMissmatchWarning: React.FC<Props> = (props): JSX.Element => {
+  const { assets: assetsWA, network } = props
 
   const intl = useIntl()
 
@@ -28,26 +27,24 @@ export const AssetMissmatchWarning: React.FC<PendingAssetsProps> = (props): JSX.
         </Styled.AssetWarningInfoButtonLabel>
         <Styled.AssetWarningInfoButtonIcon selected={collapsed} />
       </Styled.AssetWarningInfoButton>
-      <>
-        {collapsed && (
-          <>
-            <Styled.AssetWarningDescription>
-              {intl.formatMessage({ id: 'deposit.add.assetMissmatch.description' })}
-            </Styled.AssetWarningDescription>
-            <div>
-              {assetsWA.map(({ asset, address }, index) => (
-                <CStyled.AssetAddress
-                  network={network}
-                  asset={asset}
-                  size="small"
-                  address={address}
-                  key={`${assetToString(asset)}-${index}`}
-                />
-              ))}
-            </div>
-          </>
-        )}
-      </>
+      {collapsed && (
+        <>
+          <Styled.AssetWarningDescription>
+            {intl.formatMessage({ id: 'deposit.add.assetMissmatch.description' })}
+          </Styled.AssetWarningDescription>
+          <div>
+            {assetsWA.map(({ asset, address }, index) => (
+              <CStyled.AssetAddress
+                network={network}
+                asset={asset}
+                size="small"
+                address={address}
+                key={`${address}-${index}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </>
   )
 

--- a/src/renderer/components/deposit/add/AssetMissmatchWarning.tsx
+++ b/src/renderer/components/deposit/add/AssetMissmatchWarning.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+
+import { assetToString } from '@xchainjs/xchain-util'
+import { useIntl } from 'react-intl'
+
+import { Network } from '../../../../shared/api/types'
+import { AssetsWithAddress } from '../../../types/asgardex'
+import * as CStyled from './AssetMissmatchWarning.styles'
+import * as Styled from './Deposit.styles'
+
+export type PendingAssetsProps = {
+  network: Network
+  assetsWA: AssetsWithAddress
+}
+
+export const AssetMissmatchWarning: React.FC<PendingAssetsProps> = (props): JSX.Element => {
+  const { assetsWA, network } = props
+
+  const intl = useIntl()
+
+  const [collapsed, setCollapsed] = useState(false)
+
+  const subContent = (
+    <>
+      <Styled.AssetWarningInfoButton selected={collapsed} onClick={() => setCollapsed((v) => !v)}>
+        <Styled.AssetWarningInfoButtonLabel>
+          {intl.formatMessage({ id: 'common.informationMore' })}
+        </Styled.AssetWarningInfoButtonLabel>
+        <Styled.AssetWarningInfoButtonIcon selected={collapsed} />
+      </Styled.AssetWarningInfoButton>
+      <>
+        {collapsed && (
+          <>
+            <Styled.AssetWarningDescription>
+              {intl.formatMessage({ id: 'deposit.add.assetMissmatch.description' })}
+            </Styled.AssetWarningDescription>
+            <div>
+              {assetsWA.map(({ asset, address }, index) => (
+                <CStyled.AssetAddress
+                  network={network}
+                  asset={asset}
+                  size="small"
+                  address={address}
+                  key={`${assetToString(asset)}-${index}`}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </>
+    </>
+  )
+
+  return (
+    <Styled.Alert
+      type="warning"
+      message={intl.formatMessage({ id: 'deposit.add.assetMissmatch.title' })}
+      description={subContent}
+    />
+  )
+}

--- a/src/renderer/components/deposit/add/AsymAssetsWarning.tsx
+++ b/src/renderer/components/deposit/add/AsymAssetsWarning.tsx
@@ -31,34 +31,32 @@ export const AsymAssetsWarning: React.FC<AsymAssetsWarningProps> = (props): JSX.
         </Styled.AssetWarningInfoButtonLabel>
         <Styled.AssetWarningInfoButtonIcon selected={collapsed} />
       </Styled.AssetWarningInfoButton>
-      <>
-        {collapsed && (
-          <>
-            <Styled.AssetWarningDescription>
-              {intl.formatMessage({ id: 'deposit.add.asymAssets.description' })}
-            </Styled.AssetWarningDescription>
-            {assets.map((asset) => (
-              <AssetData asset={asset} network={network} key={`${assetToString(asset)}`} />
-            ))}
-            <Styled.AssetWarningDescription>
-              <FormattedMessage
-                id="deposit.add.asymAssets.recoveryDescription"
-                values={{
-                  url: (
-                    <Styled.AssetWarningDescriptionLink onClick={onClickOpenAsymTool}>
-                      {ASYM_DEPOSIT_TOOL_URL[network]}
-                    </Styled.AssetWarningDescriptionLink>
-                  )
-                }}
-              />
-            </Styled.AssetWarningDescription>
-            <Styled.WarningOpenExternalUrlButton onClick={onClickOpenAsymTool}>
-              {intl.formatMessage({ id: 'deposit.add.asymAssets.recoveryTitle' })}
-              <Styled.AssetWarningOpenExternalUrlIcon />
-            </Styled.WarningOpenExternalUrlButton>
-          </>
-        )}
-      </>
+      {collapsed && (
+        <>
+          <Styled.AssetWarningDescription>
+            {intl.formatMessage({ id: 'deposit.add.asymAssets.description' })}
+          </Styled.AssetWarningDescription>
+          {assets.map((asset) => (
+            <AssetData asset={asset} network={network} key={`${assetToString(asset)}`} />
+          ))}
+          <Styled.AssetWarningDescription>
+            <FormattedMessage
+              id="deposit.add.asymAssets.recoveryDescription"
+              values={{
+                url: (
+                  <Styled.AssetWarningDescriptionLink onClick={onClickOpenAsymTool}>
+                    {ASYM_DEPOSIT_TOOL_URL[network]}
+                  </Styled.AssetWarningDescriptionLink>
+                )
+              }}
+            />
+          </Styled.AssetWarningDescription>
+          <Styled.WarningOpenExternalUrlButton onClick={onClickOpenAsymTool}>
+            {intl.formatMessage({ id: 'deposit.add.asymAssets.recoveryTitle' })}
+            <Styled.AssetWarningOpenExternalUrlIcon />
+          </Styled.WarningOpenExternalUrlButton>
+        </>
+      )}
     </>
   )
 

--- a/src/renderer/components/deposit/add/PendingAssetsWarning.tsx
+++ b/src/renderer/components/deposit/add/PendingAssetsWarning.tsx
@@ -57,39 +57,38 @@ export const PendingAssetsWarning: React.FC<PendingAssetsProps> = (props): JSX.E
         </Styled.AssetWarningInfoButtonLabel>
         <Styled.AssetWarningInfoButtonIcon selected={collapsed} />
       </Styled.AssetWarningInfoButton>
-      <>
-        {collapsed && (
-          <>
-            <Styled.AssetWarningDescription>
-              {intl.formatMessage({ id: 'deposit.add.pendingAssets.description' })}
-            </Styled.AssetWarningDescription>
-            {assets.map((assetWB, index) => (
-              <AssetIconAmount
-                network={network}
-                assetWA={assetWB}
-                loading={loading}
-                key={`${assetToString(assetWB.asset)}-${index}`}
-              />
-            ))}
-            <Styled.AssetWarningDescription>
-              <FormattedMessage
-                id="deposit.add.pendingAssets.recoveryDescription"
-                values={{
-                  url: (
-                    <Styled.AssetWarningDescriptionLink onClick={onClickRecovery}>
-                      {RECOVERY_TOOL_URL[network]}
-                    </Styled.AssetWarningDescriptionLink>
-                  )
-                }}
-              />
-            </Styled.AssetWarningDescription>
-            <Styled.WarningOpenExternalUrlButton onClick={onClickRecovery}>
-              {intl.formatMessage({ id: 'deposit.add.pendingAssets.recoveryTitle' })}
-              <Styled.AssetWarningOpenExternalUrlIcon />
-            </Styled.WarningOpenExternalUrlButton>
-          </>
-        )}
-      </>
+
+      {collapsed && (
+        <>
+          <Styled.AssetWarningDescription>
+            {intl.formatMessage({ id: 'deposit.add.pendingAssets.description' })}
+          </Styled.AssetWarningDescription>
+          {assets.map((assetWB, index) => (
+            <AssetIconAmount
+              network={network}
+              assetWA={assetWB}
+              loading={loading}
+              key={`${assetToString(assetWB.asset)}-${index}`}
+            />
+          ))}
+          <Styled.AssetWarningDescription>
+            <FormattedMessage
+              id="deposit.add.pendingAssets.recoveryDescription"
+              values={{
+                url: (
+                  <Styled.AssetWarningDescriptionLink onClick={onClickRecovery}>
+                    {RECOVERY_TOOL_URL[network]}
+                  </Styled.AssetWarningDescriptionLink>
+                )
+              }}
+            />
+          </Styled.AssetWarningDescription>
+          <Styled.WarningOpenExternalUrlButton onClick={onClickRecovery}>
+            {intl.formatMessage({ id: 'deposit.add.pendingAssets.recoveryTitle' })}
+            <Styled.AssetWarningOpenExternalUrlIcon />
+          </Styled.WarningOpenExternalUrlButton>
+        </>
+      )}
     </>
   )
 

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -91,6 +91,7 @@ import { DepositAssets } from '../../modal/tx/extra'
 import { ViewTxButton } from '../../uielements/button'
 import { Fees, UIFeesRD } from '../../uielements/fees'
 import * as InfoIconStyled from '../../uielements/info/InfoIcon.styles'
+import { AssetMissmatchWarning } from './AssetMissmatchWarning'
 import { AsymAssetsWarning } from './AsymAssetsWarning'
 import * as Helper from './Deposit.helper'
 import * as Styled from './Deposit.styles'
@@ -1268,26 +1269,36 @@ export const SymDeposit: React.FC<Props> = (props) => {
   const prevAssetMismatch = useRef<LiquidityProviderAssetMismatch>(O.none)
 
   const renderAssetMismatch = useMemo(() => {
-    const render = (assetMismatch: LiquidityProviderAssetMismatch, loading: boolean) => (
-      <>
-        <div>loading {loading.toString()}</div>
-        <div>assetMismatch {JSON.stringify(assetMismatch, null, 2)}</div>
-      </>
-    )
+    const render = (assetMismatch: LiquidityProviderAssetMismatch) =>
+      FP.pipe(
+        assetMismatch,
+        O.fold(
+          () => <></>,
+          ({ runeAddress, assetAddress }) => (
+            <AssetMissmatchWarning
+              assetsWA={[
+                { asset: AssetRuneNative, address: runeAddress },
+                { asset, address: assetAddress }
+              ]}
+              network={network}
+            />
+          )
+        )
+      )
 
     return FP.pipe(
       symAssetMismatchRD,
       RD.fold(
         () => <></>,
-        () => render(prevAssetMismatch.current, true),
+        () => render(prevAssetMismatch.current),
         () => <></>,
         (assetMismatch) => {
           prevAssetMismatch.current = assetMismatch
-          return render(assetMismatch, false)
+          return render(assetMismatch)
         }
       )
     )
-  }, [symAssetMismatchRD])
+  }, [asset, network, symAssetMismatchRD])
 
   const prevRouterAddress = useRef<O.Option<Address>>(O.none)
 
@@ -1408,7 +1419,6 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <Col xs={24}>{renderAsymDepositWarning}</Col>
         </Styled.AlertRow>
       )}
-      <div>hasAssetMismatch {hasAssetMismatch.toString()}</div>
       {hasAssetMismatch && (
         <Styled.AlertRow>
           <Col xs={24}>{renderAssetMismatch}</Col>

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -1276,7 +1276,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           () => <></>,
           ({ runeAddress, assetAddress }) => (
             <AssetMissmatchWarning
-              assetsWA={[
+              assets={[
                 { asset: AssetRuneNative, address: runeAddress },
                 { asset, address: assetAddress }
               ]}

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -14,8 +14,7 @@ import {
   delay,
   Chain,
   assetToBase,
-  assetAmount,
-  AssetRuneNative
+  assetAmount
 } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -1424,14 +1423,6 @@ export const Swap = ({
         />
       )}
       {renderIsApprovedError}
-      <div>
-        memo:{' '}
-        {getSwapMemo({
-          asset: AssetRuneNative,
-          address: 'address',
-          limit: Utils.getSwapLimit1e8(swapResultAmountMax1e8, slipTolerance)
-        })}
-      </div>
       <Styled.SubmitContainer>
         {!isLocked(keystore) ? (
           isApproved ? (

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -14,7 +14,8 @@ import {
   delay,
   Chain,
   assetToBase,
-  assetAmount
+  assetAmount,
+  AssetRuneNative
 } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -1423,6 +1424,14 @@ export const Swap = ({
         />
       )}
       {renderIsApprovedError}
+      <div>
+        memo:{' '}
+        {getSwapMemo({
+          asset: AssetRuneNative,
+          address: 'address',
+          limit: Utils.getSwapLimit1e8(swapResultAmountMax1e8, slipTolerance)
+        })}
+      </div>
       <Styled.SubmitContainer>
         {!isLocked(keystore) ? (
           isApproved ? (

--- a/src/renderer/components/uielements/addressEllipsis/AddressEllipsis.tsx
+++ b/src/renderer/components/uielements/addressEllipsis/AddressEllipsis.tsx
@@ -12,7 +12,7 @@ import * as Styled from './AddressEllipsis.styles'
  * Based on https://github.com/bluepeter/react-middle-ellipsis/
  */
 
-type Props = {
+export type Props = {
   address: Address
   chain: Chain
   network: Network

--- a/src/renderer/components/uielements/addressEllipsis/index.tsx
+++ b/src/renderer/components/uielements/addressEllipsis/index.tsx
@@ -1,1 +1,1 @@
-export { AddressEllipsis } from './AddressEllipsis'
+export * from './AddressEllipsis'

--- a/src/renderer/components/uielements/assets/assetAddress/AssetAddress.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetAddress/AssetAddress.stories.tsx
@@ -12,7 +12,7 @@ type Args = {
   width: string
 }
 export const Template: Story<Args> = ({ size, width }) => (
-  <div style={{ width, backgroundColor: 'red' }}>
+  <div style={{ width }}>
     <Component asset={AssetBNB} size={size} address={BNB_ADDRESS_TESTNET} network="mainnet" />
   </div>
 )

--- a/src/renderer/components/uielements/assets/assetAddress/AssetAddress.stories.tsx
+++ b/src/renderer/components/uielements/assets/assetAddress/AssetAddress.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { Story, Meta } from '@storybook/react'
+import { AssetBNB } from '@xchainjs/xchain-util'
+
+import { BNB_ADDRESS_TESTNET } from '../../../../../shared/mock/address'
+import { Size } from '../assetIcon'
+import { AssetAddress as Component } from './AssetAddress'
+
+type Args = {
+  size: Size
+  width: string
+}
+export const Template: Story<Args> = ({ size, width }) => (
+  <div style={{ width, backgroundColor: 'red' }}>
+    <Component asset={AssetBNB} size={size} address={BNB_ADDRESS_TESTNET} network="mainnet" />
+  </div>
+)
+
+export const Default = Template.bind({})
+
+Default.storyName = 'default'
+
+const meta: Meta<Args> = {
+  component: Component,
+  title: 'Components/AssetAddress',
+  argTypes: {
+    size: {
+      name: 'Size',
+      control: {
+        type: 'select',
+        options: ['xsmall', 'small', 'normal', 'big', 'large']
+      },
+      defaultValue: 'normal'
+    },
+    width: {
+      name: 'Wrapper width',
+      control: {
+        type: 'select',
+        options: ['100%', '300px', '500px']
+      },
+      defaultValue: '100%'
+    }
+  }
+}
+
+export default meta

--- a/src/renderer/components/uielements/assets/assetAddress/AssetAddress.styles.ts
+++ b/src/renderer/components/uielements/assets/assetAddress/AssetAddress.styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+
+import { AddressEllipsis as UIAddressEllipsis, Props as UIAddressEllipsisProps } from '../../addressEllipsis'
+import { Label as UILabel, LabelProps as UILabelProps } from '../../label'
+import { Size as UIAssetIconSize, FontSizes } from '../assetIcon'
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+const fontSizes: FontSizes = {
+  large: 21,
+  big: 19,
+  normal: 16,
+  small: 14,
+  xsmall: 11
+}
+
+type AddressLabelProps = UILabelProps & { iconSize: UIAssetIconSize }
+export const AddressLabel = styled(UILabel)<AddressLabelProps>`
+  font-size: ${({ iconSize }) => `${fontSizes[iconSize]}px`};
+  padding-left: 5px;
+`
+
+export const AddressWrapper = styled.div`
+  overflow: none;
+  width: 100%;
+`
+
+type AddressEllipsisProps = UIAddressEllipsisProps & { iconSize: UIAssetIconSize }
+export const AddressEllipsis = styled(UIAddressEllipsis)<AddressEllipsisProps>`
+  font-size: ${({ iconSize }) => `${fontSizes[iconSize]}px`};
+  padding-left: 5px;
+  text-transform: none;
+`

--- a/src/renderer/components/uielements/assets/assetAddress/AssetAddress.tsx
+++ b/src/renderer/components/uielements/assets/assetAddress/AssetAddress.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import { Address } from '@xchainjs/xchain-client'
+import { Asset } from '@xchainjs/xchain-util'
+
+import { Network } from '../../../../../shared/api/types'
+import { AssetIcon, Size } from '../assetIcon'
+import * as Styled from './AssetAddress.styles'
+
+export type Props = {
+  asset: Asset
+  address: Address
+  network: Network
+  size?: Size
+  className?: string
+}
+
+export const AssetAddress: React.FC<Props> = (props): JSX.Element => {
+  const { asset, address, network, size = 'normal', className } = props
+
+  return (
+    <Styled.Wrapper className={className}>
+      <AssetIcon asset={asset} size={size} network={network} />
+      <Styled.AddressWrapper>
+        <Styled.AddressEllipsis
+          className={`${className}-address`}
+          address={address}
+          iconSize={size}
+          chain={asset.chain}
+          network={network}
+          enableCopy
+        />
+      </Styled.AddressWrapper>
+    </Styled.Wrapper>
+  )
+}

--- a/src/renderer/components/uielements/assets/assetAddress/index.tsx
+++ b/src/renderer/components/uielements/assets/assetAddress/index.tsx
@@ -1,0 +1,1 @@
+export * from './AssetAddress'

--- a/src/renderer/components/uielements/assets/assetIcon/index.ts
+++ b/src/renderer/components/uielements/assets/assetIcon/index.ts
@@ -1,1 +1,2 @@
+export * from './AssetIcon.types'
 export { AssetIcon } from './AssetIcon'

--- a/src/renderer/components/uielements/label/index.ts
+++ b/src/renderer/components/uielements/label/index.ts
@@ -1,1 +1,1 @@
-export { Label } from './Label'
+export * from './Label'

--- a/src/renderer/components/wallet/settings/WalletSettings.styles.ts
+++ b/src/renderer/components/wallet/settings/WalletSettings.styles.ts
@@ -165,9 +165,14 @@ export const AddressContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  flex: 1;
 `
 const ICON_SIZE = 16
+
+export const AddressWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`
 
 export const AddressEllipsis = styled(AddressEllipsisUI)`
   font-size: 16px;
@@ -280,6 +285,7 @@ export const AddressToVerifyLabel = styled.span`
 
 export const AccountAddressWrapper = styled.div`
   margin-top: 10px;
+  width: 100%;
 `
 
 export const WalletTypeLabel = styled(WalletTypeLabelUI)`

--- a/src/renderer/components/wallet/settings/WalletSettings.tsx
+++ b/src/renderer/components/wallet/settings/WalletSettings.tsx
@@ -163,9 +163,18 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
               ),
               ({ address, walletIndex }) => (
                 <>
-                  <Styled.AddressEllipsis address={address} chain={chain} network={selectedNetwork} enableCopy={true} />
-                  <Styled.QRCodeIcon onClick={() => setShowQRModal(O.some({ asset: getChainAsset(chain), address }))} />
-                  <Styled.AddressLinkIcon onClick={() => clickAddressLinkHandler(chain, address)} />
+                  <Styled.AddressWrapper>
+                    <Styled.AddressEllipsis
+                      address={address}
+                      chain={chain}
+                      network={selectedNetwork}
+                      enableCopy={true}
+                    />
+                    <Styled.QRCodeIcon
+                      onClick={() => setShowQRModal(O.some({ asset: getChainAsset(chain), address }))}
+                    />
+                    <Styled.AddressLinkIcon onClick={() => clickAddressLinkHandler(chain, address)} />
+                  </Styled.AddressWrapper>
                   {isLedgerWallet(walletType) && (
                     <Styled.EyeOutlined
                       onClick={() => {

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -38,7 +38,7 @@ const deposit: DepositMessages = {
   'deposit.add.asymAssets.recoveryDescription':
     'Asymmetrisches (einseitiges) Hinzufügen von Assets ist aktuell in ASGARDEX Desktop noch nicht möglich. Aber Du hast die Möglichkeit, dieses Feature zwischenzeitlich in THORSWap zu nutzen, um die zuvor asymmetrisch hinzugefügten Assets zurückzuüberweisen',
   'deposit.add.asymAssets.recoveryTitle': 'THORSwap',
-  'deposit.add.assetMissmatch.title': 'Asset missmatch found - DE',
+  'deposit.add.assetMissmatch.title': 'Asset Diskrepanz',
   'deposit.add.assetMissmatch.description':
     'Eines der beiden Assets wurde bereits bei einem vorangegangenen Deposit verwendet, jedoch zusammen mit einem anderen Asset. Überprüfe die folgenden Addressen um zu sehen, um welches Assetpaar es sich beim vorherigen Deposit handelt.',
   'deposit.bond.state.error': 'Bond Fehler',

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -38,6 +38,9 @@ const deposit: DepositMessages = {
   'deposit.add.asymAssets.recoveryDescription':
     'Asymmetrisches (einseitiges) Hinzufügen von Assets ist aktuell in ASGARDEX Desktop noch nicht möglich. Aber Du hast die Möglichkeit, dieses Feature zwischenzeitlich in THORSWap zu nutzen, um die zuvor asymmetrisch hinzugefügten Assets zurückzuüberweisen',
   'deposit.add.asymAssets.recoveryTitle': 'THORSwap',
+  'deposit.add.assetMissmatch.title': 'Asset missmatch found - DE',
+  'deposit.add.assetMissmatch.description':
+    'Eines der beiden Assets wurde bereits bei einem vorangegangenen Deposit verwendet, jedoch zusammen mit einem anderen Asset. Überprüfe die folgenden Addressen um zu sehen, um welches Assetpaar es sich beim vorherigen Deposit handelt.',
   'deposit.bond.state.error': 'Bond Fehler',
   'deposit.unbond.state.error': 'Unbond Fehler',
   'deposit.leave.state.error': 'Fehler beim Verlassen',

--- a/src/renderer/i18n/en/deposit.ts
+++ b/src/renderer/i18n/en/deposit.ts
@@ -37,6 +37,9 @@ const deposit: DepositMessages = {
   'deposit.add.asymAssets.recoveryDescription':
     'Asymmetrical deposit is currently not supported in ASGARDEX desktop. However, you can use this feature in THORSwap to withdraw a previous asymmetrical deposit.',
   'deposit.add.asymAssets.recoveryTitle': 'THORSwap',
+  'deposit.add.assetMissmatch.title': 'Asset missmatch found',
+  'deposit.add.assetMissmatch.description':
+    'One of current selected asset side has been already used in a previous deposit, but with another asset. Check following addresses to see the previous deposit pair.',
   'deposit.bond.state.error': 'Bond error',
   'deposit.unbond.state.error': 'Unbond error',
   'deposit.leave.state.error': 'Leave error',

--- a/src/renderer/i18n/fr/deposit.ts
+++ b/src/renderer/i18n/fr/deposit.ts
@@ -38,6 +38,9 @@ const deposit: DepositMessages = {
   'deposit.add.asymAssets.recoveryDescription':
     'Asymmetrical deposit is currently not supported in ASGARDEX desktop. However, you can use this feature in THORSwap to withdraw a previous asymmetrical deposit. - FR',
   'deposit.add.asymAssets.recoveryTitle': 'THORSwap - FR',
+  'deposit.add.assetMissmatch.title': 'Asset missmatch found - FR',
+  'deposit.add.assetMissmatch.description':
+    'One of current selected asset side has been already used in a previous deposit, but with another asset. Check following addresses to see the previous deposit pair. - FR',
   'deposit.bond.state.error': 'Erreur de caution',
   'deposit.unbond.state.error': 'Erreur de retrait',
   'deposit.leave.state.error': 'Erreur de sortie',

--- a/src/renderer/i18n/ru/deposit.ts
+++ b/src/renderer/i18n/ru/deposit.ts
@@ -37,6 +37,9 @@ const deposit: DepositMessages = {
   'deposit.add.asymAssets.recoveryDescription':
     'Asymmetrical deposit is currently not supported in ASGARDEX desktop. However, you can use this feature in THORSwap to withdraw a previous asymmetrical deposit. - RU',
   'deposit.add.asymAssets.recoveryTitle': 'THORSwap  - RU',
+  'deposit.add.assetMissmatch.title': 'Asset missmatch found - RU',
+  'deposit.add.assetMissmatch.description':
+    'One of current selected asset side has been already used in a previous deposit, but with another asset. Check following addresses to see the previous deposit pair. - RU',
   'deposit.bond.state.error': 'Ошибка при кладе',
   'deposit.unbond.state.error': 'Ошибка при выводе',
   'deposit.leave.state.error': 'Ошибка при выходе',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -330,6 +330,8 @@ type DepositMessageKey =
   | 'deposit.add.asymAssets.description'
   | 'deposit.add.asymAssets.recoveryTitle'
   | 'deposit.add.asymAssets.recoveryDescription'
+  | 'deposit.add.assetMissmatch.title'
+  | 'deposit.add.assetMissmatch.description'
   | 'deposit.bond.state.error'
   | 'deposit.unbond.state.error'
   | 'deposit.leave.state.error'

--- a/src/renderer/types/asgardex.ts
+++ b/src/renderer/types/asgardex.ts
@@ -1,3 +1,4 @@
+import { Address } from '@xchainjs/xchain-client'
 import { BaseAmount, Asset } from '@xchainjs/xchain-util'
 import { Option } from 'fp-ts/lib/Option'
 
@@ -15,6 +16,13 @@ export type AssetWithAmount = {
   asset: Asset
   amount: BaseAmount
 }
+
+export type AssetWithAddress = {
+  asset: Asset
+  address: Address
+}
+
+export type AssetsWithAddress = AssetWithAddress[]
 
 export type AssetWithWalletType = {
   asset: Asset

--- a/src/shared/mock/address.ts
+++ b/src/shared/mock/address.ts
@@ -1,2 +1,4 @@
 export const BNB_ADDRESS_TESTNET = 'tbnb1vxutrxadm0utajduxfr6wd9kqfalv0dg2wnx5y'
 export const BNB_ADDRESS_MAINNET = 'bnb1vxutrxadm0utajduxfr6wd9kqfalv0dg2wnx5y'
+
+export const RUNE_ADDRESS_TESTNET = 'tbnb1vxutrxadm0utajduxfr6wd9kqfalv0dg2wnx5y'


### PR DESCRIPTION
# Preview

- BNB side with Ledger has been used for another deposit before - that's why we have an asset mismatch with BNB  `keystore` in following example: 

https://user-images.githubusercontent.com/61792675/143596339-7d951345-4b70-4eca-9c11-f408bdd65743.mp4

- [x] `AssetAddress` component (incl. story)
- [x] `AssetMissmatchWarning` component (incl. story)
- [x] Use `AssetMissmatchWarning` in `SymDeposit`
- [x] Fix `WalletSettings` to truncate addresses in small ("mobile") screens 
- [x] `AssetWithAddress` type
- [x] Update `i18n`
- [x] Update `CHANGELOG`

Close #1938