### PR TITLE
[BTC] Support confirmed balances only

### DIFF
--- a/src/renderer/services/binance/balances.ts
+++ b/src/renderer/services/binance/balances.ts
@@ -36,6 +36,6 @@ const balances$: (walletType: WalletType, network: Network, walletIndex: number)
     liveData.map(FP.flow(A.filter(({ asset }) => !assetInBinanceBlacklist(network, asset))))
   )
 
-const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances, getBalanceByAddress$ }

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -20,9 +20,9 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, confirmedOnly: true })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, confirmedOnly: true })
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/clients/balances.ts
+++ b/src/renderer/services/clients/balances.ts
@@ -1,5 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { Address, XChainClient } from '@xchainjs/xchain-client'
+import { Address, Balance, XChainClient } from '@xchainjs/xchain-client'
 import { Asset } from '@xchainjs/xchain-util'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/lib/function'
@@ -13,6 +13,13 @@ import { liveData } from '../../helpers/rx/liveData'
 import { ApiError, ErrorId } from '../wallet/types'
 import { WalletBalancesLD, XChainClient$ } from './types'
 
+// Currently we have two parameters only for `getBalance` in XChainClient defined,
+// but `xchain-btc` has recently added a third parameter `confirmedOnly` and XChainClient needs to be changed in the future,
+// @see `xchain-btc` PR 490 https://github.com/xchainjs/xchainjs-lib/pull/490/files#diff-8fc736951c0a12557cfeea25b9e6671889c2bd252e728501d7bd6c914e6cf5b8R105-R107
+// TEmproary workaround: Override `XChainClient` interface here
+export interface XChainClientOverride extends XChainClient {
+  getBalance(address: Address, assets?: Asset[], confirmedOnly?: boolean): Promise<Balance[]>
+}
 /**
  * Observable to request balances by given `XChainClient` and `Address` (optional)
  * `Balances` are mapped into `WalletBalances`
@@ -22,18 +29,20 @@ import { WalletBalancesLD, XChainClient$ } from './types'
  * Empty list of balances returned by client will be ignored and not part of `WalletBalances`
  *
  */
-const loadBalances$ = ({
+const loadBalances$ = <C extends XChainClientOverride>({
   client,
   walletType,
   address,
   assets,
-  walletIndex
+  walletIndex,
+  confirmedOnly
 }: {
-  client: XChainClient
+  client: C
   walletType: WalletType
   address?: Address
   assets?: Asset[]
   walletIndex: number
+  confirmedOnly: boolean
 }): WalletBalancesLD =>
   FP.pipe(
     address,
@@ -44,7 +53,7 @@ const loadBalances$ = ({
       // TODO (@Veado) i18n
       () => Rx.of(RD.failure<ApiError>({ errorId: ErrorId.GET_BALANCES, msg: 'Could not get address' })),
       (walletAddress) =>
-        Rx.from(client.getBalance(walletAddress, assets)).pipe(
+        Rx.from(client.getBalance(walletAddress, assets, confirmedOnly)).pipe(
           map(RD.success),
           liveData.map(
             A.map((balance) => ({
@@ -62,6 +71,21 @@ const loadBalances$ = ({
     )
   )
 
+type Balances$ = ({
+  walletType,
+  client$,
+  trigger$,
+  assets,
+  walletIndex,
+  confirmedOnly
+}: {
+  walletType: WalletType
+  client$: XChainClient$
+  trigger$: Rx.Observable<boolean>
+  assets?: Asset[]
+  walletIndex: number
+  confirmedOnly?: boolean
+}) => WalletBalancesLD
 /**
  * State of `Balances` loaded by given `XChainClient`
  * It will be reloaded by a next value of given `TriggerStream$`
@@ -71,19 +95,7 @@ const loadBalances$ = ({
  *
  * If a client is not available (e.g. by removing keystore), it returns an `initial` state
  */
-export const balances$: ({
-  walletType,
-  client$,
-  trigger$,
-  assets,
-  walletIndex
-}: {
-  walletType: WalletType
-  client$: XChainClient$
-  trigger$: Rx.Observable<boolean>
-  assets?: Asset[]
-  walletIndex: number
-}) => WalletBalancesLD = ({ walletType, client$, trigger$, assets, walletIndex }) =>
+export const balances$: Balances$ = ({ walletType, client$, trigger$, assets, walletIndex, confirmedOnly = false }) =>
   Rx.combineLatest([trigger$.pipe(debounceTime(300)), client$]).pipe(
     RxOp.switchMap(([_, oClient]) => {
       return FP.pipe(
@@ -97,18 +109,25 @@ export const balances$: ({
               walletType,
               client,
               assets,
-              walletIndex
+              walletIndex,
+              confirmedOnly
             })
         )
       )
     })
   )
 
-export const balancesByAddress$: (
-  client$: XChainClient$,
-  trigger$: Rx.Observable<boolean>,
+type BalancesByAddress$ = ({
+  client$,
+  trigger$,
+  assets,
+  confirmedOnly
+}: {
+  client$: XChainClient$
+  trigger$: Rx.Observable<boolean>
   assets?: Asset[]
-) => ({
+  confirmedOnly?: boolean
+}) => ({
   address,
   walletType,
   walletIndex
@@ -116,8 +135,10 @@ export const balancesByAddress$: (
   address: string
   walletType: WalletType
   walletIndex: number
-}) => WalletBalancesLD =
-  (client$, trigger$, assets) =>
+}) => WalletBalancesLD
+
+export const balancesByAddress$: BalancesByAddress$ =
+  ({ client$, trigger$, assets, confirmedOnly = false }) =>
   ({ address, walletType, walletIndex }) =>
     Rx.combineLatest([trigger$.pipe(debounceTime(300)), client$]).pipe(
       RxOp.mergeMap(([_, oClient]) => {
@@ -127,7 +148,7 @@ export const balancesByAddress$: (
             // if a client is not available, "reset" state to "initial"
             () => Rx.of(RD.initial),
             // or start request and return state
-            (client) => loadBalances$({ client, address, walletType, assets, walletIndex })
+            (client) => loadBalances$({ client, address, walletType, assets, walletIndex, confirmedOnly })
           )
         )
       }),

--- a/src/renderer/services/doge/balances.ts
+++ b/src/renderer/services/doge/balances.ts
@@ -23,6 +23,6 @@ const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalance
   C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/thorchain/balances.ts
+++ b/src/renderer/services/thorchain/balances.ts
@@ -26,6 +26,6 @@ const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalance
   C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, assets: [AssetRuneNative] })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$(client$, reloadBalances$)
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
 
 export { balances$, getBalanceByAddress$, reloadBalances, reloadBalances$, resetReloadBalances }


### PR DESCRIPTION
Background: For sending BTC transactions with a memo, only confirmed UTXOs are supported for security reason (see https://github.com/xchainjs/xchainjs-lib/issues/330). By the other hand, BTC balances are including confirmed + unconfirmed amounts (Haskoin `main|stagenet` [code](https://github.com/xchainjs/xchainjs-lib/blob/993c00b8bc4fc2eac302c51da1dc26bb2fa3c7b9/packages/xchain-bitcoin/src/haskoin-api.ts#L17-L34), Sochain `testnet` [code](https://github.com/xchainjs/xchainjs-lib/blob/993c00b8bc4fc2eac302c51da1dc26bb2fa3c7b9/packages/xchain-bitcoin/src/sochain-api.ts#L75-L89) ). This ends in a mismatch by calculating possible max. values to send (#1986). 

To fix that, this PR introduces support of confirmed balances only (unconfirmed balances will be ignored).

Part of #2059