### PR TITLE
Use `TxModal` in `Send{View|Form}LTC`

### DIFF
--- a/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
+import { BCH_DECIMAL } from '@xchainjs/xchain-bitcoincash'
 import { Address, FeeOption, FeesWithRates } from '@xchainjs/xchain-client'
 import {
   assetAmount,
@@ -40,7 +40,6 @@ import { matchedWalletType, renderedWalletType } from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
 import { DEFAULT_FEE_OPTION } from './Send.const'
-import { useChangeAssetHandler } from './Send.hooks'
 import * as Shared from './Send.shared'
 
 export type FormValues = {
@@ -86,8 +85,6 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
 
   const { asset } = balance
-
-  const changeAssetHandler = useChangeAssetHandler()
 
   const [amountToSend, setAmountToSend] = useState<BaseAmount>(ZERO_BASE_AMOUNT)
 
@@ -291,12 +288,22 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
         sender: walletAddress,
         recipient: form.getFieldValue('recipient'),
         asset,
-        amount: assetToBase(assetAmount(form.getFieldValue('amount'))),
+        amount: amountToSend,
         feeOption: selectedFeeOptionKey,
         memo: form.getFieldValue('memo')
       })
     )
-  }, [subscribeSendTxState, transfer$, walletType, walletIndex, walletAddress, form, asset, selectedFeeOptionKey])
+  }, [
+    subscribeSendTxState,
+    transfer$,
+    walletType,
+    walletIndex,
+    walletAddress,
+    form,
+    asset,
+    amountToSend,
+    selectedFeeOptionKey
+  ])
 
   // State for visibility of Modal to confirm tx
   const [showPwModal, setShowPwModal] = useState(false)
@@ -356,7 +363,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
       // we have to validate input before storing into the state
       amountValidator(undefined, value)
         .then(() => {
-          setAmountToSend(assetToBase(assetAmount(value)))
+          setAmountToSend(assetToBase(assetAmount(value, BCH_DECIMAL)))
         })
         .catch(() => {}) // do nothing, Ant' form does the job for us to show an error message
     },
@@ -398,12 +405,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
     <>
       <Row>
         <Styled.Col span={24}>
-          <AccountSelector
-            onChange={changeAssetHandler}
-            selectedWallet={balance}
-            walletBalances={balances}
-            network={network}
-          />
+          <AccountSelector selectedWallet={balance} network={network} />
           <Styled.Form
             form={form}
             initialValues={{
@@ -428,7 +430,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
                   min={0}
                   size="large"
                   disabled={isLoading}
-                  decimal={BTC_DECIMAL}
+                  decimal={BCH_DECIMAL}
                   onChange={onChangeInput}
                 />
               </Styled.FormItem>

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -23,7 +23,7 @@ import { Network } from '../../../../../shared/api/types'
 import { isKeystoreWallet, isLedgerWallet } from '../../../../../shared/utils/guard'
 import { WalletType } from '../../../../../shared/wallet/types'
 import { ZERO_BASE_AMOUNT } from '../../../../const'
-import { isBnbAsset } from '../../../../helpers/assetHelper'
+import { BNB_DECIMAL, isBnbAsset } from '../../../../helpers/assetHelper'
 import { sequenceTOption } from '../../../../helpers/fpHelpers'
 import { getBnbAmountFromBalances } from '../../../../helpers/walletHelper'
 import { useSubscriptionState } from '../../../../hooks/useSubscriptionState'
@@ -40,7 +40,6 @@ import { AccountSelector } from '../../account'
 import * as H from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
-import { useChangeAssetHandler } from './Send.hooks'
 import * as Shared from './Send.shared'
 
 export type FormValues = {
@@ -85,8 +84,6 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
 
   const { asset } = balance
-
-  const changeAssetHandler = useChangeAssetHandler()
 
   const [amountToSend, setAmountToSend] = useState<BaseAmount>(ZERO_BASE_AMOUNT)
 
@@ -286,7 +283,7 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
       // we have to validate input before storing into the state
       amountValidator(undefined, value)
         .then(() => {
-          setAmountToSend(assetToBase(assetAmount(value)))
+          setAmountToSend(assetToBase(assetAmount(value, BNB_DECIMAL)))
         })
         .catch(() => {}) // do nothing, Ant' form does the job for us to show an error message
     },
@@ -311,7 +308,7 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
     <>
       <Row>
         <Styled.Col span={24}>
-          <AccountSelector onChange={changeAssetHandler} selectedWallet={balance} network={network} />
+          <AccountSelector selectedWallet={balance} network={network} />
           <Styled.Form
             form={form}
             initialValues={{ amount: bn(0) }}

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -42,7 +42,6 @@ import * as H from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
 import { DEFAULT_FEE_OPTION } from './Send.const'
-import { useChangeAssetHandler } from './Send.hooks'
 import * as Shared from './Send.shared'
 
 export type FormValues = {
@@ -88,8 +87,6 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
 
   const { asset } = balance
-
-  const changeAssetHandler = useChangeAssetHandler()
 
   const [amountToSend, setAmountToSend] = useState<BaseAmount>(ZERO_BASE_AMOUNT)
 
@@ -290,12 +287,22 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
         sender: walletAddress,
         recipient: form.getFieldValue('recipient'),
         asset: asset,
-        amount: assetToBase(assetAmount(form.getFieldValue('amount'))),
+        amount: amountToSend,
         feeOption: selectedFeeOption,
         memo: form.getFieldValue('memo')
       })
     )
