### PR TITLE
[ViewTxButton] Add button to copy tx url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.8.1 (2022-xx-xx)
+
+## Add
+
+- Feature list [#2092](https://github.com/thorchain/asgardex-electron/pull/2092)
+- [TxModal|Send] Add copy button [#1998](https://github.com/thorchain/asgardex-electron/issues/1998)
+
 # 0.8.0 (2022-02-18)
 
 ## Add

--- a/src/renderer/components/deposit/add/SymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.stories.tsx
@@ -97,6 +97,8 @@ const defaultProps: SymDepositProps = {
     console.log(`Open RUNE explorer - tx hash ${txHash}`)
     return Promise.resolve(true)
   },
+  getAssetExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
+  getRuneExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
   // mock password validation
   // Password: "123"
   validatePassword$: mockValidatePassword$,

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -56,7 +56,7 @@ import {
   SymDepositFeesHandler,
   SymDepositFeesRD
 } from '../../../services/chain/types'
-import { OpenExplorerTxUrl } from '../../../services/clients'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../services/clients'
 import {
   ApproveFeeHandler,
   ApproveParams,
@@ -114,6 +114,8 @@ export type Props = {
   reloadSelectedPoolDetail: (delay?: number) => void
   openAssetExplorerTxUrl: OpenExplorerTxUrl
   openRuneExplorerTxUrl: OpenExplorerTxUrl
+  getRuneExplorerTxUrl: GetExplorerTxUrl
+  getAssetExplorerTxUrl: GetExplorerTxUrl
   validatePassword$: ValidatePasswordHandler
   onChangeAsset: (asset: Asset) => void
   disabled?: boolean
@@ -149,6 +151,8 @@ export const SymDeposit: React.FC<Props> = (props) => {
     poolAddress: oPoolAddress,
     openAssetExplorerTxUrl,
     openRuneExplorerTxUrl,
+    getRuneExplorerTxUrl,
+    getAssetExplorerTxUrl,
     validatePassword$,
     priceAsset,
     reloadFees,
@@ -903,6 +907,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <Styled.ViewTxButtonTop
             txHash={oTxHash}
             onClick={openAssetExplorerTxUrl}
+            getExplorerTxUrl={getAssetExplorerTxUrl}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: asset.ticker })}
           />
         ))}
@@ -910,6 +915,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <ViewTxButton
             txHash={oTxHash}
             onClick={openRuneExplorerTxUrl}
+            getExplorerTxUrl={getRuneExplorerTxUrl}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: AssetRuneNative.ticker })}
           />
         ))}
@@ -936,8 +942,10 @@ export const SymDeposit: React.FC<Props> = (props) => {
     txModalExtraContent,
     intl,
     openAssetExplorerTxUrl,
+    getAssetExplorerTxUrl,
     asset.ticker,
-    openRuneExplorerTxUrl
+    openRuneExplorerTxUrl,
+    getRuneExplorerTxUrl
   ])
 
   const closePasswordModal = useCallback(() => {

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -907,7 +907,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <Styled.ViewTxButtonTop
             txHash={oTxHash}
             onClick={openAssetExplorerTxUrl}
-            getExplorerTxUrl={getAssetExplorerTxUrl}
+            txUrl={FP.pipe(oTxHash, O.chain(getAssetExplorerTxUrl))}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: asset.ticker })}
           />
         ))}
@@ -915,7 +915,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <ViewTxButton
             txHash={oTxHash}
             onClick={openRuneExplorerTxUrl}
-            getExplorerTxUrl={getRuneExplorerTxUrl}
+            txUrl={FP.pipe(oTxHash, O.chain(getRuneExplorerTxUrl))}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: AssetRuneNative.ticker })}
           />
         ))}

--- a/src/renderer/components/deposit/withdraw/Withdraw.stories.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.stories.tsx
@@ -42,6 +42,7 @@ const defaultProps: WitdrawProps = {
     console.log(`Open RUNE explorer - tx hash ${txHash}`)
     return Promise.resolve(true)
   },
+  getRuneExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
   // mock password validation
   // Password: "123"
   validatePassword$: mockValidatePassword$,

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -314,7 +314,7 @@ export const Withdraw: React.FC<Props> = ({
           <Styled.ViewTxButtonTop
             txHash={oTxHash}
             onClick={openRuneExplorerTxUrl}
-            getExplorerTxUrl={getRuneExplorerTxUrl}
+            txUrl={FP.pipe(oTxHash, O.chain(getRuneExplorerTxUrl))}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: AssetRuneNative.ticker })}
           />
         ))}

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -39,7 +39,7 @@ import {
   SymWithdrawFeesRD,
   SymWithdrawFees
 } from '../../../services/chain/types'
-import { OpenExplorerTxUrl } from '../../../services/clients'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../services/clients'
 import { PoolsDataMap } from '../../../services/midgard/types'
 import { MimirHalt } from '../../../services/thorchain/types'
 import { ValidatePasswordHandler } from '../../../services/wallet/types'
