### PR TITLE
Use TxModal in Send{View|Form}BNB

### DIFF
--- a/src/renderer/components/modal/tx/TxModal.tsx
+++ b/src/renderer/components/modal/tx/TxModal.tsx
@@ -54,6 +54,8 @@ export const TxModal: React.FC<Props> = (props): JSX.Element => {
       color: 'success',
       disabled: false,
       onClick: onClose,
+      sizevalue: 'xnormal',
+      round: 'true',
       children: <>{intl.formatMessage({ id: 'common.finish' })}</>
     }
 

--- a/src/renderer/components/modal/tx/extra/SendAsset.tsx
+++ b/src/renderer/components/modal/tx/extra/SendAsset.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { Network } from '../../../../../shared/api/types'
+import * as Styled from './Common.styles'
+import * as C from './Common.types'
+
+export type Props = {
+  asset: C.AssetData
+  title: string
+  network: Network
+}
+
+export const SendAsset: React.FC<Props> = (props): JSX.Element => {
+  const { asset, title, network } = props
+  return (
+    <>
+      <Styled.StepLabel>{title}</Styled.StepLabel>
+      <Styled.DataWrapper>
+        <Styled.AssetsContainer>
+          <Styled.AssetData size="big" asset={asset.asset} amount={asset.amount} network={network} />
+        </Styled.AssetsContainer>
+      </Styled.DataWrapper>
+    </>
+  )
+}

--- a/src/renderer/components/modal/tx/extra/SwapAssets.stories.tsx
+++ b/src/renderer/components/modal/tx/extra/SwapAssets.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 
 import { Story, Meta } from '@storybook/react'
