### PR TITLE
Use TxModal in `Send{View|Form}BTC`

### DIFF
--- a/src/renderer/components/wallet/txs/send/Send.shared.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.shared.tsx
@@ -1,0 +1,71 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import { IntlShape } from 'react-intl'
+
+import { Network } from '../../../../../shared/api/types'
+import { SendTxState } from '../../../../services/chain/types'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../../services/clients'
+import { TxModal } from '../../../modal/tx'
+import { SendAsset } from '../../../modal/tx/extra/SendAsset'
+import { ViewTxButton } from '../../../uielements/button'
+import * as H from '../TxForm.helpers'
+
+export const renderTxModal = ({
+  asset,
+  amountToSend,
+  network,
+  sendTxState,
+  resetSendTxState,
+  sendTxStartTime,
+  openExplorerTxUrl,
+  getExplorerTxUrl,
+  intl
+}: {
+  asset: Asset
+  amountToSend: BaseAmount
+  network: Network
+  sendTxState: SendTxState
+  resetSendTxState: FP.Lazy<void>
+  sendTxStartTime: number
+  openExplorerTxUrl: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
+  intl: IntlShape
+}) => {
+  const { status } = sendTxState
+
+  // don't render TxModal in initial state
+  if (RD.isInitial(status)) return <></>
+
+  const oTxHash = RD.toOption(status)
+  const txRD = FP.pipe(
+    status,
+    RD.map((txHash) => !!txHash)
+  )
+
+  return (
+    <TxModal
+      title={intl.formatMessage({ id: 'common.tx.sending' })}
+      onClose={resetSendTxState}
+      onFinish={resetSendTxState}
+      startTime={sendTxStartTime}
+      txRD={txRD}
+      extraResult={
+        <ViewTxButton
+          txHash={oTxHash}
+          onClick={openExplorerTxUrl}
+          txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
+        />
+      }
+      timerValue={H.getSendTxTimerValue(status)}
+      extra={
+        <SendAsset
+          asset={{ asset, amount: amountToSend }}
+          title={H.getSendTxDescription({ status, asset, intl })}
+          network={network}
+        />
+      }
+    />
+  )
+}

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.stories.tsx
@@ -88,7 +88,7 @@ const meta: Meta<Args> = {
   argTypes: {
     txRDStatus: {
       name: 'txRDStatus',
-      control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] },
+      control: { type: 'select', options: ['pending', 'error', 'success'] },
       defaultValue: 'success'
     },
     feeRDStatus: {

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -33,9 +33,6 @@ import { AddressValidation, GetExplorerTxUrl, OpenExplorerTxUrl, WalletBalances 
 import { ValidatePasswordHandler } from '../../../../services/wallet/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../modal/confirmation'
-import { TxModal } from '../../../modal/tx'
-import { SendAsset } from '../../../modal/tx/extra/SendAsset'
-import { ViewTxButton } from '../../../uielements/button'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { UIFeesRD } from '../../../uielements/fees'
 import { Input, InputBigNumber } from '../../../uielements/input'
@@ -44,6 +41,7 @@ import * as H from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
 import { useChangeAssetHandler } from './Send.hooks'
+import * as Shared from './Send.shared'
 
 export type FormValues = {
   recipient: Address
@@ -244,58 +242,34 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
     }
   }, [intl, network, submitTx, showConfirmationModal, validatePassword$, walletType])
 
-  const extraTxModalContent = useMemo(() => {
-    const { status } = sendTxState
-    const title = H.getSendTxDescription({ status, asset, intl })
-    return <SendAsset asset={{ asset, amount: amountToSend }} title={title} network={network} />
-  }, [intl, asset, sendTxState, amountToSend, network])
-
   // Send tx start time
   const [sendTxStartTime, setSendTxStartTime] = useState<number>(0)
 
