### PR TITLE
Use `TxModal` in `Send{View|Form}ETH`

### DIFF
--- a/src/renderer/components/modal/confirmation/WalletPasswordConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/WalletPasswordConfirmationModal.tsx
@@ -7,7 +7,7 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 
 import { ValidatePasswordLD } from '../../../services/wallet/types'
-import { Input } from '../../uielements/input'
+import { InputPassword } from '../../uielements/input'
 import { Label } from '../../uielements/label'
 import * as Styled from './ConfirmationModal.styles'
 import * as CStyled from './WalletPasswordConfirmationModal.styles'
@@ -82,8 +82,7 @@ const PasswordModal: React.FC<PasswordModalProps> = (props): JSX.Element => {
             extra={
               validatingPassword ? `${intl.formatMessage({ id: 'wallet.password.confirmation.pending' })}...` : ''
             }>
-            <Input
-              type="password"
+            <InputPassword
               typevalue="normal"
               size="large"
               value={password}

--- a/src/renderer/components/uielements/input/Input.styles.ts
+++ b/src/renderer/components/uielements/input/Input.styles.ts
@@ -97,7 +97,9 @@ export const InputNumber = styled(A.InputNumber)<InputProps>`
   }
 `
 
-export const InputPassword = styled(A.Input.Password)<InputProps>`
+export const InputPassword = styled(A.Input.Password).attrs({
+  type: 'password'
+})<InputProps>`
   ${inputStyle}
   & .ant-input-password-icon {
     color: ${colors.primary};

--- a/src/renderer/components/wallet/keystore/ImportKeystore.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.tsx
@@ -115,11 +115,7 @@ export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
           </Form.Item>
           <Styled.PasswordContainer>
             <Styled.PasswordItem name="password">
-              <InputPassword
-                size="large"
-                type="password"
-                placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()}
-              />
+              <InputPassword size="large" placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()} />
             </Styled.PasswordItem>
           </Styled.PasswordContainer>
         </Spin>

--- a/src/renderer/components/wallet/phrase/ImportPhrase.tsx
+++ b/src/renderer/components/wallet/phrase/ImportPhrase.tsx
@@ -132,11 +132,7 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
           </Form.Item>
           <Styled.PasswordContainer>
             <Styled.PasswordItem name="password" validateTrigger={['onSubmit', 'onBlur']} rules={rules}>
-              <InputPassword
-                size="large"
-                type="password"
-                placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()}
-              />
+              <InputPassword size="large" placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()} />
             </Styled.PasswordItem>
             <Styled.PasswordItem
               name="repeatPassword"
@@ -145,7 +141,6 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
               rules={rules}>
               <InputPassword
                 size="large"
-                type="password"
                 placeholder={intl.formatMessage({ id: 'wallet.password.repeat' }).toUpperCase()}
               />
             </Styled.PasswordItem>

--- a/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
+++ b/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
@@ -11,7 +11,7 @@ export const TitleContainer = styled(A.Row).attrs({ justify: 'space-between' })`
 export const SectionTitle = styled(A.Typography.Text)`
   text-transform: uppercase;
   font-size: 16px;
-  color: ${palette('gray', 2)};
+  color: ${palette('text', 0)};
 
   // Copy to Clipboard and reset mnemonic phrase action icons
   // Keep them here together to avoid inconsistency

--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -5,7 +5,7 @@ import Form, { Rule } from 'antd/lib/form'
 import { useIntl } from 'react-intl'
 
 import { Button, RefreshButton } from '../../uielements/button'
-import { InputPassword as Input } from '../../uielements/input'
+import { InputPassword } from '../../uielements/input'
 import { Phrase } from './index'
 import * as Styled from './NewPhrase.styles'
 import * as StyledPhrase from './Phrase.styles'
@@ -71,20 +71,15 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Ele
       <Styled.Form form={form} onFinish={handleFormFinish} labelCol={{ span: 24 }}>
         <StyledPhrase.PasswordContainer>
           <StyledPhrase.PasswordItem name="password" validateTrigger={['onSubmit', 'onBlur']} rules={rules}>
-            <Input
-              size="large"
-              type="password"
-              placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()}
-            />
+            <InputPassword size="large" placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()} />
           </StyledPhrase.PasswordItem>
           <StyledPhrase.PasswordItem
             name="repeatPassword"
             dependencies={['password']}
             validateTrigger={['onSubmit', 'onBlur']}
             rules={rules}>
-            <Input
+            <InputPassword
               size="large"
-              type="password"
               placeholder={intl.formatMessage({ id: 'wallet.password.repeat' }).toUpperCase()}
             />
           </StyledPhrase.PasswordItem>

