### PR TITLE
Fix `max` value for sending ETH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix Tooltip styles [#1944](https://github.com/thorchain/asgardex-electron/pull/1944)
 - [Swap] Limits added to memo needs to be 1e8 [#1946](https://github.com/thorchain/asgardex-electron/issues/1946)
 - [PoolShare] Don't combine `asym` with `sym` shares in PoolShare [#1964](https://github.com/thorchain/asgardex-electron/pull/1964)
+- [Send] Fix max value for sending ETH [#1978](https://github.com/thorchain/asgardex-electron/pull/1978)
 
 ## Internal
 

--- a/src/renderer/components/wallet/txs/send/SendFormETH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormETH.tsx
@@ -169,7 +169,12 @@ export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
   )
 
   const renderFeeOptions = useMemo(() => {
-    const onChangeHandler = (e: RadioChangeEvent) => setSelectedFeeOption(e.target.value)
+    const onChangeHandler = (e: RadioChangeEvent) => {
+      // Change amount back to `none` (ZERO) whenever selected fee is changed
+      // Just to avoid using a previous `max` value, which can be invalid now
+      setAmountToSend(O.none)
+      setSelectedFeeOption(e.target.value)
+    }
     const disabled = !feesAvailable || isLoading
 
     return (
@@ -216,13 +221,19 @@ export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
   }, [selectedFee, oEthAmount, balance])
 
   useEffect(() => {
-    // Whenever `amountToSend` has been updated, we put it back into input field
     FP.pipe(
       amountToSend,
-      O.map((amount) =>
-        form.setFieldsValue({
-          amount: baseToAsset(amount).amount()
-        })
+      O.fold(
+        // reset value to ZERO whenever amount is not set
+        () =>
+          form.setFieldsValue({
+            amount: ZERO_BN
+          }),
+        // Whenever `amountToSend` has been updated, we put it back into input field
+        (amount) =>
+          form.setFieldsValue({
+            amount: baseToAsset(amount).amount()
+          })
       )
     )
   }, [amountToSend, form])


### PR DESCRIPTION
Entered `max` value might be invalid by changing fees afterwards. This PR fixes it by resetting entered value to ZERO
whenever selected fee has been changed.

![Peek 2021-12-15 12-06](https://user-images.githubusercontent.com/61792675/146176615-adfa02c1-b58b-42cb-9f12-a1716018e67f.gif)

Test tx: https://ropsten.etherscan.io/tx/0xef0b115e0946c436b581e778b35ede47e38b9f3d733c6fa34ec5185c79fa87a2

Fix #1977