-  }, [subscribeSendTxState, transfer$, walletType, walletIndex, walletAddress, form, asset, selectedFeeOption])
+  }, [
+    subscribeSendTxState,
+    transfer$,
+    walletType,
+    walletIndex,
+    walletAddress,
+    form,
+    asset,
+    amountToSend,
+    selectedFeeOption
+  ])
 
   const [showConfirmationModal, setShowConfirmationModal] = useState(false)
 
@@ -377,7 +384,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
       // we have to validate input before storing into the state
       amountValidator(undefined, value)
         .then(() => {
-          setAmountToSend(assetToBase(assetAmount(value)))
+          setAmountToSend(assetToBase(assetAmount(value, BTC_DECIMAL)))
         })
         .catch(() => {}) // do nothing, Ant' form does the job for us to show an error message
     },
@@ -415,12 +422,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
     <>
       <Row>
         <Styled.Col span={24}>
-          <AccountSelector
-            onChange={changeAssetHandler}
-            selectedWallet={balance}
-            walletBalances={balances}
-            network={network}
-          />
+          <AccountSelector selectedWallet={balance} network={network} />
           <Styled.Form
             form={form}
             initialValues={{

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.stories.tsx
@@ -1,102 +1,128 @@
-import React from 'react'
-
-import * as RD from '@devexperts/remote-data-ts'
 import { Meta, Story } from '@storybook/react'
-import { Fees, FeeRates, FeeType } from '@xchainjs/xchain-client'
+import { Fees, FeeRates, FeeType, Address, TxHash, FeesWithRates } from '@xchainjs/xchain-client'
 import { LTC_DECIMAL } from '@xchainjs/xchain-litecoin'
-import { assetAmount, AssetLTC, assetToBase, baseAmount, formatBaseAmount } from '@xchainjs/xchain-util'
+import { assetAmount, AssetLTC, assetToBase, baseAmount } from '@xchainjs/xchain-util'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as Rx from 'rxjs'
 
+import { getMockRDValueFactory, RDStatus } from '../../../../../shared/mock/rdByStatus'
 import { mockValidatePassword$ } from '../../../../../shared/mock/wallet'
+import { WalletType } from '../../../../../shared/wallet/types'
 import { mockWalletBalance } from '../../../../helpers/test/testWalletHelper'
-import { SendTxParams } from '../../../../services/chain/types'
-import { WalletBalance } from '../../../../services/wallet/types'
-import { SendFormLTC as Component, Props as ComponentProps } from './SendFormLTC'
+import { SendTxStateHandler } from '../../../../services/chain/types'
+import { FeesWithRatesRD } from '../../../../services/litecoin/types'
+import { ApiError, ErrorId, WalletBalance } from '../../../../services/wallet/types'
+import { SendFormLTC as Component } from './SendFormLTC'
 
-const ltcBalance: WalletBalance = mockWalletBalance({
-  asset: AssetLTC,
-  amount: assetToBase(assetAmount(1.23, LTC_DECIMAL)),
-  walletAddress: 'ltc wallet address'
-})
-
-const runeBalance: WalletBalance = mockWalletBalance({
-  amount: assetToBase(assetAmount(2, LTC_DECIMAL))
-})
-
-const fees: Fees = {
-  type: FeeType.FlatFee,
-  fastest: baseAmount(3000),
-  fast: baseAmount(2000),
-  average: baseAmount(1000)
+type Args = {
+  txRDStatus: RDStatus
+  feeRDStatus: RDStatus
+  balance: string
+  validAddress: boolean
+  walletType: WalletType
 }
 
-const rates: FeeRates = {
-  fastest: 5,
-  fast: 3,
-  average: 2
-}
+const Template: Story<Args> = ({ txRDStatus, feeRDStatus, balance, validAddress, walletType }) => {
+  const transfer$: SendTxStateHandler = (_) =>
+    Rx.of({
+      steps: { current: txRDStatus === 'initial' ? 0 : 1, total: 1 },
+      status: FP.pipe(
+        txRDStatus,
+        getMockRDValueFactory<ApiError, TxHash>(
+          () => 'tx-hash',
+          () => ({
+            msg: 'error message',
+            errorId: ErrorId.SEND_TX
+          })
+        )
+      )
+    })
 
-const defaultProps: ComponentProps = {
-  walletType: 'keystore',
-  walletIndex: 0,
-  balances: [ltcBalance, runeBalance],
-  balance: ltcBalance,
-  onSubmit: ({ recipient, amount, feeOption, memo }: SendTxParams) =>
-    console.log(`to: ${recipient}, amount ${formatBaseAmount(amount)}, feeOptionKey: ${feeOption}, memo: ${memo}`),
-  isLoading: false,
-  addressValidation: (_) => true,
-  feesWithRates: RD.success({ fees, rates }),
-  reloadFeesHandler: () => console.log('reload fees'),
-  validatePassword$: mockValidatePassword$,
-  sendTxStatusMsg: '',
-  network: 'testnet'
-}
+  const ltcBalance: WalletBalance = mockWalletBalance({
+    asset: AssetLTC,
+    amount: assetToBase(assetAmount(balance, LTC_DECIMAL)),
+    walletAddress: 'ltc wallet address'
+  })
 
-export const Default: Story = () => <Component {...defaultProps} />
-Default.storyName = 'default'
+  const runeBalance: WalletBalance = mockWalletBalance({
+    amount: assetToBase(assetAmount(2, LTC_DECIMAL))
+  })
 
-export const Pending: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    isLoading: true,
-    sendTxStatusMsg: 'step 1 / 2'
+  const fees: Fees = {
+    type: FeeType.FlatFee,
+    fastest: baseAmount(3000),
+    fast: baseAmount(2000),
+    average: baseAmount(1000)
   }
-  return <Component {...props} />
-}
-Pending.storyName = 'pending'
 
-export const FeesInitial: Story = () => {
-  const props: ComponentProps = { ...defaultProps, feesWithRates: RD.initial }
-  return <Component {...props} />
-}
-FeesInitial.storyName = 'fees initial'
-
-export const FeesLoading: Story = () => {
-  const props: ComponentProps = { ...defaultProps, feesWithRates: RD.pending }
-  return <Component {...props} />
-}
-FeesLoading.storyName = 'fees loading'
-
-export const FeesFailure: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    feesWithRates: RD.failure(Error('Could not load fees and rates for any reason'))
+  const rates: FeeRates = {
+    fastest: 5,
+    fast: 3,
+    average: 2
   }
-  return <Component {...props} />
-}
-FeesFailure.storyName = 'fees failure'
 
-export const FeesNotCovered: Story = () => {
-  const props: ComponentProps = {
-    ...defaultProps,
-    balance: { ...ltcBalance, amount: baseAmount(1, LTC_DECIMAL) }
-  }
-  return <Component {...props} />
-}
-FeesNotCovered.storyName = 'fees not covered'
+  const feesWithRates: FeesWithRatesRD = FP.pipe(
+    feeRDStatus,
+    getMockRDValueFactory<Error, FeesWithRates>(
+      () => ({ fees, rates }),
+      () => Error('getting fees failed')
+    )
+  )
 
+  return (
+    <Component
+      walletType={walletType}
+      walletIndex={0}
+      walletAddress={'ltc-address'}
+      transfer$={transfer$}
+      balances={[ltcBalance, runeBalance]}
+      balance={ltcBalance}
+      addressValidation={(_: Address) => validAddress}
+      feesWithRates={feesWithRates}
+      reloadFeesHandler={() => console.log('reload fees')}
+      validatePassword$={mockValidatePassword$}
+      network="testnet"
+      openExplorerTxUrl={(txHash: TxHash) => {
+        console.log(`Open explorer - tx hash ${txHash}`)
+        return Promise.resolve(true)
+      }}
+      getExplorerTxUrl={(txHash: TxHash) => O.some(`url/asset-${txHash}`)}
+    />
+  )
+}
+
+export const Default = Template.bind({})
 const meta: Meta = {
   component: Component,
-  title: 'Wallet/SendFormLTC'
+  title: 'Wallet/SendFormLTC',
+  argTypes: {
+    txRDStatus: {
+      name: 'txRDStatus',
+      control: { type: 'select', options: ['pending', 'error', 'success'] },
+      defaultValue: 'success'
+    },
+    feeRDStatus: {
+      name: 'feeRD',
+      control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] },
+      defaultValue: 'success'
+    },
+    walletType: {
+      name: 'wallet type',
+      control: { type: 'select', options: ['keystore', 'ledger'] },
+      defaultValue: 'keystore'
+    },
+    balance: {
+      name: 'LTC balance',
+      control: { type: 'text' },
+      defaultValue: '2'
+    },
+    validAddress: {
+      name: 'valid address',
+      control: { type: 'boolean' },
+      defaultValue: true
+    }
+  }
 }
 
 export default meta

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -40,7 +40,6 @@ import { AccountSelector } from '../../account'
 import * as H from '../TxForm.helpers'
 import * as Styled from '../TxForm.styles'
 import { validateTxAmountInput } from '../TxForm.util'