-  const onFinishTxModal = useCallback(() => {
-    resetSendTxState()
-  }, [resetSendTxState])
-
-  const renderTxModal = useMemo(() => {
-    const { status } = sendTxState
-
-    // don't render TxModal in initial state
-    if (RD.isInitial(status)) return <></>
-
-    const oTxHash = RD.toOption(status)
-    const txRD = FP.pipe(
-      status,
-      RD.map((txHash) => !!txHash)
-    )
-    return (
-      <TxModal
-        title={intl.formatMessage({ id: 'common.tx.sending' })}
-        onClose={resetSendTxState}
-        onFinish={onFinishTxModal}
-        startTime={sendTxStartTime}
-        txRD={txRD}
-        extraResult={
-          <ViewTxButton
-            txHash={oTxHash}
-            onClick={openExplorerTxUrl}
-            txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
-          />
-        }
-        timerValue={H.getSendTxTimerValue(status)}
-        extra={extraTxModalContent}
-      />
-    )
-  }, [
-    sendTxState,
-    resetSendTxState,
-    onFinishTxModal,
-    sendTxStartTime,
-    openExplorerTxUrl,
-    getExplorerTxUrl,
-    extraTxModalContent,
-    intl
-  ])
+  const renderTxModal = useMemo(
+    () =>
+      Shared.renderTxModal({
+        asset,
+        amountToSend,
+        network,
+        sendTxState,
+        resetSendTxState,
+        sendTxStartTime,
+        openExplorerTxUrl,
+        getExplorerTxUrl,
+        intl
+      }),
+    [
+      asset,
+      amountToSend,
+      network,
+      sendTxState,
+      resetSendTxState,
+      sendTxStartTime,
+      openExplorerTxUrl,
+      getExplorerTxUrl,
+      intl
+    ]
+  )
 
   const uiFeesRD: UIFeesRD = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.stories.tsx
@@ -1,104 +1,132 @@
 import React from 'react'
 
-import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
 import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
-import { Address, FeeRates, Fees, FeeType } from '@xchainjs/xchain-client'
-import { assetAmount, AssetBTC, assetToBase, baseAmount, formatBaseAmount } from '@xchainjs/xchain-util'
+import { Address, FeeRates, Fees, FeesWithRates, FeeType, TxHash } from '@xchainjs/xchain-client'
+import { assetAmount, AssetBTC, assetToBase, baseAmount } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
 
+import { getMockRDValueFactory, RDStatus } from '../../../../../shared/mock/rdByStatus'
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { WalletType } from '../../../../../shared/wallet/types'
 import { THORCHAIN_DECIMAL } from '../../../../helpers/assetHelper'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/chain/types'
-import { WalletBalance } from '../../../../services/wallet/types'
-import { SendFormBTC as Component, Props as ComponentProps } from './SendFormBTC'
+import { FeesWithRatesRD } from '../../../../services/bitcoin/types'
+import { SendTxStateHandler } from '../../../../services/chain/types'
+import { ApiError, ErrorId, WalletBalance } from '../../../../services/wallet/types'
+import { SendFormBTC as Component } from './SendFormBTC'
 
-const btcBalance: WalletBalance = mockWalletBalance({
-  asset: AssetBTC,
-  amount: assetToBase(assetAmount(1.23, BTC_DECIMAL)),
-  walletAddress: 'btc wallet address'
-})
-
-const runeBalance: WalletBalance = mockWalletBalance({
-  amount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
-})
-
-const fees: Fees = {
-  type: FeeType.FlatFee,
-  fastest: baseAmount(3000),
-  fast: baseAmount(2000),
-  average: baseAmount(1000)
+type Args = {
+  txRDStatus: RDStatus
+  feeRDStatus: RDStatus
+  balance: string
+  validAddress: boolean
+  walletType: WalletType
 }
 
-const rates: FeeRates = {
-  fastest: 5,
-  fast: 3,
-  average: 2
-}
+const Template: Story<Args> = ({ txRDStatus, feeRDStatus, balance, validAddress, walletType }) => {
+  const transfer$: SendTxStateHandler = (_) =>
+    Rx.of({
+      steps: { current: txRDStatus === 'initial' ? 0 : 1, total: 1 },
+      status: FP.pipe(
+        txRDStatus,
+        getMockRDValueFactory<ApiError, TxHash>(
+          () => 'tx-hash',
+          () => ({
+            msg: 'error message',
+            errorId: ErrorId.SEND_TX
+          })
+        )
+      )
+    })
 
-const defaultProps: ComponentProps = {
-  walletType: 'keystore',
-  walletIndex: 0,
-  walletAddress: 'btc-address',
-  balances: [btcBalance, runeBalance],
-  balance: btcBalance,
-  onSubmit: ({ recipient, amount, feeOption, memo }: SendTxParams) =>
-    console.log(`to: ${recipient}, amount ${formatBaseAmount(amount)}, feeOptionKey: ${feeOption}, memo: ${memo}`),
-  isLoading: false,
-  addressValidation: (_: Address) => true,
-  feesWithRates: RD.success({ fees, rates }),
-  reloadFeesHandler: () => console.log('reload fees'),
-  validatePassword$: mockValidatePassword$,
-  sendTxStatusMsg: '',
-  network: 'testnet'
-}
+  const btcBalance: WalletBalance = mockWalletBalance({
+    asset: AssetBTC,
+    amount: assetToBase(assetAmount(balance, BTC_DECIMAL)),
+    walletAddress: 'btc wallet address'
+  })
 
-export const Default: Story = () => <Component {...defaultProps} />
-Default.storyName = 'default'
+  const runeBalance: WalletBalance = mockWalletBalance({
+    amount: assetToBase(assetAmount(2, THORCHAIN_DECIMAL))
+  })
 
-export const Pending: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    isLoading: true,
-    sendTxStatusMsg: 'step 1 / 2'
+  const fees: Fees = {
+    type: FeeType.FlatFee,
+    fastest: baseAmount(3000),
+    fast: baseAmount(2000),
+    average: baseAmount(1000)
   }
-  return <Component {...props} />
-}
-Pending.storyName = 'pending'
 
-export const FeesInitial: Story = () => {
-  const props: ComponentProps = { ...defaultProps, feesWithRates: RD.initial }
-  return <Component {...props} />
-}
-FeesInitial.storyName = 'fees initial'
-
-export const FeesLoading: Story = () => {
-  const props: ComponentProps = { ...defaultProps, feesWithRates: RD.pending }
-  return <Component {...props} />
-}
-FeesLoading.storyName = 'fees loading'
-
-export const FeesFailure: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    feesWithRates: RD.failure(Error('Could not load fees and rates for any reason'))
+  const rates: FeeRates = {
+    fastest: 5,
+    fast: 3,
+    average: 2
   }
-  return <Component {...props} />
-}
-FeesFailure.storyName = 'fees failure'
 