--- a/src/renderer/components/wallet/txs/send/Send.stories.tsx
+++ b/src/renderer/components/wallet/txs/send/Send.stories.tsx
@@ -177,40 +177,17 @@ const getTxRdFromStatus = getMockRDValueFactory(
 type Args = {
   sendForm: SendForm
   txRDStatus: RDStatus
-  sendTxStatusMsg: string
 }
 
-export const Default: Story<Args> = ({ sendForm, txRDStatus, sendTxStatusMsg }) => {
+export const Default: Story<Args> = ({ sendForm, txRDStatus }) => {
   const Component = useMemo(() => getSendForm(sendForm), [sendForm])
   const balance = useMemo(() => getSendBalance(sendForm), [sendForm])
   const txRD: TxHashRD = useMemo(() => getTxRdFromStatus(txRDStatus), [txRDStatus])
-  const isLoading = useMemo(
-    () =>
-      RD.fold(
-        () => false,
-        () => true,
-        () => false,
-        () => false
-      )(txRD),
-    [txRD]
-  )
-  return (
-    <Send
-      {...defaultProps}
-      txRD={txRD}
-      sendForm={
-        <Component
-          {...defaultComponentProps}
-          sendTxStatusMsg={sendTxStatusMsg}
-          balance={balance}
-          isLoading={isLoading}
-        />
-      }
-    />
-  )
+
+  return <Send {...defaultProps} txRD={txRD} sendForm={<Component {...defaultComponentProps} balance={balance} />} />
 }
 
-Default.args = { sendForm: 'SendFormBNB', txRDStatus: 'initial', sendTxStatusMsg: '' }
+Default.args = { sendForm: 'SendFormBNB', txRDStatus: 'initial' }
 
 const meta: Meta<Args> = {
   component: Send,
@@ -222,10 +199,7 @@ const meta: Meta<Args> = {
         options: Object.keys(SendFormsComponents)
       }
     },
-    txRDStatus: { control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] } },
-    sendTxStatusMsg: {
-      control: {}
-    }
+    txRDStatus: { control: { type: 'select', options: ['initial', 'pending', 'error', 'success'] } }
   }
 }
 

