### PR TITLE
Include Ledger based shares in wallet -> shares table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update FR translation by @Weyland2093 [#1972](https://github.com/thorchain/asgardex-electron/pull/1972)
 - Switch to haskoin.ninerealms.com [#1974](https://github.com/thorchain/asgardex-electron/issues/1974)
 - [Send] Show Ledger modal [#1979](https://github.com/thorchain/asgardex-electron/pull/1979)
+- [Wallet] Consider shares of Ledger accounts [#1980](https://github.com/thorchain/asgardex-electron/issues/1980)
 
 ## Remove
 

--- a/src/renderer/components/PoolShares/PoolShares.tsx
+++ b/src/renderer/components/PoolShares/PoolShares.tsx
@@ -143,8 +143,8 @@ export const PoolShares: React.FC<Props> = ({
   )
 
   const desktopColumns: ColumnsType<PoolShareTableRowData> = useMemo(
-    () => [iconColumn, poolColumn, ownershipColumn, valueColumn, assetColumn, runeColumn, manageColumn],
-    [iconColumn, poolColumn, ownershipColumn, valueColumn, assetColumn, runeColumn, manageColumn]
+    () => [iconColumn, poolColumn, ownershipColumn, assetColumn, runeColumn, valueColumn, manageColumn],
+    [iconColumn, poolColumn, ownershipColumn, assetColumn, runeColumn, valueColumn, manageColumn]
   )
 
   const mobileColumns: ColumnsType<PoolShareTableRowData> = useMemo(

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -248,7 +248,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
         color: 'primary'
       }
 
-    if (useRuneLedger) return { text: intl.formatMessage({ id: 'ledger.deposit.oneside' }), color: 'warning' }
+    if (useRuneLedger) return { text: intl.formatMessage({ id: 'ledger.deposit.oneside' }), color: 'primary' }
 
     if (!hasAssetLedger)
       return {
@@ -280,7 +280,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
         color: 'primary'
       }
 
-    if (useAssetLedger) return { text: intl.formatMessage({ id: 'ledger.deposit.oneside' }), color: 'warning' }
+    if (useAssetLedger) return { text: intl.formatMessage({ id: 'ledger.deposit.oneside' }), color: 'primary' }
 
     if (!hasRuneLedger)
       return {

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -48,7 +48,8 @@ import {
   getPoolAssetDetail,
   getPoolAssetsDetail,
   inboundToPoolAddresses,
-  getGasRateByChain
+  getGasRateByChain,
+  getSymSharesByAddress
 } from './utils'
 
 describe('services/midgard/utils/', () => {
@@ -425,6 +426,27 @@ describe('services/midgard/utils/', () => {
           FP.pipe(
             oResult,
             O.map((result) => eqPoolShare.equals(result, bnbShares2)),
+            O.getOrElse(() => false)
+          )
+        ).toBeTruthy()
+      })
+    })
+
+    describe('getSymSharesByAddress', () => {
+      it('returns none for empty list', () => {
+        expect(getSymSharesByAddress([], BNB_ADDRESS_TESTNET)).toBeNone()
+      })
+
+      it('returns none for non existing address', () => {
+        expect(getSymSharesByAddress(shares, 'unknown-address')).toBeNone()
+      })
+
+      it('gets shares of BNB pools', () => {
+        const oResult = getSymSharesByAddress(shares, BNB_ADDRESS_TESTNET)
+        expect(
+          FP.pipe(
+            oResult,
+            O.map((result) => eqPoolShare.equals(result, bnbShares1)),
             O.getOrElse(() => false)
           )
         ).toBeTruthy()

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -1,5 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { PoolData } from '@thorchain/asgardex-util'
+import { Address } from '@xchainjs/xchain-client'
 import {
   assetFromString,
   bnOrZero,
@@ -19,7 +20,7 @@ import * as O from 'fp-ts/lib/Option'
 
 import { isUSDAsset, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { isMiniToken } from '../../helpers/binanceHelper'
-import { eqAsset, eqChain } from '../../helpers/fp/eq'
+import { eqAsset, eqChain, eqOAddress } from '../../helpers/fp/eq'
 import { optionFromNullableString } from '../../helpers/fp/from'
 import { ordPricePool } from '../../helpers/fp/ord'
 import { getDeepestPool, RUNE_POOL_ADDRESS, RUNE_PRICE_POOL } from '../../helpers/poolHelper'
@@ -284,6 +285,19 @@ export const getSharesByAssetAndType = ({
   FP.pipe(
     shares,
     A.filter(({ asset: sharesAsset, type: sharesType }) => eqAsset.equals(asset, sharesAsset) && type === sharesType),
+    A.head
+  )
+
+/**
+ * Filters `sym` `Poolshare`'s by given asset `Address`
+ */
+export const getSymSharesByAddress = (shares: PoolShares, assetAddress: Address): O.Option<PoolShare> =>
+  FP.pipe(
+    shares,
+    A.filter(
+      ({ type, assetAddress: oAssetAddress }) =>
+        eqOAddress.equals(oAssetAddress, O.some(assetAddress)) && type === 'sym'
+    ),
     A.head
   )
 

--- a/src/renderer/views/wallet/WalletView.tsx
+++ b/src/renderer/views/wallet/WalletView.tsx
@@ -32,7 +32,7 @@ export const WalletView: React.FC = (): JSX.Element => {
   const { keystoreService, reloadBalances } = useWalletContext()
   const {
     service: {
-      shares: { reloadCombineSharesByAddresses },
+      shares: { reloadSymSharesByAddresses },
       pools: { reloadAllPools }
     }
   } = useMidgardContext()
@@ -72,7 +72,7 @@ export const WalletView: React.FC = (): JSX.Element => {
           </Route>
           <Route path={walletRoutes.poolShares.template} exact>
             {reloadButton(() => {
-              reloadCombineSharesByAddresses()
+              reloadSymSharesByAddresses()
               reloadAllPools()
             })}
             <AssetsNav />
@@ -109,7 +109,7 @@ export const WalletView: React.FC = (): JSX.Element => {
         </Switch>
       </>
     ),
-    [reloadButton, reloadBalances, reloadNodesInfo, reloadHistory, reloadCombineSharesByAddresses, reloadAllPools]
+    [reloadButton, reloadBalances, reloadNodesInfo, reloadHistory, reloadSymSharesByAddresses, reloadAllPools]
   )
 
   const renderWalletRoute = useCallback(


### PR DESCRIPTION
- [x] Add `symSharesByAddresses$`, `symShareByAddress$` to `services/midgard/shares`
- [x] Helper `getSymSharesByAddress` incl. `tests`
- [x] Update `PoolShareView.tsx` to include `Ledger` based sym. shares. Also, asym. shares will be ignored from now (we don't support it in ASGDX yet)

Close  #1980