@@ -74,6 +74,7 @@ export type Props = {
   /** Flag whether form has to be disabled or not */
   disabled?: boolean
   openRuneExplorerTxUrl: OpenExplorerTxUrl
+  getRuneExplorerTxUrl: GetExplorerTxUrl
   validatePassword$: ValidatePasswordHandler
   reloadBalances: FP.Lazy<void>
   withdraw$: SymWithdrawStateHandler
@@ -101,6 +102,7 @@ export const Withdraw: React.FC<Props> = ({
   shares: { rune: runeShare, asset: assetShare },
   disabled,
   openRuneExplorerTxUrl,
+  getRuneExplorerTxUrl,
   validatePassword$,
   reloadBalances = FP.constVoid,
   reloadFees,
@@ -312,6 +314,7 @@ export const Withdraw: React.FC<Props> = ({
           <Styled.ViewTxButtonTop
             txHash={oTxHash}
             onClick={openRuneExplorerTxUrl}
+            getExplorerTxUrl={getRuneExplorerTxUrl}
             label={intl.formatMessage({ id: 'common.tx.view' }, { assetTicker: AssetRuneNative.ticker })}
           />
         ))}
@@ -337,7 +340,8 @@ export const Withdraw: React.FC<Props> = ({
     withdrawStartTime,
     txModalExtraContent,
     intl,
-    openRuneExplorerTxUrl
+    openRuneExplorerTxUrl,
+    getRuneExplorerTxUrl
   ])
 
   const [showPasswordModal, setShowPasswordModal] = useState(false)

--- a/src/renderer/components/modal/tx/TxModal.stories.tsx
+++ b/src/renderer/components/modal/tx/TxModal.stories.tsx
@@ -63,7 +63,7 @@ const extraResult = (): JSX.Element => (
   <ViewTxButton
     txHash={O.some('hash')}
     onClick={(txHash: TxHash) => console.log('txHash', txHash)}
-    getExplorerTxUrl={(txHash: TxHash) => O.some(`url/asset-${txHash}`)}
+    txUrl={O.some(`http://txurl.example`)}
   />
 )
 

--- a/src/renderer/components/modal/tx/TxModal.stories.tsx
+++ b/src/renderer/components/modal/tx/TxModal.stories.tsx
@@ -60,7 +60,11 @@ const extraContent = (): JSX.Element => (
 )
 
 const extraResult = (): JSX.Element => (
-  <ViewTxButton txHash={O.some('hash')} onClick={(txHash: TxHash) => console.log('txHash', txHash)} />
+  <ViewTxButton
+    txHash={O.some('hash')}
+    onClick={(txHash: TxHash) => console.log('txHash', txHash)}
+    getExplorerTxUrl={(txHash: TxHash) => O.some(`url/asset-${txHash}`)}
+  />
 )
 
 export const StoryExtra: Story = () => (

--- a/src/renderer/components/swap/Swap.stories.tsx
+++ b/src/renderer/components/swap/Swap.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
 import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
+import { TxHash } from '@xchainjs/xchain-client'
 import {
   assetAmount,
   AssetBNB,
@@ -85,7 +86,9 @@ const defaultProps: SwapProps = {
   },
   goToTransaction: (txHash) => {
     console.log(txHash)
+    return Promise.resolve(true)
   },
+  getExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
   // mock password validation
   // Password: "123"
   validatePassword$: mockValidatePassword$,

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -65,7 +65,7 @@ import {
   SwapFees,
   FeeRD
 } from '../../services/chain/types'
-import { AddressValidationAsync } from '../../services/clients'
+import { AddressValidationAsync, GetExplorerTxUrl, OpenExplorerTxUrl } from '../../services/clients'
 import {
   ApproveFeeHandler,
   ApproveParams,
@@ -111,7 +111,8 @@ export type SwapProps = {
   swap$: SwapStateHandler
   poolsData: PoolsDataMap
   walletBalances: Pick<BalancesState, 'balances' | 'loading'>
-  goToTransaction: (txHash: string) => void
+  goToTransaction: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
   validatePassword$: ValidatePasswordHandler
   reloadFees: ReloadSwapFeesHandler
   reloadBalances: FP.Lazy<void>
@@ -143,7 +144,8 @@ export const Swap = ({
   swap$,
   poolsData,
   walletBalances,
-  goToTransaction = (_) => {},
+  goToTransaction,
+  getExplorerTxUrl,
   validatePassword$,
   reloadFees,
   reloadBalances = FP.constVoid,
@@ -841,16 +843,13 @@ export const Swap = ({
       (id) => intl.formatMessage({ id })
     )
 
-    const onClickViewTxHandler = (txHash: string) =>
-      FP.pipe(
-        oSourceAsset,
-        O.map(({ chain }) => chain),
-        // Note: As long as we link to `viewblock` to open tx details in a browser,
-        // `0x` needs to be removed from tx hash in case of ETH
-        // @see https://github.com/thorchain/asgardex-electron/issues/1787#issuecomment-931934508
-        O.map((chain) => (isEthChain(chain) ? txHash.replace(/0x/i, '') : txHash)),
-        O.fold(FP.constVoid, goToTransaction)
-      )
+    const oTxHash = FP.pipe(
+      sequenceTOption(oSourceAsset, RD.toOption(swapTx)),
+      // Note: As long as we link to `viewblock` to open tx details in a browser,
+      // `0x` needs to be removed from tx hash in case of ETH
+      // @see https://github.com/thorchain/asgardex-electron/issues/1787#issuecomment-931934508
+      O.map(([{ chain }, txHash]) => (isEthChain(chain) ? txHash.replace(/0x/i, '') : txHash))
+    )
 
     return (
       <TxModal
@@ -859,13 +858,14 @@ export const Swap = ({
         onFinish={onFinishTxModal}
         startTime={swapStartTime}
         txRD={swap}
-        extraResult={<ViewTxButton txHash={RD.toOption(swapTx)} onClick={onClickViewTxHandler} />}
+        extraResult={<ViewTxButton txHash={oTxHash} onClick={goToTransaction} getExplorerTxUrl={getExplorerTxUrl} />}
         timerValue={timerValue}
         extra={extraTxModalContent}
       />
     )
   }, [
     extraTxModalContent,
+    getExplorerTxUrl,
     goToTransaction,
     intl,
     oSourceAsset,

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -858,7 +858,13 @@ export const Swap = ({
         onFinish={onFinishTxModal}
         startTime={swapStartTime}
         txRD={swap}
-        extraResult={<ViewTxButton txHash={oTxHash} onClick={goToTransaction} getExplorerTxUrl={getExplorerTxUrl} />}
+        extraResult={
+          <ViewTxButton
+            txHash={oTxHash}
+            onClick={goToTransaction}
+            txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
+          />
+        }
         timerValue={timerValue}
         extra={extraTxModalContent}
       />

--- a/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
@@ -2,28 +2,26 @@ import React from 'react'
 
 import { Story, Meta } from '@storybook/react'
 import { TxHash } from '@xchainjs/xchain-client'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
+import * as P from 'fp-ts/lib/Predicate'
+import * as S from 'fp-ts/lib/string'
 
-import { GetExplorerTxUrl } from '../../../services/clients'
 import { ViewTxButton } from './ViewTxButton'
 
 const onClick = (txHash: TxHash) => console.log('txHash', txHash)
 
-const getExplorerTxUrl: GetExplorerTxUrl = (txHash: TxHash) => O.some(`url/asset-${txHash}`)
-
 type Args = {
   label: string
+  txUrl: string
   hasTxHash: boolean
 }
 
-const Template: Story<Args> = ({ label, hasTxHash }) => (
-  <ViewTxButton
-    label={label}
-    txHash={hasTxHash ? O.some('hash') : O.none}
-    onClick={onClick}
-    getExplorerTxUrl={getExplorerTxUrl}
-  />
-)
+const Template: Story<Args> = ({ label, hasTxHash, txUrl }) => {
+  const url: O.Option<string> = FP.pipe(txUrl, O.fromPredicate(P.not(S.isEmpty)))
+  const txHash: O.Option<TxHash> = hasTxHash ? O.some('hash') : O.none
+  return <ViewTxButton label={label} txHash={txHash} onClick={onClick} txUrl={url} />
+}
 
 export const Default = Template.bind({})
 
@@ -44,6 +42,13 @@ const meta: Meta<Args> = {
         type: 'text'
       },
       defaultValue: 'See Transaction'
+    },
+    txUrl: {
+      name: 'Tx URL',
+      control: {
+        type: 'text'
+      },
+      defaultValue: 'http://example.url'
     }
   },
   decorators: [

--- a/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
@@ -8,18 +8,36 @@ import { ViewTxButton } from './ViewTxButton'
 
 const onClick = (txHash: TxHash) => console.log('txHash', txHash)
 
-export const Default: Story = () => <ViewTxButton txHash={O.some('hash')} onClick={onClick} />
-Default.storyName = 'default'
+type Args = {
+  label: string
+  hasTxHash: boolean
+}
 
-export const Label: Story = () => <ViewTxButton label="click me" txHash={O.some('hash')} onClick={onClick} />
-Label.storyName = 'label'
+const Template: Story<Args> = ({ label, hasTxHash }) => (
+  <ViewTxButton label={label} txHash={hasTxHash ? O.some('hash') : O.none} onClick={onClick} />
+)
 
-export const Disabled: Story = () => <ViewTxButton txHash={O.none} onClick={onClick} />
-Disabled.storyName = 'disabled'
+export const Default = Template.bind({})
 
-const meta: Meta = {
+const meta: Meta<Args> = {
   component: ViewTxButton,
   title: 'Components/button/ViewTxButton',
+  argTypes: {
+    hasTxHash: {
+      name: 'Has tx hash',
+      control: {
+        type: 'boolean'
+      },
+      defaultValue: false
+    },
+    label: {
+      name: 'Label',
+      control: {
+        type: 'text'
+      },
+      defaultValue: 'See Transaction'
+    }
+  },
   decorators: [
     (S: Story) => (
       <div

--- a/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.stories.tsx
@@ -4,9 +4,12 @@ import { Story, Meta } from '@storybook/react'
 import { TxHash } from '@xchainjs/xchain-client'
 import * as O from 'fp-ts/lib/Option'
 
+import { GetExplorerTxUrl } from '../../../services/clients'
 import { ViewTxButton } from './ViewTxButton'
 
 const onClick = (txHash: TxHash) => console.log('txHash', txHash)
+
+const getExplorerTxUrl: GetExplorerTxUrl = (txHash: TxHash) => O.some(`url/asset-${txHash}`)
 
 type Args = {
   label: string
@@ -14,7 +17,12 @@ type Args = {
 }
 
 const Template: Story<Args> = ({ label, hasTxHash }) => (
-  <ViewTxButton label={label} txHash={hasTxHash ? O.some('hash') : O.none} onClick={onClick} />
+  <ViewTxButton
+    label={label}
+    txHash={hasTxHash ? O.some('hash') : O.none}
+    onClick={onClick}
+    getExplorerTxUrl={getExplorerTxUrl}
+  />
 )
 
 export const Default = Template.bind({})

--- a/src/renderer/components/uielements/button/ViewTxButton.styles.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.styles.tsx
@@ -28,8 +28,6 @@ export const ViewTxButton = styled(UIButton).attrs({
 const ICON_SIZE = 19
 
 export const CopyLabel = styled(A.Typography.Text)`
-  text-transform: uppercase;
-  color: ${palette('primary', 0)};
   svg {
     color: ${palette('primary', 0)};
     height: ${ICON_SIZE}px;

--- a/src/renderer/components/uielements/button/ViewTxButton.styles.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.styles.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 
+import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import { Button as UIButton } from '.'
 import { ExternalLinkIcon as UIExternalLinkIcon } from '../common/Common.styles'
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
 
 const ExternalLinkIcon = styled(UIExternalLinkIcon)`
   svg {
@@ -15,4 +21,18 @@ const ExternalLinkIcon = styled(UIExternalLinkIcon)`
 export const ViewTxButton = styled(UIButton).attrs({
   typevalue: 'transparent',
   icon: <ExternalLinkIcon />
-})``
+})`
+  padding-right: 5px;
+`
+
+const ICON_SIZE = 19
+
+export const CopyLabel = styled(A.Typography.Text)`
+  text-transform: uppercase;
+  color: ${palette('primary', 0)};
+  svg {
+    color: ${palette('primary', 0)};
+    height: ${ICON_SIZE}px;
+    width: ${ICON_SIZE}px;
+  }
+`

--- a/src/renderer/components/uielements/button/ViewTxButton.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.tsx
@@ -5,12 +5,12 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
-import { sequenceTOption } from '../../../helpers/fpHelpers'
+import { GetExplorerTxUrl } from '../../../services/clients'
 import * as Styled from './ViewTxButton.styles'
 
 type Props = {
   label?: string
-  copyable?: boolean
+  getExplorerTxUrl: GetExplorerTxUrl
   txHash: O.Option<TxHash>
   onClick: (txHash: string) => void
   className?: string
@@ -19,9 +19,9 @@ type Props = {
 export const ViewTxButton: React.FC<Props> = ({
   onClick,
   txHash: oTxHash,
+  getExplorerTxUrl,
   label,
-  className,
-  copyable = false
+  className
 }): JSX.Element => {
   const intl = useIntl()
 
@@ -40,10 +40,11 @@ export const ViewTxButton: React.FC<Props> = ({
       <Styled.CopyLabel
         copyable={
           FP.pipe(
-            sequenceTOption(O.fromNullable(copyable), oTxHash),
-            O.map(([_, txHash]) => ({
-              text: txHash,
-              tooltips: intl.formatMessage({ id: 'common.copyTxHash' })
+            oTxHash,
+            O.chain((txHash) => getExplorerTxUrl(txHash)),
+            O.map((url) => ({
+              text: url,
+              tooltips: intl.formatMessage({ id: 'common.copyTxUrl' })
             })),
             O.toUndefined
           ) || false

--- a/src/renderer/components/uielements/button/ViewTxButton.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.tsx
@@ -5,13 +5,12 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
-import { GetExplorerTxUrl } from '../../../services/clients'
 import * as Styled from './ViewTxButton.styles'
 
 type Props = {
   label?: string
-  getExplorerTxUrl: GetExplorerTxUrl
   txHash: O.Option<TxHash>
+  txUrl: O.Option<string>
   onClick: (txHash: string) => void
   className?: string
 }
@@ -19,7 +18,7 @@ type Props = {
 export const ViewTxButton: React.FC<Props> = ({
   onClick,
   txHash: oTxHash,
-  getExplorerTxUrl,
+  txUrl: oTxUrl,
   label,
   className
 }): JSX.Element => {
@@ -40,8 +39,7 @@ export const ViewTxButton: React.FC<Props> = ({
       <Styled.CopyLabel
         copyable={
           FP.pipe(
-            oTxHash,
-            O.chain((txHash) => getExplorerTxUrl(txHash)),
+            oTxUrl,
             O.map((url) => ({
               text: url,
               tooltips: intl.formatMessage({ id: 'common.copyTxUrl' })

--- a/src/renderer/components/uielements/button/ViewTxButton.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.tsx
@@ -32,8 +32,8 @@ export const ViewTxButton: React.FC<Props> = ({
   )
 
   return (
-    <Styled.Wrapper>
-      <Styled.ViewTxButton onClick={onClickHandler} disabled={O.isNone(oTxHash)} className={className}>
+    <Styled.Wrapper className={className}>
+      <Styled.ViewTxButton onClick={onClickHandler} disabled={O.isNone(oTxHash)}>
         {label || intl.formatMessage({ id: 'common.viewTransaction' })}
       </Styled.ViewTxButton>
       <Styled.CopyLabel

--- a/src/renderer/components/uielements/button/ViewTxButton.tsx
+++ b/src/renderer/components/uielements/button/ViewTxButton.tsx
@@ -5,16 +5,24 @@ import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
+import { sequenceTOption } from '../../../helpers/fpHelpers'
 import * as Styled from './ViewTxButton.styles'
 
 type Props = {
   label?: string
+  copyable?: boolean
   txHash: O.Option<TxHash>
   onClick: (txHash: string) => void
   className?: string
 }
 
-export const ViewTxButton: React.FC<Props> = ({ onClick, txHash: oTxHash, label, className }): JSX.Element => {
+export const ViewTxButton: React.FC<Props> = ({
+  onClick,
+  txHash: oTxHash,
+  label,
+  className,
+  copyable = false
+}): JSX.Element => {
   const intl = useIntl()
 
   const onClickHandler = useCallback(
@@ -25,8 +33,22 @@ export const ViewTxButton: React.FC<Props> = ({ onClick, txHash: oTxHash, label,
   )
 
   return (
-    <Styled.ViewTxButton onClick={onClickHandler} disabled={O.isNone(oTxHash)} className={className}>
-      {label || intl.formatMessage({ id: 'common.viewTransaction' })}
-    </Styled.ViewTxButton>
+    <Styled.Wrapper>
+      <Styled.ViewTxButton onClick={onClickHandler} disabled={O.isNone(oTxHash)} className={className}>
+        {label || intl.formatMessage({ id: 'common.viewTransaction' })}
+      </Styled.ViewTxButton>
+      <Styled.CopyLabel
+        copyable={
+          FP.pipe(
+            sequenceTOption(O.fromNullable(copyable), oTxHash),
+            O.map(([_, txHash]) => ({
+              text: txHash,
+              tooltips: intl.formatMessage({ id: 'common.copyTxHash' })
+            })),
+            O.toUndefined
+          ) || false
+        }
+      />
+    </Styled.Wrapper>
   )
 }

--- a/src/renderer/components/wallet/txs/send/Send.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.stories.tsx
@@ -17,6 +17,7 @@ import {
   baseToAsset,
   formatAssetAmount
 } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/lib/Option'
 
 import { Network } from '../../../../../shared/api/types'
 import { BNB_TRANSFER_FEES } from '../../../../../shared/mock/fees'
@@ -41,6 +42,7 @@ const defaultProps = {
     console.log(`view tx handler: ${txHash}`)
     return Promise.resolve(true)
   },
+  getExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
   errorActionHandler: () => console.log('error action')
 }
 

--- a/src/renderer/components/wallet/txs/send/Send.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.tsx
@@ -5,7 +5,7 @@ import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 
-import { OpenExplorerTxUrl } from '../../../../services/clients'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../../services/clients'
 import { TxHashRD } from '../../../../services/wallet/types'
 import { ErrorView } from '../../../shared/error/'
 import { SuccessView } from '../../../shared/success/'
@@ -26,6 +26,7 @@ export type Props = {
   sendForm: JSX.Element
   inititalActionHandler?: FP.Lazy<void>
   viewTxHandler: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
   finishActionHandler?: FP.Lazy<void>
   errorActionHandler?: FP.Lazy<void>
 }
@@ -34,7 +35,8 @@ export const Send: React.FC<Props> = (props): JSX.Element => {
   const {
     txRD,
     inititalActionHandler = FP.constVoid,
-    viewTxHandler = async () => Promise.resolve(),
+    viewTxHandler,
+    getExplorerTxUrl,
     finishActionHandler = FP.constVoid,
     sendForm,
     errorActionHandler = FP.constVoid
@@ -60,11 +62,11 @@ export const Send: React.FC<Props> = (props): JSX.Element => {
           <Styled.SuccessExtraButton onClick={finishActionHandler}>
             {intl.formatMessage({ id: 'common.back' })}
           </Styled.SuccessExtraButton>
-          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} />
+          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} getExplorerTxUrl={getExplorerTxUrl} />
         </Styled.SuccessExtraContainer>
       )
     },
-    [intl, finishActionHandler, viewTxHandler]
+    [finishActionHandler, intl, getExplorerTxUrl, viewTxHandler]
   )
 
   return (

--- a/src/renderer/components/wallet/txs/send/Send.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.tsx
@@ -57,12 +57,13 @@ export const Send: React.FC<Props> = (props): JSX.Element => {
   const renderSuccessExtra = useCallback(
     (txHash: string) => {
       const onClickHandler = () => viewTxHandler(txHash)
+      const txUrl = getExplorerTxUrl(txHash)
       return (
         <Styled.SuccessExtraContainer>
           <Styled.SuccessExtraButton onClick={finishActionHandler}>
             {intl.formatMessage({ id: 'common.back' })}
           </Styled.SuccessExtraButton>
-          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} getExplorerTxUrl={getExplorerTxUrl} />
+          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} txUrl={txUrl} />
         </Styled.SuccessExtraContainer>
       )
     },

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.stories.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Story, Meta } from '@storybook/react'
+import { TxHash } from '@xchainjs/xchain-client'
 import { assetAmount, AssetBNB, AssetRune67C, assetToBase, baseAmount, BNBChain } from '@xchainjs/xchain-util'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
@@ -75,6 +76,7 @@ const defaultProps: UpgradeProps = {
     console.log('success handler ' + txHash)
     return Promise.resolve(true)
   },
+  getExplorerTxUrl: (txHash: TxHash) => O.some(`url/asset-${txHash}`),
   reloadBalancesHandler: () => console.log('reload balances'),
   network: 'testnet'
 }

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -24,7 +24,7 @@ import { useSubscriptionState } from '../../../../hooks/useSubscriptionState'
 import { INITIAL_UPGRADE_RUNE_STATE } from '../../../../services/chain/const'
 import { UpgradeRuneParams, UpgradeRuneTxState, UpgradeRuneTxState$ } from '../../../../services/chain/types'
 import { FeeRD } from '../../../../services/chain/types'
-import { AddressValidation, OpenExplorerTxUrl, WalletBalances } from '../../../../services/clients'
+import { AddressValidation, GetExplorerTxUrl, OpenExplorerTxUrl, WalletBalances } from '../../../../services/clients'
 import { PoolAddressRD } from '../../../../services/midgard/types'
 import { ValidatePasswordHandler } from '../../../../services/wallet/types'
 import { AssetWithDecimal } from '../../../../types/asgardex'
@@ -54,6 +54,7 @@ export type Props = {
   reloadFeeHandler: (params: TxParams) => void
   addressValidation: AddressValidation
   successActionHandler: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
   reloadBalancesHandler: FP.Lazy<void>
   network: Network
   reloadOnError: FP.Lazy<void>
@@ -74,6 +75,7 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
     upgrade$,
     balances: oBalances,
     successActionHandler,
+    getExplorerTxUrl,
     reloadFeeHandler,
     addressValidation,
     reloadBalancesHandler,
@@ -327,11 +329,11 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
           <Styled.SuccessExtraButton onClick={onFinishHandler}>
             {intl.formatMessage({ id: 'common.back' })}
           </Styled.SuccessExtraButton>
-          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} />
+          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} getExplorerTxUrl={getExplorerTxUrl} />
         </Styled.SuccessExtraContainer>
       )
     },
-    [intl, onFinishHandler, successActionHandler]
+    [getExplorerTxUrl, intl, onFinishHandler, successActionHandler]
   )
 
   const addMaxAmountHandler = useCallback(() => setAmountToUpgrade(maxAmount), [maxAmount])

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -324,12 +324,13 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
   const renderSuccessExtra = useCallback(
     (txHash: string) => {
       const onClickHandler = () => successActionHandler(txHash)
+      const txUrl = getExplorerTxUrl(txHash)
       return (
         <Styled.SuccessExtraContainer>
           <Styled.SuccessExtraButton onClick={onFinishHandler}>
             {intl.formatMessage({ id: 'common.back' })}
           </Styled.SuccessExtraButton>
-          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} getExplorerTxUrl={getExplorerTxUrl} />
+          <ViewTxButton txHash={O.some(txHash)} onClick={onClickHandler} txUrl={txUrl} />
         </Styled.SuccessExtraContainer>
       )
     },

--- a/src/renderer/helpers/assetHelper.ts
+++ b/src/renderer/helpers/assetHelper.ts
@@ -24,6 +24,7 @@ import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
+import * as P from 'fp-ts/lib/Predicate'
 
 import { Network } from '../../shared/api/types'
 import {
@@ -236,7 +237,7 @@ export const updateEthChecksumAddress = (asset: Asset): Asset =>
     // ETH chain only
     O.fromPredicate(({ chain }) => isEthChain(chain)),
     // ETH asset only
-    O.chain(O.fromPredicate(FP.not(isEthAsset))),
+    O.chain(O.fromPredicate(P.not(isEthAsset))),
     // Get token address as checksum address
     O.chain(FP.flow(getTokenAddress, O.fromNullable)),
     // Update asset for using a checksum address

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -42,6 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'RUNE Preis',
   'common.transaction': 'Transaktion',
   'common.viewTransaction': 'Transaktion ansehen',
+  'common.copyTxHash': 'Transaktion-Hash kopieren',
   'common.fee': 'Gebühr',
   'common.fees': 'Gebühren',
   'common.fee.estimated': 'Voraussichtliche Gebühr',

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -42,7 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'RUNE Preis',
   'common.transaction': 'Transaktion',
   'common.viewTransaction': 'Transaktion ansehen',
-  'common.copyTxHash': 'Transaktion-Hash kopieren',
+  'common.copyTxUrl': 'Transaktion URL kopieren',
   'common.fee': 'Gebühr',
   'common.fees': 'Gebühren',
   'common.fee.estimated': 'Voraussichtliche Gebühr',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -42,7 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'RUNE price',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'View transaction',
-  'common.copyTxHash': 'Copy transaction hash',
+  'common.copyTxUrl': 'Copy transaction url',
   'common.fee': 'Fee',
   'common.fees': 'Fees',
   'common.fee.estimated': 'Estimated fee',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -42,6 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'RUNE price',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'View transaction',
+  'common.copyTxHash': 'Copy transaction hash',
   'common.fee': 'Fee',
   'common.fees': 'Fees',
   'common.fee.estimated': 'Estimated fee',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -42,7 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'Prix du Rune',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'Afficher la transaction',
-  'common.copyTxHash': 'Copy transaction hash - FR',
+  'common.copyTxUrl': 'Copy transaction url - FR',
   'common.fee': 'Frais',
   'common.fees': 'Frais',
   'common.fee.estimated': 'Frais estimé',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -42,6 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'Prix du Rune',
   'common.transaction': 'Transaction',
   'common.viewTransaction': 'Afficher la transaction',
+  'common.copyTxHash': 'Copy transaction hash - FR',
   'common.fee': 'Frais',
   'common.fees': 'Frais',
   'common.fee.estimated': 'Frais estimé',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -42,6 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'Стоимость RUNE',
   'common.transaction': 'Транзакция',
   'common.viewTransaction': 'Посмотреть транзакцию',
+  'common.copyTxHash': 'Copy transaction hash - RU',
   'common.fee': 'Комиссия',
   'common.fees': 'Комиссии',
   'common.fee.estimated': 'Ориентировочная комиссия',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -42,7 +42,7 @@ const common: CommonMessages = {
   'common.price.rune': 'Стоимость RUNE',
   'common.transaction': 'Транзакция',
   'common.viewTransaction': 'Посмотреть транзакцию',
-  'common.copyTxHash': 'Copy transaction hash - RU',
+  'common.copyTxUrl': 'Copy transaction url - RU',
   'common.fee': 'Комиссия',
   'common.fees': 'Комиссии',
   'common.fee.estimated': 'Ориентировочная комиссия',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -41,7 +41,7 @@ export type CommonMessageKey =
   | 'common.price.rune'
   | 'common.transaction'
   | 'common.viewTransaction'
-  | 'common.copyTxHash'
+  | 'common.copyTxUrl'
   | 'common.fee'
   | 'common.fees'
   | 'common.fee.estimated'

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -41,6 +41,7 @@ export type CommonMessageKey =
   | 'common.price.rune'
   | 'common.transaction'
   | 'common.viewTransaction'
+  | 'common.copyTxHash'
   | 'common.fee'
   | 'common.fees'
   | 'common.fee.estimated'

--- a/src/renderer/services/clients/types.ts
+++ b/src/renderer/services/clients/types.ts
@@ -45,6 +45,7 @@ export type WalletBalancesLD = LiveData<ApiError, WalletBalances>
 
 export type ExplorerUrl$ = Rx.Observable<O.Option<string>>
 export type OpenExplorerTxUrl = (txHash: string) => Promise<boolean>
+export type GetExplorerTxUrl = (txHash: string) => O.Option<string>
 export type OpenAddressUrl = (address: Address, params?: string) => Promise<boolean>
 export type AddressValidation = (address: Address) => boolean
 export type AddressValidationAsync = (address: Address) => Promise<boolean>

--- a/src/renderer/services/midgard/pools.ts
+++ b/src/renderer/services/midgard/pools.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
+import * as P from 'fp-ts/lib/Predicate'
 import * as O from 'fp-ts/Option'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -607,7 +608,7 @@ const createPoolsService = (
                   addresses,
                   A.map(({ chain, halted }) => ({ chain, halted })),
                   // Valid chains only that ones which are NOT included to the halted array
-                  FP.not(A.elem(eqHaltedChain)({ chain, halted: true }))
+                  P.not(A.elem(eqHaltedChain)({ chain, halted: true }))
                 ),
               () => new Error(`Trading for pools on ${chain} chain(s) is halted for maintenance.`)
             )

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -17,6 +17,7 @@ import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
+import * as P from 'fp-ts/lib/Predicate'
 
 import { isUSDAsset, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { isMiniToken } from '../../helpers/binanceHelper'
@@ -61,7 +62,7 @@ export const getPricePools = (details: PoolDetails, whitelist: PricePoolAssets):
     )
   )
 
-  const pricePoolAssets: PricePoolAssets = FP.pipe(whitelist, A.filter(FP.not(isUSDAsset)))
+  const pricePoolAssets: PricePoolAssets = FP.pipe(whitelist, A.filter(P.not(isUSDAsset)))
 
   return FP.pipe(
     details,

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -26,7 +26,6 @@ import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSymDepositAddresses } from '../../../hooks/useSymDepositAddresses'
 import * as poolsRoutes from '../../../routes/pools'
-import { OpenExplorerTxUrl } from '../../../services/clients'
 import { PoolAddress, PoolAssetsRD } from '../../../services/midgard/types'
 import { toPoolData } from '../../../services/midgard/utils'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
@@ -129,9 +128,13 @@ export const SymDepositView: React.FC<Props> = (props) => {
     RD.map(getAssetPoolPrice(runPrice))
   )
 
-  const openAssetExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(asset.chain))
+  const { openExplorerTxUrl: openAssetExplorerTxUrl, getExplorerTxUrl: getAssetExplorerTxUrl } = useOpenExplorerTxUrl(
+    O.some(asset.chain)
+  )
 
-  const openRuneExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+  const { openExplorerTxUrl: openRuneExplorerTxUrl, getExplorerTxUrl: getRuneExplorerTxUrl } = useOpenExplorerTxUrl(
+    O.some(THORChain)
+  )
 
   const fundsCap: O.Option<FundsCap> = useMemo(
     () =>
@@ -171,6 +174,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
           validatePassword$={validatePassword$}
           openRuneExplorerTxUrl={openRuneExplorerTxUrl}
           openAssetExplorerTxUrl={openAssetExplorerTxUrl}
+          getRuneExplorerTxUrl={getRuneExplorerTxUrl}
+          getAssetExplorerTxUrl={getAssetExplorerTxUrl}
           onChangeAsset={FP.constVoid}
           asset={assetWD}
           assetPrice={ZERO_BN}
@@ -211,6 +216,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
       validatePassword$,
       openRuneExplorerTxUrl,
       openAssetExplorerTxUrl,
+      getRuneExplorerTxUrl,
+      getAssetExplorerTxUrl,
       assetWD,
       balancesState,
       symDepositFees$,
@@ -248,6 +255,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
               validatePassword$={validatePassword$}
               openRuneExplorerTxUrl={openRuneExplorerTxUrl}
               openAssetExplorerTxUrl={openAssetExplorerTxUrl}
+              getRuneExplorerTxUrl={getRuneExplorerTxUrl}
+              getAssetExplorerTxUrl={getAssetExplorerTxUrl}
               poolData={toPoolData(poolDetail)}
               onChangeAsset={onChangeAsset}
               asset={assetWD}

--- a/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
+++ b/src/renderer/views/deposit/withdraw/WithdrawDepositView.tsx
@@ -20,7 +20,6 @@ import { getAssetPoolPrice } from '../../../helpers/poolHelper'
 import * as ShareHelpers from '../../../helpers/poolShareHelper'
 import { liveData } from '../../../helpers/rx/liveData'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
-import { OpenExplorerTxUrl } from '../../../services/clients'
 import { DEFAULT_NETWORK } from '../../../services/const'
 import { PoolShare, PoolsDataMap } from '../../../services/midgard/types'
 import { DEFAULT_BALANCES_FILTER } from '../../../services/wallet/const'
@@ -103,7 +102,9 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
     [balances]
   )
 
-  const openRuneExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+  const { openExplorerTxUrl: openRuneExplorerTxUrl, getExplorerTxUrl: getRuneExplorerTxUrl } = useOpenExplorerTxUrl(
+    O.some(THORChain)
+  )
 
   const { network$ } = useAppContext()
   const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
@@ -131,6 +132,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
         disabled
         validatePassword$={validatePassword$}
         openRuneExplorerTxUrl={openRuneExplorerTxUrl}
+        getRuneExplorerTxUrl={getRuneExplorerTxUrl}
         reloadBalances={reloadBalancesAndShares}
         withdraw$={symWithdraw$}
         network={network}
@@ -149,6 +151,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
       reloadWithdrawFees,
       validatePassword$,
       openRuneExplorerTxUrl,
+      getRuneExplorerTxUrl,
       reloadBalancesAndShares,
       symWithdraw$,
       network
@@ -187,6 +190,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
         reloadFees={reloadWithdrawFees}
         validatePassword$={validatePassword$}
         openRuneExplorerTxUrl={openRuneExplorerTxUrl}
+        getRuneExplorerTxUrl={getRuneExplorerTxUrl}
         reloadBalances={reloadBalancesAndShares}
         withdraw$={symWithdraw$}
         network={network}
@@ -206,6 +210,7 @@ export const WithdrawDepositView: React.FC<Props> = (props): JSX.Element => {
       reloadWithdrawFees,
       validatePassword$,
       openRuneExplorerTxUrl,
+      getRuneExplorerTxUrl,
       reloadBalancesAndShares,
       symWithdraw$,
       network

--- a/src/renderer/views/pools/PendingPools.tsx
+++ b/src/renderer/views/pools/PendingPools.tsx
@@ -7,7 +7,7 @@ import { ColumnsType } from 'antd/lib/table'
 import * as A from 'fp-ts/Array'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
-import { Option, none, some } from 'fp-ts/lib/Option'
+import * as P from 'fp-ts/lib/Predicate'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
@@ -60,7 +60,7 @@ export const PendingPools: React.FC<PoolsComponentProps> = ({ haltedChains, mimi
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
 
   // store previous data of pending pools to render these while reloading
-  const previousPools = useRef<Option<PoolTableRowsData>>(none)
+  const previousPools = useRef<O.Option<PoolTableRowsData>>(O.none)
 
   const { poolCycle, reloadPoolCycle } = usePoolCycle()
 
@@ -219,13 +219,13 @@ export const PendingPools: React.FC<PoolsComponentProps> = ({ haltedChains, mimi
         // success state
         ({ poolDetails }: PendingPoolsState): JSX.Element => {
           // filter out empty pools
-          const poolDetailsFiltered = A.filter<PoolDetail>(FP.not(isEmptyPool))(poolDetails)
+          const poolDetailsFiltered = A.filter<PoolDetail>(P.not(isEmptyPool))(poolDetails)
           const poolViewData = getPoolTableRowsData({
             poolDetails: poolDetailsFiltered,
             pricePoolData: selectedPricePool.poolData,
             network
           })
-          previousPools.current = some(poolViewData)
+          previousPools.current = O.some(poolViewData)
           return renderPoolsTable(poolViewData)
         }
       )(poolsRD)}

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -32,7 +32,6 @@ import { useValidateAddress } from '../../hooks/useValidateAddress'
 import { SwapRouteParams } from '../../routes/pools/swap'
 import * as walletRoutes from '../../routes/wallet'
 import { AssetWithDecimalLD, AssetWithDecimalRD } from '../../services/chain/types'
-import { OpenExplorerTxUrl } from '../../services/clients'
 import { DEFAULT_SLIP_TOLERANCE } from '../../services/const'
 import { INITIAL_BALANCES_STATE, DEFAULT_BALANCES_FILTER } from '../../services/wallet/const'
 import { isSlipTolerance, SlipTolerance } from '../../types/asgardex'
@@ -160,7 +159,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
   )
   const oTargetKeystoreAddress = useObservableState(targetKeystoreAddress$, O.none)
 
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const renderError = useCallback(
     (e: Error) => (
@@ -297,6 +296,7 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
                   keystore={keystore}
                   validatePassword$={validatePassword$}
                   goToTransaction={openExplorerTxUrl}
+                  getExplorerTxUrl={getExplorerTxUrl}
                   assets={{ inAsset: sourceAsset, outAsset: targetAsset }}
                   sourceWalletAddress={oSourceKeystoreAddress}
                   sourceLedgerAddress={oSourceLedgerAddress}

--- a/src/renderer/views/wallet/AssetDetailsView.tsx
+++ b/src/renderer/views/wallet/AssetDetailsView.tsx
@@ -23,7 +23,6 @@ import { sequenceTOption } from '../../helpers/fpHelpers'
 import { useMimirHalt } from '../../hooks/useMimirHalt'
 import { useOpenExplorerTxUrl } from '../../hooks/useOpenExplorerTxUrl'
 import { AssetDetailsParams } from '../../routes/wallet'
-import { OpenExplorerTxUrl } from '../../services/clients'
 import { DEFAULT_NETWORK } from '../../services/const'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../services/wallet/const'
 
@@ -130,7 +129,7 @@ export const AssetDetailsView: React.FC = (): JSX.Element => {
     )
   }, [oClient, oWalletAddress])
 
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
+  const { openExplorerTxUrl } = useOpenExplorerTxUrl(
     FP.pipe(
       oRouteAsset,
       O.map(({ chain }) => chain)

--- a/src/renderer/views/wallet/Interact/BondView.tsx
+++ b/src/renderer/views/wallet/Interact/BondView.tsx
@@ -16,6 +16,7 @@ import { ZERO_ASSET_AMOUNT } from '../../../const'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
 import { eqAsset } from '../../../helpers/fp/eq'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_INTERACT_STATE } from '../../../services/thorchain/const'
@@ -27,11 +28,12 @@ type Props = {
   walletType: WalletType
   walletIndex: number
   walletAddress: string
-  goToTransaction: (txHash: string) => void
 }
 
-export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddress, goToTransaction }) => {
+export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddress }) => {
   const { balancesState$ } = useWalletContext()
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const {
     state: interactState,
@@ -106,7 +108,11 @@ export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddre
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={goToTransaction} />
+          <Styled.ViewTxButton
+            txHash={O.some(txHash)}
+            onClick={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+          />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/BondView.tsx
+++ b/src/renderer/views/wallet/Interact/BondView.tsx
@@ -108,11 +108,7 @@ export const BondView: React.FC<Props> = ({ walletType, walletIndex, walletAddre
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton
-            txHash={O.some(txHash)}
-            onClick={openExplorerTxUrl}
-            getExplorerTxUrl={getExplorerTxUrl}
-          />
+          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} txUrl={getExplorerTxUrl(txHash)} />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/CustomView.tsx
+++ b/src/renderer/views/wallet/Interact/CustomView.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { TxHash } from '@xchainjs/xchain-client'
-import { BaseAmount } from '@xchainjs/xchain-util'
+import { BaseAmount, THORChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
@@ -11,6 +10,7 @@ import { WalletType } from '../../../../shared/wallet/types'
 import { Custom } from '../../../components/interact/forms/Custom'
 import { Button } from '../../../components/uielements/button'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_INTERACT_STATE } from '../../../services/thorchain/const'
 import { InteractState } from '../../../services/thorchain/types'
@@ -19,10 +19,9 @@ import * as Styled from './InteractView.styles'
 type Props = {
   walletType: WalletType
   walletIndex: number
-  openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const CustomView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl }) => {
+export const CustomView: React.FC<Props> = ({ walletType, walletIndex }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -31,6 +30,8 @@ export const CustomView: React.FC<Props> = ({ walletType, walletIndex, openExplo
 
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const customTx = useCallback(
     ({ amount, memo }: { amount: BaseAmount; memo: string }) => {
@@ -63,7 +64,11 @@ export const CustomView: React.FC<Props> = ({ walletType, walletIndex, openExplo
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} />
+          <Styled.ViewTxButton
+            txHash={O.some(txHash)}
+            onClick={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+          />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/CustomView.tsx
+++ b/src/renderer/views/wallet/Interact/CustomView.tsx
@@ -64,11 +64,7 @@ export const CustomView: React.FC<Props> = ({ walletType, walletIndex }) => {
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton
-            txHash={O.some(txHash)}
-            onClick={openExplorerTxUrl}
-            getExplorerTxUrl={getExplorerTxUrl}
-          />
+          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} txUrl={getExplorerTxUrl(txHash)} />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/InteractView.styles.tsx
+++ b/src/renderer/views/wallet/Interact/InteractView.styles.tsx
@@ -39,6 +39,4 @@ export const ErrorView = styled(ErrorViewUI)`
   }
 `
 
-export const ViewTxButton = styled(ViewTxButtonUI)`
-  margin-bottom: 15px;
-`
+export const ViewTxButton = styled(ViewTxButtonUI)``

--- a/src/renderer/views/wallet/Interact/InteractView.tsx
+++ b/src/renderer/views/wallet/Interact/InteractView.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
-import { THORChain } from '@xchainjs/xchain-util'
 import { Col, Row } from 'antd'
-import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useParams } from 'react-router'
 
@@ -10,7 +8,6 @@ import { Network } from '../../../../shared/api/types'
 import { Interact } from '../../../components/interact'
 import { BackLink } from '../../../components/uielements/backLink'
 import { useAppContext } from '../../../contexts/AppContext'
-import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import * as walletRoutes from '../../../routes/wallet'
 import { DEFAULT_NETWORK } from '../../../services/const'
 import { BondView } from './BondView'
@@ -27,8 +24,6 @@ export const InteractView: React.FC = () => {
   const { network$ } = useAppContext()
   const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
 
-  const openExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
-
   return (
     <>
       <Row justify="space-between">
@@ -39,23 +34,10 @@ export const InteractView: React.FC = () => {
       <Styled.ContentContainer>
         <Interact
           walletType={walletType}
-          bondContent={
-            <BondView
-              walletType={walletType}
-              walletIndex={walletIndex}
-              walletAddress={walletAddress}
-              goToTransaction={openExplorerTxUrl}
-            />
-          }
-          leaveContent={
-            <LeaveView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
-          }
-          unbondContent={
-            <UnbondView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
-          }
-          customContent={
-            <CustomView walletType={walletType} walletIndex={walletIndex} openExplorerTxUrl={openExplorerTxUrl} />
-          }
+          bondContent={<BondView walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />}
+          leaveContent={<LeaveView walletType={walletType} walletIndex={walletIndex} />}
+          unbondContent={<UnbondView walletType={walletType} walletIndex={walletIndex} />}
+          customContent={<CustomView walletType={walletType} walletIndex={walletIndex} />}
           network={network}
         />
       </Styled.ContentContainer>

--- a/src/renderer/views/wallet/Interact/LeaveView.tsx
+++ b/src/renderer/views/wallet/Interact/LeaveView.tsx
@@ -82,11 +82,7 @@ export const LeaveView: React.FC<Props> = ({ walletType, walletIndex }) => {
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton
-            txHash={O.some(txHash)}
-            onClick={openExplorerTxUrl}
-            getExplorerTxUrl={getExplorerTxUrl}
-          />
+          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} txUrl={getExplorerTxUrl(txHash)} />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/LeaveView.tsx
+++ b/src/renderer/views/wallet/Interact/LeaveView.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { TxHash } from '@xchainjs/xchain-client'
 import { baseAmount, THORChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
@@ -11,6 +10,7 @@ import { WalletType } from '../../../../shared/wallet/types'
 import { Leave } from '../../../components/interact/forms/Leave'
 import { Button } from '../../../components/uielements/button'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_INTERACT_STATE } from '../../../services/thorchain/const'
@@ -20,10 +20,9 @@ import * as Styled from './InteractView.styles'
 type Props = {
   walletType: WalletType
   walletIndex: number
-  openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const LeaveView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl }) => {
+export const LeaveView: React.FC<Props> = ({ walletType, walletIndex }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -32,6 +31,8 @@ export const LeaveView: React.FC<Props> = ({ walletType, walletIndex, openExplor
 
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const { validateAddress } = useValidateAddress(THORChain)
 
@@ -81,7 +82,11 @@ export const LeaveView: React.FC<Props> = ({ walletType, walletIndex, openExplor
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} />
+          <Styled.ViewTxButton
+            txHash={O.some(txHash)}
+            onClick={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+          />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/UnbondView.tsx
+++ b/src/renderer/views/wallet/Interact/UnbondView.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { TxHash } from '@xchainjs/xchain-client'
 import { baseAmount, THORChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
@@ -11,6 +10,7 @@ import { WalletType } from '../../../../shared/wallet/types'
 import { Unbond } from '../../../components/interact/forms/Unbond'
 import { Button } from '../../../components/uielements/button'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_INTERACT_STATE } from '../../../services/thorchain/const'
@@ -20,10 +20,9 @@ import * as Styled from './InteractView.styles'
 type Props = {
   walletType: WalletType
   walletIndex: number
-  openExplorerTxUrl: (txHash: TxHash) => void
 }
 
-export const UnbondView: React.FC<Props> = ({ walletType, walletIndex, openExplorerTxUrl: goToTransaction }) => {
+export const UnbondView: React.FC<Props> = ({ walletType, walletIndex }) => {
   const {
     state: interactState,
     reset: resetInteractState,
@@ -32,6 +31,8 @@ export const UnbondView: React.FC<Props> = ({ walletType, walletIndex, openExplo
 
   const { interact$ } = useThorchainContext()
   const intl = useIntl()
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const { validateAddress } = useValidateAddress(THORChain)
 
@@ -80,7 +81,11 @@ export const UnbondView: React.FC<Props> = ({ walletType, walletIndex, openExplo
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={goToTransaction} />
+          <Styled.ViewTxButton
+            txHash={O.some(txHash)}
+            onClick={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+          />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/Interact/UnbondView.tsx
+++ b/src/renderer/views/wallet/Interact/UnbondView.tsx
@@ -81,11 +81,7 @@ export const UnbondView: React.FC<Props> = ({ walletType, walletIndex }) => {
       ),
       (txHash) => (
         <Styled.SuccessView title={intl.formatMessage({ id: 'common.tx.success' })}>
-          <Styled.ViewTxButton
-            txHash={O.some(txHash)}
-            onClick={openExplorerTxUrl}
-            getExplorerTxUrl={getExplorerTxUrl}
-          />
+          <Styled.ViewTxButton txHash={O.some(txHash)} onClick={openExplorerTxUrl} txUrl={getExplorerTxUrl(txHash)} />
           <Button onClick={resetInteractState}>{intl.formatMessage({ id: 'common.back' })}</Button>
         </Styled.SuccessView>
       )

--- a/src/renderer/views/wallet/history/WalletHistoryView.tsx
+++ b/src/renderer/views/wallet/history/WalletHistoryView.tsx
@@ -39,7 +39,7 @@ export const WalletHistoryView: React.FC<Props> = ({ className, reloadHistory })
   const { requestParams, loadHistory, historyPage, prevHistoryPage, setFilter, setAddress, setPage } =
     useMidgardHistoryActions(10, reloadHistory)
 
-  const openExplorerTxUrl = useOpenExplorerTxUrl(O.some(THORChain))
+  const { openExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const keystoreAddresses$ = useMemo<Rx.Observable<WalletAddresses>>(
     () =>

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -14,21 +14,13 @@ import {
 } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
-import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useParams } from 'react-router'
 
-import { Network } from '../../../../shared/api/types'
 import { ErrorView } from '../../../components/shared/error/'
 import { BackLink } from '../../../components/uielements/backLink'
-import { useAppContext } from '../../../contexts/AppContext'
-import { useWalletContext } from '../../../contexts/WalletContext'
-import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { SendParams } from '../../../routes/wallet'
 import * as walletRoutes from '../../../routes/wallet'
-import { OpenExplorerTxUrl } from '../../../services/clients'
-import { DEFAULT_NETWORK } from '../../../services/const'
-import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { SendViewBNB, SendViewBCH, SendViewBTC, SendViewETH, SendViewDOGE, SendViewTHOR, SendViewLTC } from './index'
 
 type Props = {}
@@ -39,24 +31,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
   const walletIndex = parseInt(walletIndexRoute)
   const intl = useIntl()
 
-  const { network$ } = useAppContext()
-  const network = useObservableState<Network>(network$, DEFAULT_NETWORK)
-
   const oSelectedAsset = useMemo(() => O.fromNullable(assetFromString(asset)), [asset])
-
-  const {
-    balancesState$,
-    keystoreService: { validatePassword$ }
-  } = useWalletContext()
-
-  const [{ balances }] = useObservableState(() => balancesState$(DEFAULT_BALANCES_FILTER), INITIAL_BALANCES_STATE)
-
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
-    FP.pipe(
-      oSelectedAsset,
-      O.map(({ chain }) => chain)
-    )
-  )
 
   const renderAssetError = useMemo(
     () => (
@@ -85,24 +60,10 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
               walletAddress={walletAddress}
               walletIndex={walletIndex}
               asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
             />
           )
         case BCHChain:
-          return (
-            <SendViewBCH
-              walletType={walletType}
-              walletIndex={walletIndex}
-              asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
-            />
-          )
+          return <SendViewBCH walletType={walletType} walletIndex={walletIndex} asset={asset} />
         case BTCChain:
           return (
             <SendViewBTC
@@ -110,24 +71,10 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
               walletIndex={walletIndex}
               walletAddress={walletAddress}
               asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
             />
           )
         case ETHChain:
-          return (
-            <SendViewETH
-              walletType={walletType}
-              walletIndex={walletIndex}
-              asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
-            />
-          )
+          return <SendViewETH walletType={walletType} walletIndex={walletIndex} asset={asset} />
         case THORChain:
           return (
             <SendViewTHOR
@@ -135,36 +82,12 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
               walletIndex={walletIndex}
               walletAddress={walletAddress}
               asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
             />
           )
         case LTCChain:
-          return (
-            <SendViewLTC
-              walletType={walletType}
-              walletIndex={walletIndex}
-              asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
-            />
-          )
+          return <SendViewLTC walletType={walletType} walletIndex={walletIndex} asset={asset} />
         case DOGEChain:
-          return (
-            <SendViewDOGE
-              walletType={walletType}
-              walletIndex={walletIndex}
-              asset={asset}
-              balances={balances}
-              openExplorerTxUrl={openExplorerTxUrl}
-              validatePassword$={validatePassword$}
-              network={network}
-            />
-          )
+          return <SendViewDOGE walletType={walletType} walletIndex={walletIndex} asset={asset} />
         default:
           return (
             <h1>
@@ -178,7 +101,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
           )
       }
     },
-    [walletType, walletAddress, walletIndex, balances, openExplorerTxUrl, validatePassword$, network, intl]
+    [walletType, walletAddress, walletIndex, intl]
   )
 
   return FP.pipe(

--- a/src/renderer/views/wallet/send/SendViewBCH.tsx
+++ b/src/renderer/views/wallet/send/SendViewBCH.tsx
@@ -1,44 +1,58 @@
 import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, BCHChain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
+import { BCHChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
-import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { Send } from '../../../components/wallet/txs/send'
 import { SendFormBCH } from '../../../components/wallet/txs/send'
 import { useBitcoinCashContext } from '../../../contexts/BitcoinCashContext'
 import { useChainContext } from '../../../contexts/ChainContext'
+import { useWalletContext } from '../../../contexts/WalletContext'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useNetwork } from '../../../hooks/useNetwork'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { FeesWithRatesLD } from '../../../services/bitcoincash/types'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { SendTxParams, SendTxState } from '../../../services/chain/types'
-import { OpenExplorerTxUrl, WalletBalances } from '../../../services/clients'
-import { NonEmptyWalletBalances, ValidatePasswordHandler, WalletBalance } from '../../../services/wallet/types'
+import { WalletBalances } from '../../../services/clients'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { WalletBalance } from '../../../services/wallet/types'
 import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
   asset: Asset
-  balances: O.Option<NonEmptyWalletBalances>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  validatePassword$: ValidatePasswordHandler
-  network: Network
 }
 
 export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset } = props
 
   const intl = useIntl()
   const history = useHistory()
+
+  const { network } = useNetwork()
+
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(BCHChain))
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
@@ -121,6 +135,7 @@ export const SendViewBCH: React.FC<Props> = (props): JSX.Element => {
           <Send
             txRD={sendTxState.status}
             viewTxHandler={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
             finishActionHandler={finishActionHandler}
             errorActionHandler={resetSendTxState}
             sendForm={sendForm(walletBalance)}

--- a/src/renderer/views/wallet/send/SendViewDOGE.tsx
+++ b/src/renderer/views/wallet/send/SendViewDOGE.tsx
@@ -8,37 +8,49 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
-import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { Send } from '../../../components/wallet/txs/send'
 import { SendFormDOGE } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useDogeContext } from '../../../contexts/DogeContext'
+import { useWalletContext } from '../../../contexts/WalletContext'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useNetwork } from '../../../hooks/useNetwork'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import type { SendTxParams, SendTxState } from '../../../services/chain/types'
-import { OpenExplorerTxUrl, WalletBalances } from '../../../services/clients'
+import { WalletBalances } from '../../../services/clients'
 import { FeesWithRatesLD } from '../../../services/doge/types'
-import { NonEmptyWalletBalances, ValidatePasswordHandler, WalletBalance } from '../../../services/wallet/types'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { WalletBalance } from '../../../services/wallet/types'
 import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
   asset: Asset
-  balances: O.Option<NonEmptyWalletBalances>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  validatePassword$: ValidatePasswordHandler
-  network: Network
 }
 
 export const SendViewDOGE: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset } = props
 
   const intl = useIntl()
   const history = useHistory()
+
+  const { network } = useNetwork()
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(DOGEChain))
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
@@ -121,6 +133,7 @@ export const SendViewDOGE: React.FC<Props> = (props): JSX.Element => {
         <Send
           txRD={sendTxState.status}
           viewTxHandler={openExplorerTxUrl}
+          getExplorerTxUrl={getExplorerTxUrl}
           finishActionHandler={finishActionHandler}
           errorActionHandler={resetSendTxState}
           sendForm={sendForm(walletBalance)}

--- a/src/renderer/views/wallet/send/SendViewETH.tsx
+++ b/src/renderer/views/wallet/send/SendViewETH.tsx
@@ -2,41 +2,54 @@ import React, { useCallback, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { ETHAddress } from '@xchainjs/xchain-ethereum'
-import { Asset, baseAmount } from '@xchainjs/xchain-util'
+import { Asset, baseAmount, ETHChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
-import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { Send, SendFormETH } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useEthereumContext } from '../../../contexts/EthereumContext'
+import { useWalletContext } from '../../../contexts/WalletContext'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useNetwork } from '../../../hooks/useNetwork'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { SendTxParams, SendTxState } from '../../../services/chain/types'
-import { FeesRD, OpenExplorerTxUrl, WalletBalances } from '../../../services/clients'
-import { NonEmptyWalletBalances, ValidatePasswordHandler, WalletBalance } from '../../../services/wallet/types'
+import { FeesRD, WalletBalances } from '../../../services/clients'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { WalletBalance } from '../../../services/wallet/types'
 import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
   asset: Asset
-  balances: O.Option<NonEmptyWalletBalances>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  network: Network
-  validatePassword$: ValidatePasswordHandler
 }
 
 export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset } = props
 
   const intl = useIntl()
   const history = useHistory()
+
+  const { network } = useNetwork()
+
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(ETHChain))
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
@@ -127,6 +140,7 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
         <Send
           txRD={sendTxState.status}
           viewTxHandler={openExplorerTxUrl}
+          getExplorerTxUrl={getExplorerTxUrl}
           finishActionHandler={finishActionHandler}
           errorActionHandler={finishActionHandler}
           sendForm={sendForm(walletBalance)}

--- a/src/renderer/views/wallet/send/SendViewLTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewLTC.tsx
@@ -8,37 +8,50 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
-import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { Send } from '../../../components/wallet/txs/send/'
 import { SendFormLTC } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useLitecoinContext } from '../../../contexts/LitecoinContext'
+import { useWalletContext } from '../../../contexts/WalletContext'
 import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { useNetwork } from '../../../hooks/useNetwork'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { SendTxParams, SendTxState } from '../../../services/chain/types'
-import { OpenExplorerTxUrl, WalletBalances } from '../../../services/clients'
+import { WalletBalances } from '../../../services/clients'
 import { FeesWithRatesLD } from '../../../services/litecoin/types'
-import { NonEmptyWalletBalances, ValidatePasswordHandler, WalletBalance } from '../../../services/wallet/types'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { WalletBalance } from '../../../services/wallet/types'
 import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
   asset: Asset
-  balances: O.Option<NonEmptyWalletBalances>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  validatePassword$: ValidatePasswordHandler
-  network: Network
 }
 
 export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset, balances: oBalances, openExplorerTxUrl, validatePassword$, network } = props
+  const { walletType, walletIndex, asset } = props
 
   const intl = useIntl()
   const history = useHistory()
+
+  const { network } = useNetwork()
+
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(LTCChain))
 
   const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
 
@@ -121,6 +134,7 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
         <Send
           txRD={sendTxState.status}
           viewTxHandler={openExplorerTxUrl}
+          getExplorerTxUrl={getExplorerTxUrl}
           finishActionHandler={finishActionHandler}
           errorActionHandler={resetSendTxState}
           sendForm={sendForm(walletBalance)}

--- a/src/renderer/views/wallet/send/SendViewTHOR.tsx
+++ b/src/renderer/views/wallet/send/SendViewTHOR.tsx
@@ -9,20 +9,23 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 
-import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { LoadingView } from '../../../components/shared/loading'
 import { Send, SendFormTHOR } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
+import { useWalletContext } from '../../../contexts/WalletContext'
 import { liveData } from '../../../helpers/rx/liveData'
 import { getWalletBalanceByAddress } from '../../../helpers/walletHelper'
+import { useNetwork } from '../../../hooks/useNetwork'
+import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { INITIAL_SEND_STATE } from '../../../services/chain/const'
 import { FeeRD, SendTxParams, SendTxState } from '../../../services/chain/types'
-import { OpenExplorerTxUrl, WalletBalances } from '../../../services/clients'
-import { NonEmptyWalletBalances, ValidatePasswordHandler, WalletBalance } from '../../../services/wallet/types'
+import { WalletBalances } from '../../../services/clients'
+import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
+import { WalletBalance } from '../../../services/wallet/types'
 import * as Helper from './SendView.helper'
 
 type Props = {
@@ -30,26 +33,26 @@ type Props = {
   walletIndex: number
   walletAddress: Address
   asset: Asset
-  balances: O.Option<NonEmptyWalletBalances>
-  openExplorerTxUrl: OpenExplorerTxUrl
-  validatePassword$: ValidatePasswordHandler
-  network: Network
 }
 
 export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
-  const {
-    walletType,
-    walletIndex,
-    walletAddress,
-    asset,
-    balances: oBalances,
-    openExplorerTxUrl,
-    validatePassword$,
-    network
-  } = props
+  const { walletType, walletIndex, walletAddress, asset } = props
 
   const intl = useIntl()
   const history = useHistory()
+
+  const { network } = useNetwork()
+  const {
+    balancesState$,
+    keystoreService: { validatePassword$ }
+  } = useWalletContext()
+
+  const [{ balances: oBalances }] = useObservableState(
+    () => balancesState$(DEFAULT_BALANCES_FILTER),
+    INITIAL_BALANCES_STATE
+  )
+
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(THORChain))
 
   const oWalletBalance = useMemo(
     () =>
@@ -144,6 +147,7 @@ export const SendViewTHOR: React.FC<Props> = (props): JSX.Element => {
         <Send
           txRD={sendTxState.status}
           viewTxHandler={openExplorerTxUrl}
+          getExplorerTxUrl={getExplorerTxUrl}
           finishActionHandler={finishActionHandler}
           errorActionHandler={finishActionHandler}
           sendForm={sendForm(walletBalance)}

--- a/src/renderer/views/wallet/upgrade/UpgradeView.tsx
+++ b/src/renderer/views/wallet/upgrade/UpgradeView.tsx
@@ -26,7 +26,6 @@ import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { AssetDetailsParams } from '../../../routes/wallet'
 import { AssetWithDecimalLD, AssetWithDecimalRD } from '../../../services/chain/types'
-import { OpenExplorerTxUrl } from '../../../services/clients'
 import { DEFAULT_NETWORK } from '../../../services/const'
 import { PoolAddressRD } from '../../../services/midgard/types'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
@@ -169,7 +168,7 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
     )
   }, [reloadInboundAddresses, reloadBalancesByChain, oRuneNonNativeAsset, oBalances, targetPoolAddressRD])
 
-  const openExplorerTxUrl: OpenExplorerTxUrl = useOpenExplorerTxUrl(
+  const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(
     FP.pipe(
       oRuneNonNativeAsset,
       O.map(({ chain }) => chain)
@@ -205,6 +204,7 @@ export const UpgradeView: React.FC<Props> = (): JSX.Element => {
                     upgrade$: upgradeRuneToNative$,
                     balances: oBalances,
                     successActionHandler: openExplorerTxUrl,
+                    getExplorerTxUrl,
                     reloadBalancesHandler: reloadBalancesByChain(runeAsset.asset.chain),
                     network,
                     reloadOnError

--- a/src/renderer/views/wallet/upgrade/types.ts
+++ b/src/renderer/views/wallet/upgrade/types.ts
@@ -5,7 +5,7 @@ import * as O from 'fp-ts/Option'
 import { Network } from '../../../../shared/api/types'
 import { WalletType } from '../../../../shared/wallet/types'
 import { UpgradeRuneParams, UpgradeRuneTxState$ } from '../../../services/chain/types'
-import { AddressValidation, OpenExplorerTxUrl } from '../../../services/clients'
+import { AddressValidation, GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../services/clients'
 import { PoolAddressRD } from '../../../services/midgard/types'
 import { NonEmptyWalletBalances, ValidatePasswordHandler } from '../../../services/wallet/types'
 import { AssetWithDecimal } from '../../../types/asgardex'
@@ -22,6 +22,7 @@ export type CommonUpgradeProps = {
   upgrade$: (_: UpgradeRuneParams) => UpgradeRuneTxState$
   balances: O.Option<NonEmptyWalletBalances>
   successActionHandler: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
   reloadBalancesHandler: FP.Lazy<void>
   network: Network
   reloadOnError: FP.Lazy<void>


### PR DESCRIPTION
![Peek 2022-02-21 20-48](https://user-images.githubusercontent.com/61792675/155019741-cfda6dab-51c0-48c5-89cc-a48debfe6289.gif)

- [x] Add `Copy` tx url button to `ViewTxButton` (used in `TxModal`, misc. success views etc.)
- [x] Refactor `SendView` + `Send{XYZ}View`s to push down less props
- [x] Update stories

Close #1998