### PR TITLE
Handle (confirmed) BTC balances the better way

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -613,7 +613,8 @@ export const Swap = ({
     // max value of token can be allocated for swap
     if (isChainAsset(sourceChainAsset))
       return Utils.maxAmountToSwapMax1e8(sourceAssetAmountMax1e8, swapFees.inFee.amount)
-    else return sourceAssetAmountMax1e8
+
+    return sourceAssetAmountMax1e8
   }, [lockedWallet, sourceAssetAmountMax1e8, sourceChainAsset, swapFees])
 
   const setAmountToSwapMax1e8 = useCallback(

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -65,7 +65,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletAddress: 'BNB wallet address',
           walletIndex: 0
         }
-      ])
+      ]),
+      balanceType: 'all'
     }
   ],
   [BTCChain]: [
@@ -82,7 +83,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletAddress: 'BNB wallet address',
           walletIndex: 0
         }
-      ])
+      ]),
+      balanceType: 'all'
     }
   ],
   [ETHChain]: [
@@ -99,7 +101,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletAddress: 'ETH wallet address',
           walletIndex: 0
         }
-      ])
+      ]),
+      balanceType: 'all'
     }
   ],
   [THORChain]: [
@@ -116,7 +119,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletAddress: 'BNB wallet address',
           walletIndex: 0
         }
-      ])
+      ]),
+      balanceType: 'all'
     }
   ],
   [LTCChain]: [
@@ -133,7 +137,8 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletAddress: 'LTC wallet address',
           walletIndex: 0
         }
-      ])
+      ]),
+      balanceType: 'all'
     }
   ]
 }

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -66,7 +66,7 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletIndex: 0
         }
       ]),
-      balanceType: 'all'
+      balancesType: 'all'
     }
   ],
   [BTCChain]: [
@@ -84,7 +84,7 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletIndex: 0
         }
       ]),
-      balanceType: 'all'
+      balancesType: 'all'
     }
   ],
   [ETHChain]: [
@@ -102,7 +102,7 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletIndex: 0
         }
       ]),
-      balanceType: 'all'
+      balancesType: 'all'
     }
   ],
   [THORChain]: [
@@ -120,7 +120,7 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletIndex: 0
         }
       ]),
-      balanceType: 'all'
+      balancesType: 'all'
     }
   ],
   [LTCChain]: [
@@ -138,7 +138,7 @@ const balances: Partial<Record<Chain, ChainBalances>> = {
           walletIndex: 0
         }
       ]),
-      balanceType: 'all'
+      balancesType: 'all'
     }
   ]
 }