--- a/src/renderer/views/wallet/send/SendView.tsx
+++ b/src/renderer/views/wallet/send/SendView.tsx
@@ -67,7 +67,14 @@ export const SendView: React.FC<Props> = (): JSX.Element => {
         case BTCChain:
           return <SendViewBTC walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case ETHChain:
-          return <SendViewETH walletType={walletType} walletIndex={walletIndex} asset={asset} />
+          return (
+            <SendViewETH
+              walletType={walletType}
+              walletIndex={walletIndex}
+              walletAddress={walletAddress}
+              asset={asset}
+            />
+          )
         case THORChain:
           return <SendViewTHOR walletType={walletType} walletIndex={walletIndex} walletAddress={walletAddress} />
         case LTCChain:

--- a/src/renderer/views/wallet/send/SendViewBNB.tsx
+++ b/src/renderer/views/wallet/send/SendViewBNB.tsx
@@ -78,6 +78,7 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
         <SendFormBNB
           walletType={walletType}
           walletIndex={walletIndex}
+          walletAddress={walletAddress}
           balances={FP.pipe(
             oBalances,
             O.getOrElse<WalletBalances>(() => [])
@@ -86,7 +87,6 @@ export const SendViewBNB: React.FC<Props> = (props): JSX.Element => {
           transfer$={transfer$}
           openExplorerTxUrl={openExplorerTxUrl}
           getExplorerTxUrl={getExplorerTxUrl}
-          walletAddress={walletAddress}
           addressValidation={validateAddress}
           fee={feeRD}
           reloadFeesHandler={reloadFees}

--- a/src/renderer/views/wallet/send/SendViewETH.tsx
+++ b/src/renderer/views/wallet/send/SendViewETH.tsx
@@ -1,41 +1,33 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
+import { Address } from '@xchainjs/xchain-client'
 import { ETHAddress } from '@xchainjs/xchain-ethereum'
 import { Asset, baseAmount, ETHChain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
-import { useIntl } from 'react-intl'
-import { useHistory } from 'react-router-dom'
 
 import { WalletType } from '../../../../shared/wallet/types'
-import { Send, SendFormETH } from '../../../components/wallet/txs/send/'
+import { SendFormETH } from '../../../components/wallet/txs/send/'
 import { useChainContext } from '../../../contexts/ChainContext'
 import { useEthereumContext } from '../../../contexts/EthereumContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
-import { getWalletBalanceByAsset } from '../../../helpers/walletHelper'
+import { getWalletBalanceByAddressAndAsset } from '../../../helpers/walletHelper'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
-import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
-import { INITIAL_SEND_STATE } from '../../../services/chain/const'
-import { SendTxParams, SendTxState } from '../../../services/chain/types'
 import { FeesRD, WalletBalances } from '../../../services/clients'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
-import { WalletBalance } from '../../../services/wallet/types'
-import * as Helper from './SendView.helper'
 
 type Props = {
   walletType: WalletType
   walletIndex: number
+  walletAddress: Address
   asset: Asset
 }
 
 export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
-  const { walletType, walletIndex, asset } = props
-
-  const intl = useIntl()
-  const history = useHistory()
+  const { walletType, walletIndex, walletAddress, asset } = props
 
   const { network } = useNetwork()
 
@@ -51,22 +43,16 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
 
   const { openExplorerTxUrl, getExplorerTxUrl } = useOpenExplorerTxUrl(O.some(ETHChain))
 
-  const oWalletBalance = useMemo(() => getWalletBalanceByAsset(oBalances, asset), [oBalances, asset])
+  const oWalletBalance = useMemo(
+    () =>
+      FP.pipe(
+        oBalances,
+        O.chain((balances) => getWalletBalanceByAddressAndAsset({ balances, address: walletAddress, asset }))
+      ),
+    [asset, oBalances, walletAddress]
+  )
 
   const { transfer$ } = useChainContext()
-
-  const {
-    state: sendTxState,
-    reset: resetSendTxState,
-    subscribe: subscribeSendTxState
-  } = useSubscriptionState<SendTxState>(INITIAL_SEND_STATE)
-
-  const onSend = useCallback(
-    (params: SendTxParams) => {
-      subscribeSendTxState(transfer$(params))
-    },
-    [subscribeSendTxState, transfer$]
-  )
 
   const { fees$, reloadFees } = useEthereumContext()
 
@@ -84,66 +70,27 @@ export const SendViewETH: React.FC<Props> = (props): JSX.Element => {
     RD.initial
   )
 
-  const isLoading = useMemo(() => RD.isPending(sendTxState.status), [sendTxState.status])
-
-  const sendTxStatusMsg = useMemo(
-    () => Helper.sendTxStatusMsg({ sendTxState, asset, intl }),
-    [asset, intl, sendTxState]
-  )
-
-  /**
-   * Custom send form used by ETH chain only
-   */
-  const sendForm = useCallback(
-    (walletBalance: WalletBalance) => (
-      <SendFormETH
-        walletType={walletType}
-        walletIndex={walletIndex}
-        balance={walletBalance}
-        balances={FP.pipe(
-          oBalances,
-          O.getOrElse<WalletBalances>(() => [])
-        )}
-        fees={feesRD}
-        isLoading={isLoading}
-        onSubmit={onSend}
-        sendTxStatusMsg={sendTxStatusMsg}
-        reloadFeesHandler={reloadFees}
-        validatePassword$={validatePassword$}
-        network={network}
-      />
-    ),
-    [
-      walletType,
-      walletIndex,
-      oBalances,
-      feesRD,
-      isLoading,
-      onSend,
-      sendTxStatusMsg,
-      reloadFees,
-      validatePassword$,
-      network
-    ]
-  )
-
-  const finishActionHandler = useCallback(() => {
-    resetSendTxState()
-    history.goBack()
-  }, [history, resetSendTxState])
-
   return FP.pipe(
     oWalletBalance,
     O.fold(
       () => <></>,
       (walletBalance) => (
-        <Send
-          txRD={sendTxState.status}
-          viewTxHandler={openExplorerTxUrl}
+        <SendFormETH
+          walletType={walletType}
+          walletIndex={walletIndex}
+          walletAddress={walletAddress}
+          balance={walletBalance}
+          balances={FP.pipe(
+            oBalances,
+            O.getOrElse<WalletBalances>(() => [])
+          )}
+          fees={feesRD}
+          transfer$={transfer$}
+          openExplorerTxUrl={openExplorerTxUrl}
           getExplorerTxUrl={getExplorerTxUrl}
-          finishActionHandler={finishActionHandler}
-          errorActionHandler={finishActionHandler}
-          sendForm={sendForm(walletBalance)}
+          reloadFeesHandler={reloadFees}
+          validatePassword$={validatePassword$}
+          network={network}
         />
       )
     )


### PR DESCRIPTION
- [x] Use `TxModal` in `Send{View|Form}ETH`
- [x] Quick fix: Improve usage of `InputPassword` + fix copy headline in `NewPhrase`

![Screenshot from 2022-02-24 17-57-01](https://user-images.githubusercontent.com/61792675/155578267-450f4d79-e3d2-481c-bd27-4cdfaad92503.png)


Part of #2073