-import { useChangeAssetHandler } from './Send.hooks'
 import * as Shared from './Send.shared'
 
 export type FormValues = {
@@ -83,8 +82,6 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
   const intl = useIntl()
 
   const { asset } = balance
-
-  const changeAssetHandler = useChangeAssetHandler()
 
   const [amountToSend, setAmountToSend] = useState<BaseAmount>(ZERO_BASE_AMOUNT)
 
@@ -309,7 +306,7 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
     <>
       <Row>
         <Styled.Col span={24}>
-          <AccountSelector onChange={changeAssetHandler} selectedWallet={balance} network={network} />
+          <AccountSelector selectedWallet={balance} network={network} />
           <Styled.Form
             form={form}
             initialValues={{ amount: bn(0) }}

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -63,7 +63,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
             />
           )
         case BCHChain:
-          return <SendViewBCH walletAddress={walletAddress} walletType={walletType} walletIndex={walletIndex} />
+          return <SendViewBCH walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case BTCChain:
           return <SendViewBTC walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case ETHChain:
@@ -71,7 +71,7 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
         case THORChain:
           return <SendViewTHOR walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case LTCChain:
-          return <SendViewLTC walletType={walletType} walletIndex={walletIndex} asset={asset} />
+          return <SendViewLTC walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case DOGEChain:
           return <SendViewDOGE walletType={walletType} walletIndex={walletIndex} asset={asset} />
         default:

--- a/src/renderer/views/wallet/send/SendViewLTC.tsx
+++ b/src/renderer/views/wallet/send/SendViewLTC.tsx
@@ -1,43 +1,33 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
-import { Asset, LTCChain } from '@xchainjs/xchain-util'
+import { Address } from '@xchainjs/xchain-client'
+import { LTCChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/Option'
 import { useObservableState } from 'observable-hooks'
-import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { WalletType } from '../../../../shared/wallet/types'
-import { Send } from '../../../components/wallet/txs/send/'
 import { SendFormLTC } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useLitecoinContext } from '../../../contexts/LitecoinContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
-import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { getWalletBalanceByAddress } from '../../../helpers/walletHelper'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
-import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
 import { useValidateAddress } from '../../../hooks/useValidateAddress'
-import { INITIAL_SEND_STATE } from '../../../services/chain/const'
-import { SendTxParams, SendTxState } from '../../../services/chain/types'
 import { WalletBalances } from '../../../services/clients'
 import { FeesWithRatesLD } from '../../../services/litecoin/types'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
-import { WalletBalance } from '../../../services/wallet/types'
-import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
-  asset: Asset
+  walletAddress: Address
 }
 
 export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset } = props
-
-  const intl = useIntl()
-  const history = useHistory()
+  const { walletType, walletIndex, walletAddress } = props
 
   const { network } = useNetwork()
 
