### PR TITLE
Set allowPrerelease -> false

### DIFF
--- a/src/main/api/appUpdate.ts
+++ b/src/main/api/appUpdate.ts
@@ -10,7 +10,7 @@ import IPCMessages from '../ipc/messages'
 export const registerAppCheckUpdatedHandler = (isDev = false) => {
   // Disable autoDownload
   autoUpdater.autoDownload = false
-  autoUpdater.allowPrerelease = true
+  autoUpdater.allowPrerelease = false
 
   if (isDev) {
     autoUpdater.logger = {


### PR DESCRIPTION
After double check, links to release pages are working with `0.6.0` - no change / fix needed. 
`allowPrerelease` has been set to `false` for debugging things locally (and properly) only.

Close #1983 