-export const FeesNotCovered: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    balance: { ...btcBalance, amount: baseAmount(1, BTC_DECIMAL) }
-  }
-  return <Component {...props} />
-}
-FeesNotCovered.storyName = 'fees not covered'
+  const feesWithRates: FeesWithRatesRD = FP.pipe(
+    feeRDStatus,
+    getMockRDValueFactory<Error, FeesWithRates>(
+      () => ({ fees, rates }),
+      () => Error('getting fees failed')
+    )
+  )
 
-const meta: Meta = {
+  return (
+    <Component
+      walletType={walletType}
+      walletIndex={0}
+      walletAddress={'btc-address'}
+      transfer$={transfer$}
+      balances={[btcBalance, runeBalance]}
+      balance={btcBalance}
+      addressValidation={(_: Address) => validAddress}
+      feesWithRates={feesWithRates}
+      reloadFeesHandler={() => console.log('reload fees')}
+      validatePassword$={mockValidatePassword$}
+      network="testnet"
+      openExplorerTxUrl={(txHash: TxHash) => {
+        console.log(`Open explorer - tx hash ${txHash}`)
+        return Promise.resolve(true)
+      }}
+      getExplorerTxUrl={(txHash: TxHash) => O.some(`url/asset-${txHash}`)}
+    />
+  )
+}
+
+export const Default = Template.bind({})
+
+const meta: Meta<Args> = {
   component: Component,
-  title: 'Wallet/SendFormBTC'
+  title: 'Wallet/SendFormBTC',
+  argTypes: {
+    txRDStatus: {
+      name: 'txRDStatus',
+      control: { type: 'select', options: ['pending', 'error', 'success'] },
+      defaultValue: 'success'
+    },
+    feeRDStatus: {
+      name: 'feeRD',
+      control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] },
+      defaultValue: 'success'
+    },
+    walletType: {
+      name: 'wallet type',
+      control: { type: 'select', options: ['keystore', 'ledger'] },
+      defaultValue: 'keystore'
+    },
+    balance: {
+      name: 'BTC Balance',
+      control: { type: 'text' },
+      defaultValue: '2'
+    },
+    validAddress: {
+      name: 'valid address',
+      control: { type: 'boolean' },
+      defaultValue: true
+    }
+  }
 }
 
 export default meta

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
@@ -94,7 +94,7 @@ const meta: Meta<Args> = {
       defaultValue: 'keystore'
     },
     balance: {
-      name: 'BNB Balance',
+      name: 'RUNE Balance',
       control: { type: 'text' },
       defaultValue: '2'
     },

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.stories.tsx
@@ -80,7 +80,7 @@ const meta: Meta<Args> = {
   argTypes: {
     txRDStatus: {
       name: 'txRDStatus',
-      control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] },
+      control: { type: 'select', options: ['pending', 'error', 'success'] },
       defaultValue: 'success'
     },
     feeRDStatus: {

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -33,9 +33,6 @@ import { AddressValidation, GetExplorerTxUrl, OpenExplorerTxUrl, WalletBalances 
 import { ValidatePasswordHandler } from '../../../../services/wallet/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../modal/confirmation'
-import { TxModal } from '../../../modal/tx'
-import { SendAsset } from '../../../modal/tx/extra/SendAsset'
-import { ViewTxButton } from '../../../uielements/button'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { UIFeesRD } from '../../../uielements/fees'
 import { Input, InputBigNumber } from '../../../uielements/input'
@@ -44,6 +41,7 @@ import * as H from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
 import { useChangeAssetHandler } from './Send.hooks'
+import * as Shared from './Send.shared'
 
 export type FormValues = {
   recipient: string
@@ -245,55 +243,31 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
     }
   }, [intl, network, submitTx, showConfirmationModal, validatePassword$, walletType])
 