-import { assetAmount, AssetBNB, AssetRuneNative, assetToBase, bn } from '@xchainjs/xchain-util'
+import { assetAmount, AssetBNB, AssetRuneNative, assetToBase } from '@xchainjs/xchain-util'
 
 import { SwapAssets, Props } from './SwapAssets'
 
 const defaultProps: Props = {
   stepDescription: 'step 1',
-  slip: bn(1),
   source: { asset: AssetRuneNative, amount: assetToBase(assetAmount(30)) },
   target: { asset: AssetBNB, amount: assetToBase(assetAmount(1)) },
   network: 'testnet'

--- a/src/renderer/components/modal/tx/extra/SwapAssets.styles.tsx
+++ b/src/renderer/components/modal/tx/extra/SwapAssets.styles.tsx
@@ -1,9 +1,0 @@
-import styled from 'styled-components'
-
-import { Trend as UITrend } from '../../../uielements/trend'
-
-export const Trend = styled(UITrend)`
-  width: 100%;
-  padding-top: 20px;
-  justify-content: center; /* overridden */
-`

--- a/src/renderer/components/modal/tx/extra/SwapAssets.tsx
+++ b/src/renderer/components/modal/tx/extra/SwapAssets.tsx
@@ -1,22 +1,18 @@
 import React from 'react'
 
-import BigNumber from 'bignumber.js'
-
 import { Network } from '../../../../../shared/api/types'
 import * as Styled from './Common.styles'
 import * as C from './Common.types'
-import * as SwapStyled from './SwapAssets.styles'
 
 export type Props = {
   source: C.AssetData
   target: C.AssetData
-  slip?: BigNumber
   stepDescription: string
   network: Network
 }
 
 export const SwapAssets: React.FC<Props> = (props): JSX.Element => {
-  const { source, target, stepDescription, network, slip } = props
+  const { source, target, stepDescription, network } = props
   return (
     <>
       <Styled.StepLabel>{stepDescription}</Styled.StepLabel>
@@ -27,7 +23,6 @@ export const SwapAssets: React.FC<Props> = (props): JSX.Element => {
           <Styled.AssetData asset={target.asset} amount={target.amount} network={network} />
         </Styled.AssetsContainer>
       </Styled.DataWrapper>
-      {slip && <SwapStyled.Trend amount={slip} />}
     </>
   )
 }

--- a/src/renderer/components/wallet/account/AccountSelector.styles.ts
+++ b/src/renderer/components/wallet/account/AccountSelector.styles.ts
@@ -21,7 +21,7 @@ export const AssetInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  margin-left: 16px;
+  margin-left: 30px;
 `
 
 export const AssetTitleWrapper = styled.div`
@@ -29,18 +29,18 @@ export const AssetTitleWrapper = styled.div`
   align-items: center;
 `
 export const AssetTitle = styled.div`
-  font-size: 32px;
+  font-size: 36px;
   font-family: 'MainFontRegular';
   color: ${palette('text', 0)};
-  line-height: 34px;
+  line-height: 100%;
   text-transform: uppercase;
 `
 
 export const AssetSubTitle = styled.div`
-  font-size: 17px;
+  font-size: 19px;
   font-family: 'MainFontRegular';
   color: ${palette('text', 2)};
-  line-height: 21px;
+  line-height: 26px;
   text-transform: uppercase;
 `
 

--- a/src/renderer/components/wallet/account/AccountSelector.tsx
+++ b/src/renderer/components/wallet/account/AccountSelector.tsx
@@ -18,7 +18,7 @@ import * as Styled from './AccountSelector.styles'
 
 type Props = {
   selectedWallet: WalletBalance
-  walletBalances: WalletBalances
+  walletBalances?: WalletBalances
   onChange?: (params: { asset: Asset; walletAddress: Address; walletType: WalletType; walletIndex: number }) => void
   size?: IconSize
   network: Network
@@ -30,7 +30,7 @@ const filterFunction = ({ asset }: WalletBalance, searchTerm: string) => {
 }
 
 export const AccountSelector: React.FC<Props> = (props): JSX.Element => {
-  const { selectedWallet, walletBalances, onChange = (_) => {}, size = 'large', network } = props
+  const { selectedWallet, walletBalances = [], onChange = (_) => {}, size = 'large', network } = props
 
   const intl = useIntl()
 

--- a/src/renderer/components/wallet/txs/TxForm.helpers.tsx
+++ b/src/renderer/components/wallet/txs/TxForm.helpers.tsx
@@ -1,10 +1,15 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
+import { Asset } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
+import { IntlShape } from 'react-intl'
 
 import { WalletType } from '../../../../shared/wallet/types'
+import { emptyString } from '../../../helpers/stringHelper'
 import { getWalletByAddress } from '../../../helpers/walletHelper'
 import { WalletBalances } from '../../../services/clients'
+import { TxHashRD } from '../../../services/wallet/types'
 import { WalletTypeLabel } from '../../uielements/common/Common.styles'
 import * as Styled from './TxForm.styles'
 
@@ -25,4 +30,41 @@ export const matchedWalletType = (balances: WalletBalances, recipientAddress: Ad
   FP.pipe(
     getWalletByAddress(balances, recipientAddress),
     O.map(({ walletType }) => walletType)
+  )
+
+export const getSendTxTimerValue = (status: TxHashRD) =>
+  FP.pipe(
+    status,
+    RD.fold(
+      () => 0,
+      FP.flow(
+        O.map(({ loaded }) => loaded),
+        O.getOrElse(() => 0)
+      ),
+      () => 0,
+      () => 100
+    )
+  )
+
+export const getSendTxDescription = ({
+  status,
+  asset,
+  intl
+}: {
+  status: TxHashRD
+  asset: Asset
+  intl: IntlShape
+}): string =>
+  FP.pipe(
+    status,
+    RD.fold(
+      () => emptyString,
+      () =>
+        `${intl.formatMessage({ id: 'common.step' }, { current: 1, total: 1 })}: ${intl.formatMessage(
+          { id: 'common.tx.sendingAsset' },
+          { assetTicker: asset.ticker }
+        )}`,
+      () => emptyString,
+      () => intl.formatMessage({ id: 'common.tx.success' })
+    )
   )

--- a/src/renderer/components/wallet/txs/send/Send.helpers.ts
+++ b/src/renderer/components/wallet/txs/send/Send.helpers.ts
@@ -1,0 +1,21 @@
+import * as RD from '@devexperts/remote-data-ts'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+
+import { TxHashRD } from '../../../../services/wallet/types'
+
+export const sendTxTimerValue = (
+  status: TxHashRD // Get timer value
+) =>
+  FP.pipe(
+    status,
+    RD.fold(
+      () => 0,
+      FP.flow(
+        O.map(({ loaded }) => loaded),
+        O.getOrElse(() => 0)
+      ),
+      () => 0,
+      () => 100
+    )
+  )

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
@@ -6,11 +6,8 @@ import { Asset, BNBChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
-import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { WalletType } from '../../../../shared/wallet/types'
-import { Send } from '../../../components/wallet/txs/send'
 import { SendFormBNB } from '../../../components/wallet/txs/send'
 import { useBinanceContext } from '../../../contexts/BinanceContext'
 import { useChainContext } from '../../../contexts/ChainContext'
@@ -19,14 +16,10 @@ import { liveData } from '../../../helpers/rx/liveData'
 import { getWalletBalanceByAddressAndAsset } from '../../../helpers/walletHelper'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
-import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
-import { INITIAL_SEND_STATE } from '../../../services/chain/const'
-import { FeeRD, SendTxParams, SendTxState } from '../../../services/chain/types'
+import { FeeRD } from '../../../services/chain/types'
 import { WalletBalances } from '../../../services/clients'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
-import { WalletBalance } from '../../../services/wallet/types'
-import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
@@ -37,9 +30,6 @@ type Props = {
 
 export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
   const { walletAddress, asset, walletType, walletIndex } = props
-
-  const intl = useIntl()
-  const history = useHistory()
 
   const { network } = useNetwork()
 
@@ -66,19 +56,6 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
 
   const { transfer$ } = useChainContext()
 
-  const {
-    state: sendTxState,
-    reset: resetSendTxState,
-    subscribe: subscribeSendTxState
-  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
-
-  const onSend = useCallback(
-    (params: SendTxParams) => {
-      subscribeSendTxState(transfer$(params))
-    },
-    [subscribeSendTxState, transfer$]
-  )
-
   const { fees$, reloadFees } = useBinanceContext()
 
   const [feeRD] = useObservableState<FeeRD>(
@@ -90,75 +67,30 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
     RD.initial
   )
 
-  /**
-   * Address validation provided by BinanceClient
-   */
   const { validateAddress } = useValidateAddress(BNBChain)
-
-  const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
-
-  const sendTxStatusMsg = useMemo(
-    () => Helper.sendTxStatusMsg({ sendTxState, asset, intl }),
-    [asset, intl, sendTxState]
-  )
-
-  /**
-   * Custom send form used by BNB chain only
-   */
-  const sendForm = useCallback(
-    (walletBalance: WalletBalance) => (
-      <SendFormBNB
-        walletType={walletType}
-        walletIndex={walletIndex}
-        balances={FP.pipe(
-          oBalances,
-          O.getOrElse<WalletBalances>(() => [])
-        )}
-        balance={walletBalance}
-        isLoading={isLoading}
-        walletAddress={walletAddress}
-        onSubmit={onSend}
-        addressValidation={validateAddress}
-        fee={feeRD}
-        reloadFeesHandler={reloadFees}
-        validatePassword$={validatePassword$}
-        sendTxStatusMsg={sendTxStatusMsg}
-        network={network}
-      />
-    ),
-    [
-      walletType,
-      walletIndex,
-      oBalances,
-      isLoading,
-      walletAddress,
-      onSend,
-      validateAddress,
-      feeRD,
-      reloadFees,
-      validatePassword$,
-      sendTxStatusMsg,
-      network
-    ]
-  )
-
-  const finishActionHandler = useCallback(() => {
-    resetSendTxState()
-    history.goBack()
-  }, [history, resetSendTxState])
 
   return FP.pipe(
     oWalletBalance,
     O.fold(
       () => <></>,
       (walletBalance) => (
-        <Send
-          txRD={sendTxState.status}
-          viewTxHandler={openExplorerTxUrl}
+        <SendFormBNB
+          walletType={walletType}
+          walletIndex={walletIndex}
+          balances={FP.pipe(
+            oBalances,
+            O.getOrElse<WalletBalances>(() => [])
+          )}
+          balance={walletBalance}
+          transfer$={transfer$}
+          openExplorerTxUrl={openExplorerTxUrl}
           getExplorerTxUrl={getExplorerTxUrl}
-          finishActionHandler={finishActionHandler}
-          errorActionHandler={finishActionHandler}
-          sendForm={sendForm(walletBalance)}
+          walletAddress={walletAddress}
+          addressValidation={validateAddress}
+          fee={feeRD}
+          reloadFeesHandler={reloadFees}
+          validatePassword$={validatePassword$}
+          network={network}
         />
       )
     )


### PR DESCRIPTION
## Preview Storybook

https://user-images.githubusercontent.com/61792675/155386252-1b2ea0f8-531b-4121-859f-005136235973.mp4

## Changes
- [x] Refactor `SendViewBNB` + `SendFormBNB` to get rid of success + error views to use TxModal only
- [x] Update stories
- [x] Update `transfer$` service to provide data needed by TxModal
- [x] Add `SendAsset` (used by TxModal)
- [x] Remove `slip` from `SwapAssets`
- [x] Remove unneeded `SwapAssets.styles.tsx`
- [x] Update styles of `TxModal`
- [x] Make `walletBalances`optional in `AccountSelector` (balances might be removed in the future)


Part of #2073 