--- a/src/renderer/contexts/BitcoinContext.tsx
+++ b/src/renderer/contexts/BitcoinContext.tsx
@@ -7,6 +7,9 @@ import {
   addressUI$,
   reloadBalances,
   balances$,
+  balancesConfirmed$,
+  getBalanceByAddress$,
+  getBalanceConfirmedByAddress$,
   txRD$,
   reloadFees,
   fees$,
@@ -28,6 +31,9 @@ export type BitcoinContextValue = {
   addressUI$: typeof addressUI$
   reloadBalances: typeof reloadBalances
   balances$: typeof balances$
+  balancesConfirmed$: typeof balancesConfirmed$
+  getBalanceByAddress$: typeof getBalanceByAddress$
+  getBalanceConfirmedByAddress$: typeof getBalanceConfirmedByAddress$
   reloadFees: typeof reloadFees
   fees$: typeof fees$
   reloadFeesWithRates: typeof reloadFeesWithRates
@@ -49,6 +55,9 @@ const initialContext: BitcoinContextValue = {
   addressUI$,
   reloadBalances,
   balances$,
+  balancesConfirmed$,
+  getBalanceByAddress$,
+  getBalanceConfirmedByAddress$,
   reloadFees,
   fees$,
   reloadFeesWithRates,

--- a/src/renderer/helpers/assetHelper.ts
+++ b/src/renderer/helpers/assetHelper.ts
@@ -38,7 +38,7 @@ import {
 import { ERC20_WHITELIST } from '../types/generated/thorchain/erc20whitelist'
 import { PricePoolAsset } from '../views/pools/Pools.types'
 import { getEthChecksumAddress } from './addressHelper'
-import { getChainAsset, isBchChain, isBnbChain, isBtcChain, isEthChain, isLtcChain } from './chainHelper'
+import { getChainAsset, isBchChain, isBnbChain, isBtcChain, isDogeChain, isEthChain, isLtcChain } from './chainHelper'
 import { eqAsset, eqString } from './fp/eq'
 import { sequenceTOption } from './fpHelpers'
 
@@ -223,7 +223,8 @@ export const isChainAsset = (asset: Asset): boolean => eqAsset.equals(asset, get
 
 export const isUSDAsset = (asset: Asset): boolean => asset.ticker.includes('USD')
 
-export const isUtxoAssetChain = ({ chain }: Asset) => isBtcChain(chain) || isBchChain(chain) || isLtcChain(chain)
+export const isUtxoAssetChain = ({ chain }: Asset) =>
+  isBtcChain(chain) || isBchChain(chain) || isLtcChain(chain) || isDogeChain(chain)
 
 /**
  * Update ETH token (ERC20) addresses to be based on checksum addresses

--- a/src/renderer/services/binance/balances.ts
+++ b/src/renderer/services/binance/balances.ts
@@ -31,11 +31,11 @@ const balances$: (walletType: WalletType, network: Network, walletIndex: number)
   walletIndex
 ) =>
   FP.pipe(
-    C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex }),
+    C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' }),
     // Filter out black listed assets
     liveData.map(FP.flow(A.filter(({ asset }) => !assetInBinanceBlacklist(network, asset))))
   )
 
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances, getBalanceByAddress$ }

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -20,9 +20,27 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, confirmedOnly: true })
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' })
+
+// State of balances loaded by Client
+const balancesConfirmed$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'confirmed' })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, confirmedOnly: true })
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
 
-export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }
+const getBalanceConfirmedByAddress$ = C.balancesByAddress$({
+  client$,
+  trigger$: reloadBalances$,
+  walletBalanceType: 'confirmed'
+})
+
+export {
+  balances$,
+  balancesConfirmed$,
+  reloadBalances,
+  getBalanceByAddress$,
+  getBalanceConfirmedByAddress$,
+  reloadBalances$,
+  resetReloadBalances
+}

--- a/src/renderer/services/bitcoin/index.ts
+++ b/src/renderer/services/bitcoin/index.ts
@@ -1,5 +1,13 @@
 import { network$ } from '../app/service'
-import { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances } from './balances'
+import {
+  balances$,
+  balancesConfirmed$,
+  reloadBalances,
+  getBalanceByAddress$,
+  getBalanceConfirmedByAddress$,
+  reloadBalances$,
+  resetReloadBalances
+} from './balances'
 import { client$, clientState$, address$, addressUI$, explorerUrl$ } from './common'
 import { createFeesService } from './fees'
 import { createLedgerService } from './ledger'
@@ -20,7 +28,9 @@ export {
   reloadBalances$,
   resetReloadBalances,
   balances$,
+  balancesConfirmed$,
   getBalanceByAddress$,
+  getBalanceConfirmedByAddress$,
   reloadFees,
   fees$,
   reloadFeesWithRates,

--- a/src/renderer/services/bitcoincash/balances.ts
+++ b/src/renderer/services/bitcoincash/balances.ts
@@ -20,6 +20,6 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/doge/balances.ts
+++ b/src/renderer/services/doge/balances.ts
@@ -20,9 +20,9 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/ethereum/balances.ts
+++ b/src/renderer/services/ethereum/balances.ts
@@ -40,7 +40,7 @@ const balances$: ({
   // because `xchain-ethereum` does for each asset a single request
   const assets: Asset[] | undefined = network === 'testnet' ? ETHAssetsTestnet : undefined
   return FP.pipe(
-    C.balances$({ client$, trigger$: reloadBalances$, assets, walletType, walletIndex }),
+    C.balances$({ client$, trigger$: reloadBalances$, assets, walletType, walletIndex, walletBalanceType: 'all' }),
     // Filter assets based on ERC20Whitelist (mainnet only)
     liveData.map(FP.flow(A.filter(({ asset }) => validAssetForETH(asset, network))))
   )

--- a/src/renderer/services/litecoin/balances.ts
+++ b/src/renderer/services/litecoin/balances.ts
@@ -20,6 +20,6 @@ const reloadBalances = () => {
 
 // State of balances loaded by Client
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex })
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' })
 
 export { balances$, reloadBalances, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/thorchain/balances.ts
+++ b/src/renderer/services/thorchain/balances.ts
@@ -23,9 +23,16 @@ const reloadBalances = () => {
 // State of balances loaded by Client
 // TODO (@veado) Remove `assets` list to enable synths - currently we support `AssetRuneNative` only
 const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
-  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, assets: [AssetRuneNative] })
+  C.balances$({
+    client$,
+    trigger$: reloadBalances$,
+    walletType,
+    walletIndex,
+    assets: [AssetRuneNative],
+    walletBalanceType: 'all'
+  })
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$ })
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
 
 export { balances$, getBalanceByAddress$, reloadBalances, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/wallet/const.ts
+++ b/src/renderer/services/wallet/const.ts
@@ -4,7 +4,14 @@ import * as O from 'fp-ts/lib/Option'
 
 import { LoadTxsParams } from '../clients'
 import { MAX_ITEMS_PER_PAGE } from '../const'
-import { BalancesState, KeystoreState, LedgerAddressesMap, LedgerAddressMap, LoadTxsHandler } from './types'
+import {
+  BalancesState,
+  BalancesStateFilter,
+  KeystoreState,
+  LedgerAddressesMap,
+  LedgerAddressMap,
+  LoadTxsHandler
+} from './types'
 
 export const INITIAL_KEYSTORE_STATE: KeystoreState = O.none
 
@@ -12,6 +19,19 @@ export const INITIAL_BALANCES_STATE: BalancesState = {
   balances: O.none,
   errors: O.none,
   loading: false
+}
+
+export const DEFAULT_BALANCES_FILTER: BalancesStateFilter = {
+  [Chain.Binance]: 'all',
+  [Chain.Bitcoin]: 'all',
+  [Chain.BitcoinCash]: 'all',
+  [Chain.Ethereum]: 'all',
+  [Chain.Cosmos]: 'all',
+  [Chain.Polkadot]: 'all',
+  [Chain.Litecoin]: 'all',
+  [Chain.THORChain]: 'all',
+  [Chain.Doge]: 'all',
+  [Chain.Terra]: 'all'
 }
 
 export const INITIAL_LOAD_TXS_PROPS: LoadTxsParams = {

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -71,7 +71,7 @@ export type ChainBalance = {
   walletAddress: O.Option<Address>
   chain: Chain
   balances: WalletBalancesRD
-  balanceType: WalletBalanceType
+  balancesType: WalletBalanceType
 }
 
 export type ChainBalance$ = Rx.Observable<ChainBalance>

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -9,7 +9,7 @@ import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
 import { LedgerError, Network } from '../../../shared/api/types'
-import { WalletAddress, WalletType } from '../../../shared/wallet/types'
+import { WalletAddress, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
 import { LoadTxsParams, WalletBalancesLD, WalletBalancesRD } from '../clients'
 
@@ -71,6 +71,7 @@ export type ChainBalance = {
   walletAddress: O.Option<Address>
   chain: Chain
   balances: WalletBalancesRD
+  balanceType: WalletBalanceType
 }
 
 export type ChainBalance$ = Rx.Observable<ChainBalance>
@@ -92,7 +93,8 @@ export type BalancesState = {
   loading: boolean
 }
 
-export type BalancesState$ = Rx.Observable<BalancesState>
+export type BalancesStateFilter = Record<Chain, WalletBalanceType>
+export type BalancesState$ = (filter: BalancesStateFilter) => Rx.Observable<BalancesState>
 
 export type LoadTxsHandler = (props: LoadTxsParams) => void
 export type ResetTxsPageHandler = FP.Lazy<void>

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, AssetRuneNative, assetToString, bn, THORChain } from '@xchainjs/xchain-util'
+import { Asset, AssetRuneNative, assetToString, bn, Chain, THORChain } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
@@ -29,7 +29,7 @@ import * as poolsRoutes from '../../../routes/pools'
 import { OpenExplorerTxUrl } from '../../../services/clients'
 import { PoolAddress, PoolAssetsRD } from '../../../services/midgard/types'
 import { toPoolData } from '../../../services/midgard/utils'
-import { INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { Props } from './SymDepositView.types'
 
 export const SymDepositView: React.FC<Props> = (props) => {
@@ -102,7 +102,14 @@ export const SymDepositView: React.FC<Props> = (props) => {
   const runPrice = useObservableState(priceRatio$, bn(1))
   const [selectedPricePoolAsset] = useObservableState(() => FP.pipe(selectedPricePoolAsset$, RxOp.map(O.toUndefined)))
 
-  const balancesState = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
+  const [balancesState] = useObservableState(
+    () =>
+      balancesState$({
+        ...DEFAULT_BALANCES_FILTER,
+        [Chain.Bitcoin]: 'confirmed'
+      }),
+    INITIAL_BALANCES_STATE
+  )
 
   const reloadBalances = useCallback(() => {
     reloadBalancesByChain(assetWD.asset.chain)()

--- a/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
+++ b/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, AssetRuneNative, BaseAmount, bn, THORChain } from '@xchainjs/xchain-util'
+import { Asset, AssetRuneNative, BaseAmount, bn, Chain, THORChain } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
@@ -23,6 +23,7 @@ import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { OpenExplorerTxUrl } from '../../../services/clients'
 import { DEFAULT_NETWORK } from '../../../services/const'
 import { PoolShare, PoolsDataMap } from '../../../services/midgard/types'
+import { DEFAULT_BALANCES_FILTER } from '../../../services/wallet/const'
 import { getBalanceByAsset } from '../../../services/wallet/util'
 import { PoolDetail } from '../../../types/generated/midgard'
 import { Props } from './WithdrawDepositView.types'
@@ -83,7 +84,10 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
   const [balances] = useObservableState(
     () =>
       FP.pipe(
-        balancesState$,
+        balancesState$({
+          ...DEFAULT_BALANCES_FILTER,
+          [Chain.Bitcoin]: 'confirmed'
+        }),
         RxOp.map((state) => state.balances)
       ),
     O.none

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -34,7 +34,7 @@ import * as walletRoutes from '../../routes/wallet'
 import { AssetWithDecimalLD, AssetWithDecimalRD } from '../../services/chain/types'
 import { OpenExplorerTxUrl } from '../../services/clients'
 import { DEFAULT_SLIP_TOLERANCE } from '../../services/const'
-import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
+import { INITIAL_BALANCES_STATE, DEFAULT_BALANCES_FILTER } from '../../services/wallet/const'
 import { isSlipTolerance, SlipTolerance } from '../../types/asgardex'
 import * as Styled from './SwapView.styles'
 
@@ -119,7 +119,14 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
 
   const targetAssetRD: AssetWithDecimalRD = useObservableState(targetAssetDecimal$, RD.initial)
 
-  const balancesState = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
+  const [balancesState] = useObservableState(
+    () =>
+      balancesState$({
+        ...DEFAULT_BALANCES_FILTER,
+        [Chain.Bitcoin]: 'confirmed'
+      }),
+    INITIAL_BALANCES_STATE
+  )
 
   const selectedPoolAddress = useObservableState(selectedPoolAddress$, O.none)
 

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -25,7 +25,7 @@ import { useOpenExplorerTxUrl } from '../../hooks/useOpenExplorerTxUrl'
 import { AssetDetailsParams } from '../../routes/wallet'
 import { OpenExplorerTxUrl } from '../../services/clients'
 import { DEFAULT_NETWORK } from '../../services/const'
-import { INITIAL_BALANCES_STATE } from '../../services/wallet/const'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 
 export const AssetDetailsView: React.FC = (): JSX.Element => {
   const intl = useIntl()
@@ -63,7 +63,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
   const { getTxs$, balancesState$, loadTxs, reloadBalancesByChain, setSelectedAsset, resetTxsPage } = useWalletContext()
 
   const [txsRD] = useObservableState(() => getTxs$(oWalletAddress, walletIndex), RD.initial)
-  const { balances: oBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
+  const { balances: oBalances } = useObservableState(balancesState$(DEFAULT_BALANCES_FILTER), INITIAL_BALANCES_STATE)
 
   useEffect(() => {
     return () => resetTxsPage()

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -36,7 +36,7 @@ export const AssetsView: React.FC = (): JSX.Element => {
           FP.pipe(
             chainBalances,
             // we show all balances
-            A.filter(({ balanceType }) => balanceType === 'all'),
+            A.filter(({ balancesType }) => balancesType === 'all'),
             // accept balances > 0 only
             A.map((chainBalance) => ({
               ...chainBalance,

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
 import { Asset, assetToString } from '@xchainjs/xchain-util'
+import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import { useObservableState } from 'observable-hooks'
 import { useHistory } from 'react-router-dom'
@@ -27,21 +28,27 @@ export const AssetsView: React.FC = (): JSX.Element => {
   const { network$ } = useAppContext()
   const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
 
-  // accept balances > 0 only
   const [chainBalances] = useObservableState(
     () =>
-      chainBalances$.pipe(
-        RxOp.map((chainBalances) =>
-          chainBalances.map((chainBalance) => ({
-            ...chainBalance,
-            balances: FP.pipe(
-              chainBalance.balances,
-              RD.map((balances) => balances.filter((balance) => balance.amount.amount().isGreaterThan(0)))
-            )
-          }))
+      FP.pipe(
+        chainBalances$,
+        RxOp.map<ChainBalances, ChainBalances>((chainBalances) =>
+          FP.pipe(
+            chainBalances,
+            // we show all balances
+            A.filter(({ balanceType }) => balanceType === 'all'),
+            // accept balances > 0 only
+            A.map((chainBalance) => ({
+              ...chainBalance,
+              balances: FP.pipe(
+                chainBalance.balances,
+                RD.map((balances) => balances.filter((balance) => balance.amount.gt(0)))
+              )
+            }))
+          )
         )
       ),
-    [] as ChainBalances
+    []
   )
 
   const {

--- a/src/renderer/views/wallet/Interact/BondView.tsx
+++ b/src/renderer/views/wallet/Interact/BondView.tsx
@@ -20,6 +20,7 @@ import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_INTERACT_STATE } from '../../../services/thorchain/const'
 import { InteractState } from '../../../services/thorchain/types'
+import { DEFAULT_BALANCES_FILTER } from '../../../services/wallet/const'
 import * as Styled from './InteractView.styles'
 
 type Props = {
@@ -46,7 +47,7 @@ export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddre
   const [runeBalance] = useObservableState(
     () =>
       FP.pipe(
-        balancesState$,
+        balancesState$(DEFAULT_BALANCES_FILTER),
         RxOp.map(({ balances }) => balances),
         RxOp.map(
           FP.flow(

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -28,7 +28,7 @@ import { SendParams } from '../../../routes/wallet'
 import * as walletRoutes from '../../../routes/wallet'
 import { OpenExplorerTxUrl } from '../../../services/clients'
 import { DEFAULT_NETWORK } from '../../../services/const'
-import { INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { SendViewBNB, SendViewBCH, SendViewBTC, SendViewETH, SendViewDOGE, SendViewTHOR, SendViewLTC } from './index'
 
 type Props = {}
@@ -49,7 +49,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
     keystoreService: { validatePassword$ }
   } = useWalletContext()
 
-  const { balances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
+  const [{ balances }] = useObservableState(() => balancesState$(DEFAULT_BALANCES_FILTER), INITIAL_BALANCES_STATE)
 
   const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
     FP.pipe(

--- a/src/renderer/views/wallet/upgrade/UpgradeView.tsx
+++ b/src/renderer/views/wallet/upgrade/UpgradeView.tsx
@@ -29,7 +29,7 @@ import { AssetWithDecimalLD, AssetWithDecimalRD } from '../../../services/chain/
 import { OpenExplorerTxUrl } from '../../../services/clients'
 import { DEFAULT_NETWORK } from '../../../services/const'
 import { PoolAddressRD } from '../../../services/midgard/types'
-import { INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { AssetWithDecimal } from '../../../types/asgardex'
 import { CommonUpgradeProps } from './types'
 import { UpgradeBNB } from './UpgradeViewBNB'
@@ -82,7 +82,11 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
     keystoreService: { validatePassword$ },
     reloadBalancesByChain
   } = useWalletContext()
-  const { balances: oBalances } = useObservableState(balancesState$, INITIAL_BALANCES_STATE)
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
 
   const {
     service: {

--- a/src/shared/wallet/types.ts
+++ b/src/shared/wallet/types.ts
@@ -3,5 +3,7 @@ import { Chain } from '@xchainjs/xchain-util'
 
 export type WalletType = 'keystore' | 'ledger'
 
+export type WalletBalanceType = 'all' | 'confirmed'
+
 export type WalletAddress = { address: Address; type: WalletType; chain: Chain; walletIndex: number }
 export type WalletAddresses = WalletAddress[]


### PR DESCRIPTION
## Background
Since confirmed UTXOs of `BTC` can be spent for sending txs with a memo only (see https://github.com/xchainjs/xchainjs-lib/issues/330), SWAP, DEPOSIT, WITHDRAW can handling "confirmed" balances only. In `wallet` -> `assets` 'all' balances (confirmed and not confirmed) are accessible to send. 

## Changes

Spendable UTXOs (BTC) are considered in ASGARDEX as follow now:
- SWAP/DEPOSIT/WITHDRAW: 'confirmed` only
- SEND: 'all' (confirmed + unconfirmed)