-  const extraTxModalContent = useMemo(() => {
-    const { status } = sendTxState
-    const title = H.getSendTxDescription({ status, asset, intl })
-    return <SendAsset asset={{ asset, amount: amountToSend }} title={title} network={network} />
-  }, [intl, asset, sendTxState, amountToSend, network])
-
-  const onFinishTxModal = useCallback(() => {
-    resetSendTxState()
-  }, [resetSendTxState])
-
-  const renderTxModal = useMemo(() => {
-    const { status } = sendTxState
-
-    // don't render TxModal in initial state
-    if (RD.isInitial(status)) return <></>
-
-    const oTxHash = RD.toOption(status)
-    const txRD = FP.pipe(
-      status,
-      RD.map((txHash) => !!txHash)
-    )
-    return (
-      <TxModal
-        title={intl.formatMessage({ id: 'common.tx.sending' })}
-        onClose={resetSendTxState}
-        onFinish={onFinishTxModal}
-        startTime={sendTxStartTime}
-        txRD={txRD}
-        extraResult={
-          <ViewTxButton
-            txHash={oTxHash}
-            onClick={openExplorerTxUrl}
-            txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
-          />
-        }
-        timerValue={H.getSendTxTimerValue(status)}
-        extra={extraTxModalContent}
-      />
-    )
-  }, [
-    sendTxState,
-    resetSendTxState,
-    onFinishTxModal,
-    sendTxStartTime,
-    openExplorerTxUrl,
-    getExplorerTxUrl,
-    extraTxModalContent,
-    intl
-  ])
+  const renderTxModal = useMemo(
+    () =>
+      Shared.renderTxModal({
+        asset,
+        amountToSend,
+        network,
+        sendTxState,
+        resetSendTxState,
+        sendTxStartTime,
+        openExplorerTxUrl,
+        getExplorerTxUrl,
+        intl
+      }),
+    [
+      asset,
+      amountToSend,
+      network,
+      sendTxState,
+      resetSendTxState,
+      sendTxStartTime,
+      openExplorerTxUrl,
+      getExplorerTxUrl,
+      intl
+    ]
+  )
 
   const uiFeesRD: UIFeesRD = useMemo(
     () =>

--- a/src/renderer/services/chain/transaction/transfer.ts
+++ b/src/renderer/services/chain/transaction/transfer.ts
@@ -24,7 +24,7 @@ export const transfer$: SendTxStateHandler = (params) => {
     set: setState
   } = observableState<SendTxState>({
     ...INITIAL_SEND_STATE,
-    status: RD.progress({ loaded: 75, total }),
+    status: RD.progress({ loaded: 40, total }),
     steps: { current: 1, total: 1 }
   })
 

--- a/src/renderer/views/wallet/send/SendViewBTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewBTC.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
@@ -6,27 +6,19 @@ import { Asset, BTCChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
-import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { WalletType } from '../../../../shared/wallet/types'
-import { Send } from '../../../components/wallet/txs/send/'
 import { SendFormBTC } from '../../../components/wallet/txs/send/'
 import { useBitcoinContext } from '../../../contexts/BitcoinContext'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
-import { getWalletBalanceByAssetAndWalletType } from '../../../helpers/walletHelper'
+import { getWalletBalanceByAddress } from '../../../helpers/walletHelper'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
-import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
 import { FeesWithRatesLD } from '../../../services/bitcoin/types'
-import { INITIAL_SEND_STATE } from '../../../services/chain/const'
-import { SendTxParams, SendTxState } from '../../../services/chain/types'
 import { WalletBalances } from '../../../services/clients'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
-import { WalletBalance } from '../../../services/wallet/types'
-import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
@@ -36,10 +28,7 @@ type Props = {
 }
 
 export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, walletAddress, asset } = props
-
-  const intl = useIntl()
-  const history = useHistory()
+  const { walletType, walletIndex, walletAddress } = props
 
   const { network } = useNetwork()
 
@@ -56,24 +45,15 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
   const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(BTCChain))
 
   const oWalletBalance = useMemo(
-    () => getWalletBalanceByAssetAndWalletType({ oWalletBalances: oBalances, asset, walletType }),
-    [oBalances, asset, walletType]
+    () =>
+      FP.pipe(
+        oBalances,
+        O.chain((balances) => getWalletBalanceByAddress(balances, walletAddress))
+      ),
+    [oBalances, walletAddress]
   )
 
   const { transfer$ } = useChainContext()