@@ -53,22 +43,16 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
 
   const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(LTCChain))
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
+  const oWalletBalance = useMemo(
+    () =>
+      FP.pipe(
+        oBalances,
+        O.chain((balances) => getWalletBalanceByAddress(balances, walletAddress))
+      ),
+    [oBalances, walletAddress]
+  )
 
   const { transfer$ } = useChainContext()
-
-  const {
-    state: sendTxState,
-    reset: resetSendTxState,
-    subscribe: subscribeSendTxState
-  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
-
-  const onSend = useCallback(
-    (params: SendTxParams) => {
-      subscribeSendTxState(transfer$(params))
-    },
-    [subscribeSendTxState, transfer$]
-  )
 
   const { feesWithRates$, reloadFeesWithRates } = useLitecoinContext()
 
@@ -77,67 +61,28 @@ export const SendViewLTC: React.FC<Props> = (props): JSX.Element => {
 
   const { validateAddress } = useValidateAddress(LTCChain)
 
-  const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
-
-  const sendTxStatusMsg = useMemo(
-    () => Helper.sendTxStatusMsg({ sendTxState, asset, intl }),
-    [asset, intl, sendTxState]
-  )
-  /**
-   * Custom send form used by LTC only
-   */
-  const sendForm = useCallback(
-    (walletBalance: WalletBalance) => (
-      <SendFormLTC
-        walletType={walletType}
-        walletIndex={walletIndex}
-        balances={FP.pipe(
-          oBalances,
-          O.getOrElse<WalletBalances>(() => [])
-        )}
-        balance={walletBalance}
-        isLoading={isLoading}
-        onSubmit={onSend}
-        addressValidation={validateAddress}
-        feesWithRates={feesWithRatesRD}
-        reloadFeesHandler={reloadFeesWithRates}
-        validatePassword$={validatePassword$}
-        sendTxStatusMsg={sendTxStatusMsg}
-        network={network}
-      />
-    ),
-    [
-      walletType,
-      walletIndex,
-      oBalances,
-      isLoading,
-      onSend,
-      validateAddress,
-      feesWithRatesRD,
-      reloadFeesWithRates,
-      validatePassword$,
-      sendTxStatusMsg,
-      network
-    ]
-  )
-
-  const finishActionHandler = useCallback(() => {
-    resetSendTxState()
-    history.goBack()
-  }, [history, resetSendTxState])
-
   return FP.pipe(
     oWalletBalance,
     O.fold(
       () => <></>,
       (walletBalance) => (
-        <Send
-          txRD={sendTxState.status}
-          viewTxHandler={openExplorerTxUrl}
+        <SendFormLTC
+          walletType={walletType}
+          walletIndex={walletIndex}
+          walletAddress={walletAddress}
+          balances={FP.pipe(
+            oBalances,
+            O.getOrElse<WalletBalances>(() => [])
+          )}
+          balance={walletBalance}
+          transfer$={transfer$}
+          openExplorerTxUrl={openExplorerTxUrl}
           getExplorerTxUrl={getExplorerTxUrl}
-          finishActionHandler={finishActionHandler}
-          errorActionHandler={resetSendTxState}
-          sendForm={sendForm(walletBalance)}
+          addressValidation={validateAddress}
+          feesWithRates={feesWithRatesRD}
+          reloadFeesHandler={reloadFeesWithRates}
+          validatePassword$={validatePassword$}
+          network={network}
         />
       )
     )


### PR DESCRIPTION
- [x] Use `TxModal` in `Send{View|Form}LTC`
- [x] Remove deprecated `changeAssetHandler`
- [x] Use `amountToSend` in `transfer$` 

![Screenshot from 2022-02-24 16-06-41](https://user-images.githubusercontent.com/61792675/155551378-3c15de98-d587-45cf-8321-b5b20128b6b0.png)


Part of #2073