### PR TITLE
Fix: Don't combine `asym` with `sym` shares in PoolShare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Add
 
 - [Ledger] Add liquidity using Ledger [#1926](https://github.com/thorchain/asgardex-electron/pull/1926), [#1927](https://github.com/thorchain/asgardex-electron/issues/1927) [#1936](https://github.com/thorchain/asgardex-electron/issues/1936), [#1962](https://github.com/thorchain/asgardex-electron/pull/1962)
+- [Ledger] Support Ledger for withdrawals [#1963](https://github.com/thorchain/asgardex-electron/pull/1963)
 - [ADD] Update shares for Ledger [#1942](https://github.com/thorchain/asgardex-electron/pull/1942)
 - Restore previous windows dimensions with next start of ASGDX [#1879](https://github.com/thorchain/asgardex-electron/issues/1879)
 - Show asset icon in TxDetail (wallet history + pool details)[#1955](https://github.com/thorchain/asgardex-electron/pull/1955)
@@ -21,6 +22,7 @@
 - [PoolDetail] Make tx explorer accessible for locked / not imported wallet users [#1871](https://github.com/thorchain/asgardex-electron/issues/1871)
 - Fix Tooltip styles [#1944](https://github.com/thorchain/asgardex-electron/pull/1944)
 - [Swap] Limits added to memo needs to be 1e8 [#1946](https://github.com/thorchain/asgardex-electron/issues/1946)
+- [PoolShare] Don't combine `asym` with `sym` shares in PoolShare [#1964](https://github.com/thorchain/asgardex-electron/pull/1964)
 
 ## Internal
 

--- a/src/renderer/components/deposit/Deposit.stories.tsx
+++ b/src/renderer/components/deposit/Deposit.stories.tsx
@@ -24,7 +24,7 @@ const defaultProps: DepositProps = {
       units: bn('300000000'),
       asset: AssetBNB,
       type: 'sym',
-      assetAddress: BNB_ADDRESS_TESTNET,
+      assetAddress: O.some(BNB_ADDRESS_TESTNET),
       runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: assetToBase(assetAmount(1.5, THORCHAIN_DECIMAL))
     },
@@ -32,7 +32,7 @@ const defaultProps: DepositProps = {
       units: bn('100000000'),
       asset: AssetBNB,
       type: 'asym',
-      assetAddress: BNB_ADDRESS_TESTNET,
+      assetAddress: O.some(BNB_ADDRESS_TESTNET),
       runeAddress: O.none,
       assetAddedAmount: assetToBase(assetAmount(1, THORCHAIN_DECIMAL))
     },
@@ -40,7 +40,7 @@ const defaultProps: DepositProps = {
       units: bn('200000000'),
       asset: AssetRuneNative,
       type: 'asym',
-      assetAddress: '',
+      assetAddress: O.none,
       runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
     }

--- a/src/renderer/components/deposit/Deposit.stories.tsx
+++ b/src/renderer/components/deposit/Deposit.stories.tsx
@@ -5,7 +5,7 @@ import { Story, Meta } from '@storybook/react'
 import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, bn, BNBChain } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 
-import { BNB_ADDRESS_TESTNET } from '../../../shared/mock/address'
+import { BNB_ADDRESS_TESTNET, RUNE_ADDRESS_TESTNET } from '../../../shared/mock/address'
 import { BNB_DECIMAL, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { mockWalletAddress } from '../../helpers/test/testWalletHelper'
 import { DEFAULT_MIMIR_HALT } from '../../services/thorchain/const'
@@ -24,18 +24,24 @@ const defaultProps: DepositProps = {
       units: bn('300000000'),
       asset: AssetBNB,
       type: 'sym',
+      assetAddress: BNB_ADDRESS_TESTNET,
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: assetToBase(assetAmount(1.5, THORCHAIN_DECIMAL))
     },
     {
       units: bn('100000000'),
       asset: AssetBNB,
       type: 'asym',
+      assetAddress: BNB_ADDRESS_TESTNET,
+      runeAddress: O.none,
       assetAddedAmount: assetToBase(assetAmount(1, THORCHAIN_DECIMAL))
     },
     {
       units: bn('200000000'),
       asset: AssetRuneNative,
       type: 'asym',
+      assetAddress: '',
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
     }
   ]),

--- a/src/renderer/components/deposit/Deposit.tsx
+++ b/src/renderer/components/deposit/Deposit.tsx
@@ -8,7 +8,7 @@ import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
 
 import { WalletAddress } from '../../../shared/wallet/types'
-import { eqAddress, eqOAddress } from '../../helpers/fp/eq'
+import { eqOAddress } from '../../helpers/fp/eq'
 import { PoolDetailRD, PoolShareRD, PoolSharesRD } from '../../services/midgard/types'
 import { getSharesByAssetAndType } from '../../services/midgard/utils'
 import { MimirHalt } from '../../services/thorchain/types'
@@ -97,7 +97,7 @@ export const Deposit: React.FC<Props> = (props) => {
               ({ runeAddress, assetAddress }) =>
                 // use shares of current selected addresses only
                 eqOAddress.equals(runeAddress, O.some(runeWalletAddress.address)) &&
-                eqAddress.equals(assetAddress, assetWalletAddress.address)
+                eqOAddress.equals(assetAddress, O.some(assetWalletAddress.address))
             )
           )
         )

--- a/src/renderer/components/deposit/withdraw/Withdraw.styles.ts
+++ b/src/renderer/components/deposit/withdraw/Withdraw.styles.ts
@@ -6,7 +6,7 @@ import { AssetIcon as AssetIconBase } from '../../uielements/assets/assetIcon'
 import { AssetLabel as AssetLabelUI } from '../../uielements/assets/assetLabel'
 import { ViewTxButton as UIViewTxButton } from '../../uielements/button'
 import { Button as UIButton } from '../../uielements/button'
-import { WalletTypeLabel as WalletTypeLabelUI, Tooltip as UITooltip } from '../../uielements/common/Common.styles'
+import { WalletTypeLabel as WalletTypeLabelUI } from '../../uielements/common/Common.styles'
 import { Label as UILabel } from '../../uielements/label'
 import { Slider as BaseSlider } from '../../uielements/slider'
 
@@ -131,15 +131,6 @@ export const AssetLabel = styled(AssetLabelUI)`
   padding: 0px;
   margin: 0;
 `
-
-export const Tooltip = styled(UITooltip).attrs({
-  overlayStyle: {
-    textTransform: 'none',
-    fontSize: 14,
-    maxWidth: '400px',
-    fontFamily: 'MainFontRegular'
-  }
-})``
 
 export const WalletTypeLabel = styled(WalletTypeLabelUI)`
   font-size: 8px;

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -46,6 +46,7 @@ import { AssetWithDecimal } from '../../../types/asgardex'
 import { PasswordModal } from '../../modal/password'
 import { TxModal } from '../../modal/tx'
 import { DepositAssets } from '../../modal/tx/extra'
+import { TooltipAddress } from '../../uielements/common/Common.styles'
 import { Fees, UIFeesRD } from '../../uielements/fees'
 import { Label } from '../../uielements/label'
 import * as Helper from './Withdraw.helper'
@@ -448,7 +449,7 @@ export const Withdraw: React.FC<Props> = ({
       </Label>
 
       <Styled.AssetOutputContainer>
-        <Styled.Tooltip title={runeAddress}>
+        <TooltipAddress title={runeAddress}>
           <Styled.AssetContainer>
             <Styled.AssetIcon asset={AssetRuneNative} network={network} />
             <Styled.AssetLabel asset={AssetRuneNative} />
@@ -456,7 +457,7 @@ export const Withdraw: React.FC<Props> = ({
               <Styled.WalletTypeLabel>{intl.formatMessage({ id: 'ledger.title' })}</Styled.WalletTypeLabel>
             )}
           </Styled.AssetContainer>
-        </Styled.Tooltip>
+        </TooltipAddress>
         <Styled.OutputContainer>
           <Styled.OutputLabel>
             {formatAssetAmount({
@@ -481,7 +482,7 @@ export const Withdraw: React.FC<Props> = ({
       </Styled.AssetOutputContainer>
 
       <Styled.AssetOutputContainer>
-        <Styled.Tooltip title={assetAddress}>
+        <TooltipAddress title={assetAddress}>
           <Styled.AssetContainer>
             <Styled.AssetIcon asset={asset} network={network} />
             <Styled.AssetLabel asset={asset} />
@@ -489,7 +490,7 @@ export const Withdraw: React.FC<Props> = ({
               <Styled.WalletTypeLabel>{intl.formatMessage({ id: 'ledger.title' })}</Styled.WalletTypeLabel>
             )}
           </Styled.AssetContainer>
-        </Styled.Tooltip>
+        </TooltipAddress>
         <Styled.OutputContainer>
           <Styled.OutputLabel>
             {formatAssetAmount({

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -14,8 +14,7 @@ import {
   delay,
   Chain,
   assetToBase,
-  assetAmount,
-  AssetRuneNative
+  assetAmount
 } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -1437,14 +1436,6 @@ export const Swap = ({
         />
       )}
       {renderIsApprovedError}
-      <div>
-        memo:{' '}
-        {getSwapMemo({
-          asset: AssetRuneNative,
-          address: 'address',
-          limit: Utils.getSwapLimit1e8(swapResultAmountMax1e8, slipTolerance)
-        })}
-      </div>
       <Styled.SubmitContainer>
         {!isLocked(keystore) ? (
           isApproved ? (

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -14,7 +14,8 @@ import {
   delay,
   Chain,
   assetToBase,
-  assetAmount
+  assetAmount,
+  AssetRuneNative
 } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import BigNumber from 'bignumber.js'
@@ -1436,6 +1437,14 @@ export const Swap = ({
         />
       )}
       {renderIsApprovedError}
+      <div>
+        memo:{' '}
+        {getSwapMemo({
+          asset: AssetRuneNative,
+          address: 'address',
+          limit: Utils.getSwapLimit1e8(swapResultAmountMax1e8, slipTolerance)
+        })}
+      </div>
       <Styled.SubmitContainer>
         {!isLocked(keystore) ? (
           isApproved ? (

--- a/src/renderer/components/uielements/assets/assetCard/AssetCard.styles.ts
+++ b/src/renderer/components/uielements/assets/assetCard/AssetCard.styles.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import { CheckButton as CheckButtonUI } from '../../button/CheckButton'
-import { Tooltip as UITooltip } from '../../common/Common.styles'
 import { InputBigNumber as InputBigNumberUI } from '../../input'
 import { Label } from '../../label'
 import { AssetLabel as AssetLabelUI } from '../assetLabel'
@@ -94,15 +93,6 @@ export const Header = styled.div`
   padding: 10px 11px 10px 0;
   border-bottom: 1px solid ${palette('gray', 0)};
 `
-
-export const Tooltip = styled(UITooltip).attrs({
-  overlayStyle: {
-    textTransform: 'none',
-    fontSize: 14,
-    maxWidth: '400px',
-    fontFamily: 'MainFontRegular'
-  }
-})``
 
 export const BalanceLabel = styled(Label)`
   width: auto;

--- a/src/renderer/components/uielements/assets/assetCard/AssetCard.tsx
+++ b/src/renderer/components/uielements/assets/assetCard/AssetCard.tsx
@@ -25,6 +25,7 @@ import { isBtcAsset } from '../../../../helpers/assetHelper'
 import { ordAsset } from '../../../../helpers/fp/ord'
 import { useClickOutside } from '../../../../hooks/useOutsideClick'
 import { AssetWithAddress } from '../../../../types/asgardex'
+import { TooltipAddress } from '../../common/Common.styles'
 import { InfoIcon } from '../../info'
 import * as InfoIconStyled from '../../info/InfoIcon.styles'
 import { Slider } from '../../slider'
@@ -152,12 +153,12 @@ export const AssetCard: React.FC<Props> = (props): JSX.Element => {
     <Styled.AssetCardWrapper ref={ref}>
       <Dropdown overlay={renderMenu()} trigger={[]} visible={openDropdown}>
         <Styled.CardBorderWrapper error={minAmountError}>
-          <Styled.Tooltip title={assetAddress}>
+          <TooltipAddress title={assetAddress}>
             <Styled.Header>
               <Styled.AssetLabel asset={asset} />
               {balanceLabel}
             </Styled.Header>
-          </Styled.Tooltip>
+          </TooltipAddress>
           <Styled.CardTopRow>
             <Styled.AssetDataWrapper>
               <Styled.AssetData>

--- a/src/renderer/components/uielements/common/Common.styles.ts
+++ b/src/renderer/components/uielements/common/Common.styles.ts
@@ -36,3 +36,12 @@ export const Tooltip = styled(A.Tooltip).attrs({
     textTransform: 'uppercase'
   }
 })``
+
+export const TooltipAddress = styled(A.Tooltip).attrs({
+  overlayStyle: {
+    textTransform: 'none',
+    fontSize: 14,
+    maxWidth: '400px',
+    fontFamily: 'MainFontRegular'
+  }
+})``

--- a/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
@@ -14,7 +14,7 @@ export const DefaultPoolShare = () => (
     asset={{ asset: AssetBNB, decimal: BNB_DECIMAL }}
     assetPrice={assetToBase(assetAmount(120.1))}
     shares={{ rune: assetToBase(assetAmount(1500)), asset: assetToBase(assetAmount(500)) }}
-    addresses={{ rune: O.some(RUNE_ADDRESS_TESTNET), asset: BNB_ADDRESS_TESTNET }}
+    addresses={{ rune: O.some(RUNE_ADDRESS_TESTNET), asset: O.some(BNB_ADDRESS_TESTNET) }}
     priceAsset={AssetRuneNative}
     runePrice={assetToBase(assetAmount(400))}
     poolShare={bn(100)}
@@ -36,7 +36,7 @@ storiesOf('Components/PoolShare', module)
         asset={{ asset: AssetBNB, decimal: BNB_DECIMAL }}
         assetPrice={ZERO_BASE_AMOUNT}
         shares={{ rune: ZERO_BASE_AMOUNT, asset: ZERO_BASE_AMOUNT }}
-        addresses={{ rune: O.none, asset: BNB_ADDRESS_TESTNET }}
+        addresses={{ rune: O.none, asset: O.some(BNB_ADDRESS_TESTNET) }}
         priceAsset={AssetRuneNative}
         loading={true}
         runePrice={ZERO_BASE_AMOUNT}

--- a/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.stories.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { bn, assetToBase, assetAmount, AssetBNB, AssetRuneNative } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/lib/Option'
 
+import { BNB_ADDRESS_TESTNET, RUNE_ADDRESS_TESTNET } from '../../../../shared/mock/address'
 import { ZERO_BN, ZERO_BASE_AMOUNT } from '../../../const'
 import { BNB_DECIMAL } from '../../../helpers/assetHelper'
 import { PoolShare } from './PoolShare'
@@ -11,7 +13,8 @@ export const DefaultPoolShare = () => (
   <PoolShare
     asset={{ asset: AssetBNB, decimal: BNB_DECIMAL }}
     assetPrice={assetToBase(assetAmount(120.1))}
-    shares={{ rune: assetToBase(assetAmount(500)), asset: assetToBase(assetAmount(500)) }}
+    shares={{ rune: assetToBase(assetAmount(1500)), asset: assetToBase(assetAmount(500)) }}
+    addresses={{ rune: O.some(RUNE_ADDRESS_TESTNET), asset: BNB_ADDRESS_TESTNET }}
     priceAsset={AssetRuneNative}
     runePrice={assetToBase(assetAmount(400))}
     poolShare={bn(100)}
@@ -33,6 +36,7 @@ storiesOf('Components/PoolShare', module)
         asset={{ asset: AssetBNB, decimal: BNB_DECIMAL }}
         assetPrice={ZERO_BASE_AMOUNT}
         shares={{ rune: ZERO_BASE_AMOUNT, asset: ZERO_BASE_AMOUNT }}
+        addresses={{ rune: O.none, asset: BNB_ADDRESS_TESTNET }}
         priceAsset={AssetRuneNative}
         loading={true}
         runePrice={ZERO_BASE_AMOUNT}

--- a/src/renderer/components/uielements/poolShare/PoolShare.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.tsx
@@ -1,5 +1,6 @@
 import React, { RefObject, useCallback, useMemo, useRef } from 'react'
 
+import { Address } from '@xchainjs/xchain-client'
 import {
   formatBN,
   BaseAmount,
@@ -12,10 +13,13 @@ import {
 } from '@xchainjs/xchain-util'
 import { Col } from 'antd'
 import BigNumber from 'bignumber.js'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
 import { THORCHAIN_DECIMAL } from '../../../helpers/assetHelper'
 import { AssetWithDecimal } from '../../../types/asgardex'
+import { TooltipAddress } from '../common/Common.styles'
 import * as Styled from './PoolShare.styles'
 import { PoolShareCard } from './PoolShareCard'
 
@@ -31,6 +35,7 @@ type Props = {
   assetPrice: BaseAmount
   poolShare: BigNumber
   depositUnits: BigNumber
+  addresses: { rune: O.Option<Address>; asset: Address }
   smallWidth?: boolean
   loading?: boolean
 }
@@ -38,6 +43,7 @@ type Props = {
 export const PoolShare: React.FC<Props> = (props): JSX.Element => {
   const {
     asset: assetWD,
+    addresses: { rune: oRuneAddress, asset: assetAddress },
     runePrice,
     loading,
     priceAsset,
@@ -51,6 +57,11 @@ export const PoolShare: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
 
   const { asset } = assetWD
+
+  const runeAddress = FP.pipe(
+    oRuneAddress,
+    O.getOrElse(() => '')
+  )
 
   const totalDepositPrice = useMemo(
     () => baseAmount(runePrice.amount().plus(assetPrice.amount())),
@@ -78,45 +89,53 @@ export const PoolShare: React.FC<Props> = (props): JSX.Element => {
       <>
         <Styled.RedemptionHeader>
           <Styled.CardRow>
-            <Col span={12}>
-              <Styled.RedemptionAsset asset={AssetRuneNative} />
-            </Col>
-            <Col span={12}>
-              <Styled.RedemptionAsset asset={asset} />
-            </Col>
+            <TooltipAddress title={assetAddress}>
+              <Col span={12}>
+                <Styled.RedemptionAsset asset={asset} />
+              </Col>
+            </TooltipAddress>
+            <TooltipAddress title={runeAddress}>
+              <Col span={12}>
+                <Styled.RedemptionAsset asset={AssetRuneNative} />
+              </Col>
+            </TooltipAddress>
           </Styled.CardRow>
         </Styled.RedemptionHeader>
         <Styled.CardRow>
-          {renderRedemptionCol(runeShare, runePrice, AssetRuneNative)}
           {renderRedemptionCol(assetShare, assetPrice, asset)}
+          {renderRedemptionCol(runeShare, runePrice, AssetRuneNative)}
         </Styled.CardRow>
       </>
     ),
-    [asset, renderRedemptionCol, runeShare, runePrice, assetShare, assetPrice]
+    [runeAddress, assetAddress, asset, renderRedemptionCol, runeShare, runePrice, assetShare, assetPrice]
   )
 
   const renderRedemptionSmall = useMemo(
     () => (
       <>
         <Styled.RedemptionHeader>
-          <Styled.CardRow>
-            <Col span={24}>
-              <Styled.RedemptionAsset asset={AssetRuneNative} />
-            </Col>
-          </Styled.CardRow>
+          <TooltipAddress title={assetAddress}>
+            <Styled.CardRow>
+              <Col span={24}>
+                <Styled.RedemptionAsset asset={asset} />
+              </Col>
+            </Styled.CardRow>
+          </TooltipAddress>
         </Styled.RedemptionHeader>
         <Styled.CardRow>{renderRedemptionCol(runeShare, runePrice, AssetRuneNative)}</Styled.CardRow>
         <Styled.RedemptionHeader>
-          <Styled.CardRow>
-            <Col span={24}>
-              <Styled.RedemptionAsset asset={asset} />
-            </Col>
-          </Styled.CardRow>
+          <TooltipAddress title={runeAddress}>
+            <Styled.CardRow>
+              <Col span={24}>
+                <Styled.RedemptionAsset asset={AssetRuneNative} />
+              </Col>
+            </Styled.CardRow>
+          </TooltipAddress>
         </Styled.RedemptionHeader>
         <Styled.CardRow>{renderRedemptionCol(assetShare, assetPrice, asset)}</Styled.CardRow>
       </>
     ),
-    [renderRedemptionCol, runeShare, runePrice, asset, assetShare, assetPrice]
+    [runeAddress, renderRedemptionCol, runeShare, runePrice, assetAddress, asset, assetShare, assetPrice]
   )
   const renderRedemption = useMemo(
     () => (smallWidth ? renderRedemptionSmall : renderRedemptionLarge),

--- a/src/renderer/components/uielements/poolShare/PoolShare.tsx
+++ b/src/renderer/components/uielements/poolShare/PoolShare.tsx
@@ -35,7 +35,7 @@ type Props = {
   assetPrice: BaseAmount
   poolShare: BigNumber
   depositUnits: BigNumber
-  addresses: { rune: O.Option<Address>; asset: Address }
+  addresses: { rune: O.Option<Address>; asset: O.Option<Address> }
   smallWidth?: boolean
   loading?: boolean
 }
@@ -43,7 +43,7 @@ type Props = {
 export const PoolShare: React.FC<Props> = (props): JSX.Element => {
   const {
     asset: assetWD,
-    addresses: { rune: oRuneAddress, asset: assetAddress },
+    addresses: { rune: oRuneAddress, asset: oAssetAddress },
     runePrice,
     loading,
     priceAsset,
@@ -60,6 +60,11 @@ export const PoolShare: React.FC<Props> = (props): JSX.Element => {
 
   const runeAddress = FP.pipe(
     oRuneAddress,
+    O.getOrElse(() => '')
+  )
+
+  const assetAddress = FP.pipe(
+    oAssetAddress,
     O.getOrElse(() => '')
   )
 

--- a/src/renderer/helpers/fp/eq.test.ts
+++ b/src/renderer/helpers/fp/eq.test.ts
@@ -15,6 +15,7 @@ import {
 import * as O from 'fp-ts/lib/Option'
 
 import { LedgerErrorId } from '../../../shared/api/types'
+import { BNB_ADDRESS_TESTNET, RUNE_ADDRESS_TESTNET } from '../../../shared/mock/address'
 import { ASSETS_TESTNET } from '../../../shared/mock/assets'
 import { WalletAddress } from '../../../shared/wallet/types'
 import { SymDepositAddresses } from '../../services/chain/types'
@@ -312,6 +313,8 @@ describe('helpers/fp/eq', () => {
         type: 'asym',
         units: bn(1),
         asset: AssetRuneNative,
+        runeAddress: O.some(RUNE_ADDRESS_TESTNET),
+        assetAddress: O.none,
         assetAddedAmount: baseAmount(1)
       }
       expect(eqPoolShare.equals(a, a)).toBeTruthy()
@@ -321,6 +324,8 @@ describe('helpers/fp/eq', () => {
         type: 'asym',
         units: bn(1),
         asset: AssetRuneNative,
+        runeAddress: O.some(RUNE_ADDRESS_TESTNET),
+        assetAddress: O.none,
         assetAddedAmount: baseAmount(1)
       }
       // b = same as a, but another units
@@ -343,18 +348,24 @@ describe('helpers/fp/eq', () => {
       type: 'asym',
       units: bn(1),
       asset: AssetRuneNative,
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
+      assetAddress: O.none,
       assetAddedAmount: baseAmount(1)
     }
     const b: PoolShare = {
       type: 'sym',
       units: bn(1),
       asset: AssetBNB,
+      assetAddress: O.some(BNB_ADDRESS_TESTNET),
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: baseAmount(0.5)
     }
     const c: PoolShare = {
       type: 'all',
       units: bn(1),
       asset: AssetBTC,
+      assetAddress: O.some('btc-address'),
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       assetAddedAmount: baseAmount(1)
     }
     it('is equal', () => {

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -114,7 +114,7 @@ export const eqPoolShare = Eq.struct<PoolShare>({
   assetAddedAmount: eqBaseAmount,
   units: eqBigNumber,
   type: eqString,
-  assetAddress: eqAddress,
+  assetAddress: eqOAddress,
   runeAddress: eqOAddress
 })
 

--- a/src/renderer/helpers/fp/eq.ts
+++ b/src/renderer/helpers/fp/eq.ts
@@ -35,6 +35,9 @@ export const eqBigNumber: Eq.Eq<BigNumber> = {
 
 export const eqOBigNumber: Eq.Eq<O.Option<BigNumber>> = O.getEq(eqBigNumber)
 
+export const eqAddress: Eq.Eq<Address> = eqString
+export const eqOAddress: Eq.Eq<O.Option<Address>> = eqOString
+
 export const eqAsset: Eq.Eq<Asset> = {
   equals: (x, y) => eqString.equals(x.chain, y.chain) && eqString.equals(x.symbol.toUpperCase(), y.symbol.toUpperCase())
 }
@@ -110,7 +113,9 @@ export const eqPoolShare = Eq.struct<PoolShare>({
   asset: eqAsset,
   assetAddedAmount: eqBaseAmount,
   units: eqBigNumber,
-  type: eqString
+  type: eqString,
+  assetAddress: eqAddress,
+  runeAddress: eqOAddress
 })
 
 export const eqPoolShares = A.getEq(eqPoolShare)
@@ -179,9 +184,6 @@ const eqLedgerError = Eq.struct<LedgerError>({
 })
 
 export const eqWalletType: Eq.Eq<WalletType> = eqString
-
-export const eqAddress: Eq.Eq<Address> = eqString
-export const eqOAddress: Eq.Eq<O.Option<Address>> = eqOString
 
 export const eqWalletAddress = Eq.struct<WalletAddress>({
   address: eqString,

--- a/src/renderer/services/midgard/shares.ts
+++ b/src/renderer/services/midgard/shares.ts
@@ -8,6 +8,7 @@ import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
+import { optionFromNullableString } from '../../helpers/fp/from'
 import { liveData, LiveData } from '../../helpers/rx/liveData'
 import { triggerStream, observableState } from '../../helpers/stateHelper'
 import { MemberPool } from '../../types/generated/midgard'
@@ -87,6 +88,8 @@ const createSharesService = (
               O.fromNullable,
               O.map((asset) => ({
                 type: !!runeAddress && !!assetAddress ? 'sym' : 'asym',
+                assetAddress,
+                runeAddress: optionFromNullableString(runeAddress),
                 asset,
                 units: bnOrZero(liquidityUnits),
                 // BaseAmount of added asset - Note: Thorchain treats all assets as 1e8 decimal based

--- a/src/renderer/services/midgard/shares.ts
+++ b/src/renderer/services/midgard/shares.ts
@@ -88,7 +88,7 @@ const createSharesService = (
               O.fromNullable,
               O.map((asset) => ({
                 type: !!runeAddress && !!assetAddress ? 'sym' : 'asym',
-                assetAddress,
+                assetAddress: optionFromNullableString(assetAddress),
                 runeAddress: optionFromNullableString(runeAddress),
                 asset,
                 units: bnOrZero(liquidityUnits),

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -222,6 +222,8 @@ export type PoolShareType = DepositType | 'all'
 export type PoolShare = {
   units: BigNumber
   asset: Asset
+  assetAddress: Address
+  runeAddress: O.Option<Address>
   assetAddedAmount: BaseAmount
   type: PoolShareType
 }

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -222,7 +222,7 @@ export type PoolShareType = DepositType | 'all'
 export type PoolShare = {
   units: BigNumber
   asset: Asset
-  assetAddress: Address
+  assetAddress: O.Option<Address>
   runeAddress: O.Option<Address>
   assetAddedAmount: BaseAmount
   type: PoolShareType

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -20,6 +20,7 @@ import {
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
+import { BNB_ADDRESS_TESTNET, RUNE_ADDRESS_TESTNET } from '../../../shared/mock/address'
 import {
   ONE_RUNE_BASE_AMOUNT,
   TWO_RUNE_BASE_AMOUNT,
@@ -31,7 +32,7 @@ import { eqAsset, eqPoolShare, eqPoolShares, eqOBigNumber } from '../../helpers/
 import { RUNE_POOL_ADDRESS, RUNE_PRICE_POOL } from '../../helpers/poolHelper'
 import { PoolDetail } from '../../types/generated/midgard'
 import { PricePool, PricePools } from '../../views/pools/Pools.types'
-import { PoolAddress, PoolShare, PoolShares, PoolsState, PoolsStateRD } from './types'
+import { PoolAddress, PoolShare, PoolShares, PoolsStateRD } from './types'
 import {
   getPricePools,
   pricePoolSelector,
@@ -151,12 +152,12 @@ describe('services/midgard/utils/', () => {
     const btc: PricePool = { asset: AssetBTC, poolData }
     const rune: PricePool = RUNE_PRICE_POOL
     const mockPoolsStateSuccess = (pricePools: PricePools): PoolsStateRD =>
-      RD.success<PoolsState>({
+      RD.success({
         assetDetails: [],
         poolAssets: [],
         poolDetails: [],
-        pricePools: O.some(pricePools),
-        poolsData: {}
+        poolsData: {},
+        pricePools: O.some(pricePools)
       })
 
     it('selects ETH pool', () => {
@@ -290,24 +291,32 @@ describe('services/midgard/utils/', () => {
       asset: AssetETH,
       assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
       units: bn('100000000'),
+      assetAddress: 'eth-address',
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       type: 'sym'
     }
     const bnbShares1: PoolShare = {
       asset: AssetBNB,
       assetAddedAmount: TWO_RUNE_BASE_AMOUNT,
       units: bn('200000000'),
+      assetAddress: BNB_ADDRESS_TESTNET,
+      runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       type: 'sym'
     }
     const bnbShares2: PoolShare = {
       asset: AssetBNB,
       assetAddedAmount: THREE_RUNE_BASE_AMOUNT,
       units: bn('300000000'),
+      assetAddress: BNB_ADDRESS_TESTNET,
+      runeAddress: O.none,
       type: 'asym'
     }
     const btcShares: PoolShare = {
       asset: AssetBTC,
       assetAddedAmount: FOUR_RUNE_BASE_AMOUNT,
       units: bn('400000000'),
+      assetAddress: 'btc-address',
+      runeAddress: O.none,
       type: 'asym'
     }
     const shares: PoolShares = [ethShares, bnbShares1, bnbShares2, btcShares]
@@ -332,6 +341,8 @@ describe('services/midgard/utils/', () => {
                 asset: AssetBNB,
                 assetAddedAmount: assetToBase(assetAmount(5)),
                 units: bn('500000000'),
+                assetAddress: BNB_ADDRESS_TESTNET,
+                runeAddress: O.some(RUNE_ADDRESS_TESTNET),
                 type: 'all'
               })
             ),
@@ -344,6 +355,8 @@ describe('services/midgard/utils/', () => {
         expect(FP.pipe(result, O.toNullable)).toEqual({
           asset: AssetETH,
           units: bn('100000000'),
+          assetAddress: 'eth-address',
+          runeAddress: O.some(RUNE_ADDRESS_TESTNET),
           assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
           type: 'all'
         })
@@ -360,17 +373,23 @@ describe('services/midgard/utils/', () => {
             asset: AssetETH,
             assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
             units: bn('100000000'),
+            assetAddress: 'eth-address',
+            runeAddress: O.some(RUNE_ADDRESS_TESTNET),
             type: 'all'
           },
           {
             asset: AssetBNB,
             assetAddedAmount: assetToBase(assetAmount(5)),
             units: bn('500000000'),
+            assetAddress: BNB_ADDRESS_TESTNET,
+            runeAddress: O.some(RUNE_ADDRESS_TESTNET),
             type: 'all'
           },
           {
             asset: AssetBTC,
             assetAddedAmount: FOUR_RUNE_BASE_AMOUNT,
+            assetAddress: 'btc-address',
+            runeAddress: O.none,
             units: bn('400000000'),
             type: 'all'
           }

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -291,7 +291,7 @@ describe('services/midgard/utils/', () => {
       asset: AssetETH,
       assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
       units: bn('100000000'),
-      assetAddress: 'eth-address',
+      assetAddress: O.some('eth-address'),
       runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       type: 'sym'
     }
@@ -299,7 +299,7 @@ describe('services/midgard/utils/', () => {
       asset: AssetBNB,
       assetAddedAmount: TWO_RUNE_BASE_AMOUNT,
       units: bn('200000000'),
-      assetAddress: BNB_ADDRESS_TESTNET,
+      assetAddress: O.some(BNB_ADDRESS_TESTNET),
       runeAddress: O.some(RUNE_ADDRESS_TESTNET),
       type: 'sym'
     }
@@ -307,7 +307,7 @@ describe('services/midgard/utils/', () => {
       asset: AssetBNB,
       assetAddedAmount: THREE_RUNE_BASE_AMOUNT,
       units: bn('300000000'),
-      assetAddress: BNB_ADDRESS_TESTNET,
+      assetAddress: O.some(BNB_ADDRESS_TESTNET),
       runeAddress: O.none,
       type: 'asym'
     }
@@ -315,7 +315,7 @@ describe('services/midgard/utils/', () => {
       asset: AssetBTC,
       assetAddedAmount: FOUR_RUNE_BASE_AMOUNT,
       units: bn('400000000'),
-      assetAddress: 'btc-address',
+      assetAddress: O.some('btc-address'),
       runeAddress: O.none,
       type: 'asym'
     }
@@ -341,7 +341,7 @@ describe('services/midgard/utils/', () => {
                 asset: AssetBNB,
                 assetAddedAmount: assetToBase(assetAmount(5)),
                 units: bn('500000000'),
-                assetAddress: BNB_ADDRESS_TESTNET,
+                assetAddress: O.some(BNB_ADDRESS_TESTNET),
                 runeAddress: O.some(RUNE_ADDRESS_TESTNET),
                 type: 'all'
               })
@@ -355,7 +355,7 @@ describe('services/midgard/utils/', () => {
         expect(FP.pipe(result, O.toNullable)).toEqual({
           asset: AssetETH,
           units: bn('100000000'),
-          assetAddress: 'eth-address',
+          assetAddress: O.some('eth-address'),
           runeAddress: O.some(RUNE_ADDRESS_TESTNET),
           assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
           type: 'all'
@@ -373,7 +373,7 @@ describe('services/midgard/utils/', () => {
             asset: AssetETH,
             assetAddedAmount: ONE_RUNE_BASE_AMOUNT,
             units: bn('100000000'),
-            assetAddress: 'eth-address',
+            assetAddress: O.some('eth-address'),
             runeAddress: O.some(RUNE_ADDRESS_TESTNET),
             type: 'all'
           },
@@ -381,14 +381,14 @@ describe('services/midgard/utils/', () => {
             asset: AssetBNB,
             assetAddedAmount: assetToBase(assetAmount(5)),
             units: bn('500000000'),
-            assetAddress: BNB_ADDRESS_TESTNET,
+            assetAddress: O.some(BNB_ADDRESS_TESTNET),
             runeAddress: O.some(RUNE_ADDRESS_TESTNET),
             type: 'all'
           },
           {
             asset: AssetBTC,
             assetAddedAmount: FOUR_RUNE_BASE_AMOUNT,
-            assetAddress: 'btc-address',
+            assetAddress: O.some('btc-address'),
             runeAddress: O.none,
             units: bn('400000000'),
             type: 'all'

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -258,6 +258,8 @@ export const combineSharesByAsset = (shares: PoolShares, asset: Asset): O.Option
             ...acc,
             units: cur.units.plus(acc.units),
             assetAddedAmount: baseAmount(cur.assetAddedAmount.amount().plus(acc.assetAddedAmount.amount())),
+            assetAddress: acc.assetAddress,
+            runeAddress: O.isSome(acc.runeAddress) ? acc.runeAddress : cur.runeAddress,
             type: 'all'
           })
         ),

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -98,13 +98,14 @@ export const DepositView: React.FC<Props> = () => {
   const poolShares$: PoolSharesLD = useMemo(
     () =>
       FP.pipe(
-        oAssetWalletAddress,
+        // re-load shares whenever selected asset or rune address has been changed
+        sequenceTOption(oAssetWalletAddress, oRuneWalletAddress),
         O.fold(
           () => Rx.EMPTY,
-          ({ address }) => shares$(address)
+          ([{ address }, _]) => shares$(address)
         )
       ),
-    [oAssetWalletAddress, shares$]
+    [oAssetWalletAddress, oRuneWalletAddress, shares$]
   )
 
   const poolSharesRD = useObservableState<PoolSharesRD>(poolShares$, RD.initial)

--- a/src/renderer/views/deposit/share/ShareView.tsx
+++ b/src/renderer/views/deposit/share/ShareView.tsx
@@ -4,6 +4,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { getValueOfAsset1InAsset2, getValueOfRuneInAsset } from '@thorchain/asgardex-util'
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 import { Spin } from 'antd'
+import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
@@ -45,14 +46,14 @@ export const ShareView: React.FC<Props> = ({
   const { poolData: pricePoolData } = useObservableState(selectedPricePool$, RUNE_PRICE_POOL)
 
   const renderPoolShareReady = useCallback(
-    ({ units }: PoolShare, poolDetail: PoolDetail) => {
+    ({ units, runeAddress, assetAddress }: PoolShare, poolDetail: PoolDetail) => {
       const runeShare: BaseAmount = ShareHelpers.getRuneShare(units, poolDetail)
       const assetShare: BaseAmount = ShareHelpers.getAssetShare({
         liquidityUnits: units,
         detail: poolDetail,
         assetDecimal: assetWD.decimal
       })
-      const poolShare = ShareHelpers.getPoolShare(units, poolDetail)
+      const poolShare: BigNumber = ShareHelpers.getPoolShare(units, poolDetail)
 
       const poolData = toPoolData(poolDetail)
 
@@ -76,6 +77,7 @@ export const ShareView: React.FC<Props> = ({
           assetPrice={assetPrice}
           runePrice={runePrice}
           smallWidth={smallWidth}
+          addresses={{ rune: runeAddress, asset: assetAddress }}
         />
       )
     },


### PR DESCRIPTION
- [x] Don't combine `asym` with `sym` shares in DepositView / PoolShare
component to support `sym` shares only
- [x] Show tooltip for addresses in PoolShare component
- [x] Add `assetAddress` + `runeAddress` to `PoolShare` type
- [x] Fix loading of shares while switching wallets (rune side only -> keystore/ledger)
- [x] Provide `TooltipAddress` component