-
-  const {
-    state: sendTxState,
-    reset: resetSendTxState,
-    subscribe: subscribeSendTxState
-  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
-
-  const onSend = useCallback(
-    (params: SendTxParams) => {
-      subscribeSendTxState(transfer$(params))
-    },
-    [subscribeSendTxState, transfer$]
-  )
 
   const { feesWithRates$, reloadFeesWithRates } = useBitcoinContext()
 
@@ -82,69 +62,28 @@ export const SendViewBTC: React.FC<Props> = (props): JSX.Element => {
 
   const { validateAddress } = useValidateAddress(BTCChain)
 
-  const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
-
-  const sendTxStatusMsg = useMemo(
-    () => Helper.sendTxStatusMsg({ sendTxState, asset, intl }),
-    [asset, intl, sendTxState]
-  )
-  /**
-   * Custom send form used by BTC only
-   */
-  const sendForm = useCallback(
-    (walletBalance: WalletBalance) => (
-      <SendFormBTC
-        walletType={walletType}
-        walletIndex={walletIndex}
-        walletAddress={walletAddress}
-        balances={FP.pipe(
-          oBalances,
-          O.getOrElse<WalletBalances>(() => [])
-        )}
-        balance={walletBalance}
-        isLoading={isLoading}
-        onSubmit={onSend}
-        addressValidation={validateAddress}
-        feesWithRates={feesWithRatesRD}
-        reloadFeesHandler={reloadFeesWithRates}
-        validatePassword$={validatePassword$}
-        sendTxStatusMsg={sendTxStatusMsg}
-        network={network}
-      />
-    ),
-    [
-      walletType,
-      walletIndex,
-      walletAddress,
-      oBalances,
-      isLoading,
-      onSend,
-      validateAddress,
-      feesWithRatesRD,
-      reloadFeesWithRates,
-      validatePassword$,
-      sendTxStatusMsg,
-      network
-    ]
-  )
-
-  const finishActionHandler = useCallback(() => {
-    resetSendTxState()
-    history.goBack()
-  }, [history, resetSendTxState])
-
   return FP.pipe(
     oWalletBalance,
     O.fold(
       () => <></>,
       (walletBalance) => (
-        <Send
-          txRD={sendTxState.status}
-          viewTxHandler={openExplorerTxUrl}
+        <SendFormBTC
+          walletType={walletType}
+          walletIndex={walletIndex}
+          walletAddress={walletAddress}
+          balances={FP.pipe(
+            oBalances,
+            O.getOrElse<WalletBalances>(() => [])
+          )}
+          balance={walletBalance}
+          transfer$={transfer$}
+          openExplorerTxUrl={openExplorerTxUrl}
           getExplorerTxUrl={getExplorerTxUrl}
-          finishActionHandler={finishActionHandler}
-          errorActionHandler={resetSendTxState}
-          sendForm={sendForm(walletBalance)}
+          addressValidation={validateAddress}
+          feesWithRates={feesWithRatesRD}
+          reloadFeesHandler={reloadFeesWithRates}
+          validatePassword$={validatePassword$}
+          network={network}
         />
       )
     )


### PR DESCRIPTION
- [x] Extract `renderTxModal` into `Send.shared`
- [x] Use `TxModal` in `Send{View|Form}BTC`

## Storybook

![Screenshot from 2022-02-24 12-59-51](https://user-images.githubusercontent.com/61792675/155519952-bd4f4666-900a-4296-b2e3-4766b90b688c.png)

Part of #2073