### PR TITLE
[Ledger] Let user compare BCH address formats 

### DIFF
--- a/src/main/api/ledger/bitcoincash/address.ts
+++ b/src/main/api/ledger/bitcoincash/address.ts
@@ -20,9 +20,9 @@ export const getAddress = async (
     const clientNetwork = toClientNetwork(network)
     const derivePath = getDerivationPath(walletIndex, clientNetwork)
     const { bitcoinAddress: bchAddress } = await app.getWalletPublicKey(derivePath, {
-      // legacy format with 44' paths
+      // cashaddr in case of Bitcoin Cash
       // @see https://github.com/LedgerHQ/ledgerjs/blob/master/packages/hw-app-btc/README.md#parameters-2
-      format: 'legacy'
+      format: 'cashaddr'
     })
     return E.right({ address: bchAddress, chain: BCHChain, type: 'ledger', walletIndex })
   } catch (error) {
@@ -39,9 +39,9 @@ export const verifyAddress: VerifyAddressHandler = async ({ transport, network, 
   const clientNetwork = toClientNetwork(network)
   const derivePath = getDerivationPath(walletIndex, clientNetwork)
   const _ = await app.getWalletPublicKey(derivePath, {
-    // legacy format with 44' paths
+    // cashaddr in case of Bitcoin Cash
     // @see https://github.com/LedgerHQ/ledgerjs/blob/master/packages/hw-app-btc/README.md#parameters-2
-    format: 'legacy',
+    format: 'cashaddr',
     verify: true // confirm the address on the device
   })
   return true

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -1593,15 +1593,14 @@ export const SymDeposit: React.FC<Props> = (props) => {
           chain={useRuneLedger ? THORChain : asset.chain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.ledger.sign' })}
-          addresses={FP.pipe(
+          bchAddresses={FP.pipe(
             oDepositParams,
             O.chain(({ poolAddress, runeSender, assetSender }) => {
               const recipient = poolAddress.address
               if (useRuneLedger) return O.some({ recipient, sender: runeSender })
               if (useAssetLedger) return O.some({ recipient, sender: assetSender })
               return O.none
-            }),
-            O.toUndefined
+            })
           )}
         />
       )}

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -1593,7 +1593,7 @@ export const SymDeposit: React.FC<Props> = (props) => {
           chain={useRuneLedger ? THORChain : asset.chain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.ledger.sign' })}
-          bchAddresses={FP.pipe(
+          addresses={FP.pipe(
             oDepositParams,
             O.chain(({ poolAddress, runeSender, assetSender }) => {
               const recipient = poolAddress.address

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -1593,6 +1593,16 @@ export const SymDeposit: React.FC<Props> = (props) => {
           chain={useRuneLedger ? THORChain : asset.chain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.ledger.sign' })}
+          addresses={FP.pipe(
+            oDepositParams,
+            O.chain(({ poolAddress, runeSender, assetSender }) => {
+              const recipient = poolAddress.address
+              if (useRuneLedger) return O.some({ recipient, sender: runeSender })
+              if (useAssetLedger) return O.some({ recipient, sender: assetSender })
+              return O.none
+            }),
+            O.toUndefined
+          )}
         />
       )}
 

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -556,6 +556,7 @@ export const Withdraw: React.FC<Props> = ({
           chain={THORChain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.withdraw.ledger.sign' })}
+          addresses={undefined}
         />
       )}
 

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -556,7 +556,7 @@ export const Withdraw: React.FC<Props> = ({
           chain={THORChain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.withdraw.ledger.sign' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )}
 

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -556,7 +556,7 @@ export const Withdraw: React.FC<Props> = ({
           chain={THORChain}
           network={network}
           description={intl.formatMessage({ id: 'deposit.withdraw.ledger.sign' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )}
 

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
@@ -20,6 +20,10 @@ const Template: Story<Args> = ({ chain, visible, description }) => {
       chain={chain}
       description={description}
       network="mainnet"
+      addresses={{
+        sender: 'qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a',
+        recipient: 'qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy'
+      }}
     />
   )
 }
@@ -41,9 +45,9 @@ const meta: Meta<Args> = {
       name: 'Chain',
       control: {
         type: 'select',
-        options: ['BNB', 'BTC', 'ETH']
+        options: ['BNB', 'BCH', 'BTC', 'ETH']
       },
-      defaultValue: 'BNB'
+      defaultValue: 'BCH'
     },
     onClose: {
       action: 'onClose'

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
@@ -21,7 +21,7 @@ const Template: Story<Args> = ({ chain, visible, description }) => {
       chain={chain}
       description={description}
       network="mainnet"
-      bchAddresses={O.some({
+      addresses={O.some({
         sender: 'qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a',
         recipient: 'qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy'
       })}

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { Meta, Story } from '@storybook/react'
 import { Chain } from '@xchainjs/xchain-util'
+import * as O from 'fp-ts/lib/Option'
 
 import { LedgerConfirmationModal } from './'
 
@@ -20,10 +21,10 @@ const Template: Story<Args> = ({ chain, visible, description }) => {
       chain={chain}
       description={description}
       network="mainnet"
-      addresses={{
+      bchAddresses={O.some({
         sender: 'qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a',
         recipient: 'qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy'
-      }}
+      })}
     />
   )
 }
@@ -49,13 +50,8 @@ const meta: Meta<Args> = {
       },
       defaultValue: 'BCH'
     },
-    onClose: {
-      action: 'onClose'
-    },
-    onSuccess: {
-      action: 'onSuccess'
-    },
     description: {
+      name: 'Description',
       control: {
         type: 'text'
       },

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
@@ -53,16 +53,6 @@ export const NoteBCH = styled.p`
   text-align: center;
 `
 
-export const CashAddrConverterUrl = styled.span`
-  text-transform: uppercase;
-  color: inherit;
-  text-decoration: underline;
-  cursor: pointer;
-  &:hover {
-    color: ${palette('primary', 0)};
-  }
-`
-
 export const Icon = styled(AIcon)`
   display: inline-block;
   margin-right: 5px;

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
@@ -1,8 +1,11 @@
+import AIcon, { CaretRightOutlined } from '@ant-design/icons'
 import styled from 'styled-components'
+import { palette } from 'styled-theme'
 
 import { ReactComponent as LedgerConnectUI } from '../../../assets/svg/ledger-device-connect.svg'
 import { media } from '../../../helpers/styleHelper'
 import { AssetIcon as AssetIconUI } from '../../uielements/assets/assetIcon/AssetIcon'
+import { Button } from '../../uielements/button'
 
 export const LedgerContainer = styled.div`
   position: relative;
@@ -36,8 +39,66 @@ export const Content = styled.div`
   display: flex;
   flex-direction: column;
 `
+
 export const Description = styled.p`
   font-family: 'MainFontRegular';
   font-size: 12;
   text-align: center;
+`
+
+export const NoteBCH = styled.p`
+  font-family: 'MainFontRegular';
+  font-size: 12;
+  text-align: center;
+`
+
+export const CashAddrConverterUrl = styled.span`
+  text-transform: uppercase;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  &:hover {
+    color: ${palette('primary', 0)};
+  }
+`
+
+export const Icon = styled(AIcon)`
+  display: inline-block;
+  margin-right: 5px;
+  svg {
+    width: 17px;
+    height: 17px;
+    stroke: ${palette('warning', 0)};
+    fill: none;
+  }
+`
+export const AddressWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0 0 0;
+`
+export const AddressContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-transform: none;
+  align-items: center;
+`
+
+export const AddressTitle = styled.p`
+  font-family: 'MainFontBold';
+  font-size: 12px;
+  color: inherit;
+  text-transform: uppercase;
+  padding: 0;
+  margin: 0;
+`
+
+export const CompareAddressButton = styled(Button)`
+  box-shadow: none;
+`
+
+export const ExpandIcon = styled(CaretRightOutlined)`
+  svg {
+    color: inherit;
+  }
 `

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.styles.ts
@@ -6,6 +6,7 @@ import { ReactComponent as LedgerConnectUI } from '../../../assets/svg/ledger-de
 import { media } from '../../../helpers/styleHelper'
 import { AssetIcon as AssetIconUI } from '../../uielements/assets/assetIcon/AssetIcon'
 import { Button } from '../../uielements/button'
+import { CopyLabel as CopyLabelUI } from '../../uielements/label'
 
 export const LedgerContainer = styled.div`
   position: relative;
@@ -86,7 +87,7 @@ export const AddressContainer = styled.div`
 
 export const AddressTitle = styled.p`
   font-family: 'MainFontBold';
-  font-size: 12px;
+  font-size: 10px;
   color: inherit;
   text-transform: uppercase;
   padding: 0;
@@ -101,4 +102,9 @@ export const ExpandIcon = styled(CaretRightOutlined)`
   svg {
     color: inherit;
   }
+`
+
+export const CopyLabel = styled(CopyLabelUI)`
+  padding-top: 20px;
+  font-size: 12px;
 `

--- a/src/renderer/components/modal/confirmation/LedgerConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/LedgerConfirmationModal.tsx
@@ -1,9 +1,15 @@
+import { useState } from 'react'
+
+import { toLegacyAddress } from '@xchainjs/xchain-bitcoincash'
+import { Address } from '@xchainjs/xchain-client'
 import { Chain, chainToString } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import { useIntl } from 'react-intl'
 
 import { Network } from '../../../../shared/api/types'
 import { getChainAsset } from '../../../helpers/chainHelper'
+import { AttentionIcon } from '../../icons'
+import { AddressEllipsis } from '../../uielements/addressEllipsis'
 import { ConfirmationModal } from './ConfirmationModal'
 import * as Styled from './LedgerConfirmationModal.styles'
 
@@ -14,6 +20,7 @@ type Props = {
   onClose: FP.Lazy<void>
   chain: Chain
   description?: string
+  addresses?: { sender: Address; recipient: Address }
 }
 
 export const LedgerConfirmationModal: React.FC<Props> = ({
@@ -22,11 +29,16 @@ export const LedgerConfirmationModal: React.FC<Props> = ({
   onSuccess,
   chain,
   network,
-  description = ''
+  description = '',
+  addresses
 }) => {
   const intl = useIntl()
 
+  // const CASHADDR_CONVERTER_URL = 'https://www.bitcoin.com/tools/cash-address-converter'
+
   const asset = getChainAsset(chain)
+
+  const [showAddresses, setShowAddresses] = useState(false)
 
   return (
     <ConfirmationModal
@@ -45,6 +57,75 @@ export const LedgerConfirmationModal: React.FC<Props> = ({
             {intl.formatMessage({ id: 'ledger.needsconnected' }, { chain: chainToString(chain) })}
           </Styled.Description>
           {description && <Styled.Description>{description}</Styled.Description>}
+          {/* {isBchChain(chain) && (
+            <Styled.NoteBCH>
+              <Styled.Icon component={AttentionIcon} />
+              <FormattedMessage
+                id="ledger.legacyformat.note"
+                values={{
+                  url: (
+                    <Styled.CashAddrConverterUrl onClick={() => openUrl(CASHADDR_CONVERTER_URL)}>
+                      {CASHADDR_CONVERTER_URL}
+                    </Styled.CashAddrConverterUrl>
+                  )
+                }}
+              />
+            </Styled.NoteBCH>
+          )
+          } */}
+          {addresses && (
+            <>
+              <Styled.NoteBCH>
+                <Styled.Icon component={AttentionIcon} />
+                {intl.formatMessage({ id: 'ledger.legacyformat.note' }, { url: 'ulr' })}
+              </Styled.NoteBCH>
+
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Styled.CompareAddressButton
+                  typevalue="transparent"
+                  type="text"
+                  onClick={() => setShowAddresses((current) => !current)}>
+                  {intl.formatMessage({ id: showAddresses ? 'ledger.legacyformat.hide' : 'ledger.legacyformat.show' })}
+                  <Styled.ExpandIcon rotate={showAddresses ? 270 : 90} />
+                </Styled.CompareAddressButton>
+              </div>
+
+              {showAddresses && (
+                <>
+                  <Styled.AddressWrapper>
+                    <Styled.AddressContainer>
+                      <Styled.AddressTitle>Sender</Styled.AddressTitle>
+                      <AddressEllipsis network={network} chain={chain} address={addresses.sender} enableCopy />
+                    </Styled.AddressContainer>
+                    <Styled.AddressContainer>
+                      <Styled.AddressTitle>(Legacy)</Styled.AddressTitle>
+                      <AddressEllipsis
+                        network={network}
+                        chain={chain}
+                        address={toLegacyAddress(addresses.sender)}
+                        enableCopy
+                      />
+                    </Styled.AddressContainer>
+                  </Styled.AddressWrapper>
+                  <Styled.AddressWrapper>
+                    <Styled.AddressContainer>
+                      <Styled.AddressTitle>Recipient</Styled.AddressTitle>
+                      <AddressEllipsis network={network} chain={chain} address={addresses.recipient} enableCopy />
+                    </Styled.AddressContainer>
+                    <Styled.AddressContainer>
+                      <Styled.AddressTitle>(Legacy)</Styled.AddressTitle>
+                      <AddressEllipsis
+                        network={network}
+                        chain={chain}
+                        address={toLegacyAddress(addresses.recipient)}
+                        enableCopy
+                      />
+                    </Styled.AddressContainer>
+                  </Styled.AddressWrapper>{' '}
+                </>
+              )}
+            </>
+          )}
         </Styled.Content>
       }
     />

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -921,12 +921,30 @@ export const Swap = ({
             visible={showLedgerModal}
             chain={chain}
             description={intl.formatMessage({ id: 'swap.ledger.sign' })}
+            addresses={FP.pipe(
+              oSwapParams,
+              O.chain(({ poolAddress, sender }) => {
+                const recipient = poolAddress.address
+                if (useSourceAssetLedger) return O.some({ recipient, sender })
+                return O.none
+              }),
+              O.toUndefined
+            )}
           />
         )),
         O.toNullable
       ),
 
-    [intl, network, oSourceAsset, onCloseLedgerModal, onSucceedLedgerModal, showLedgerModal]
+    [
+      intl,
+      network,
+      oSourceAsset,
+      oSwapParams,
+      onCloseLedgerModal,
+      onSucceedLedgerModal,
+      showLedgerModal,
+      useSourceAssetLedger
+    ]
   )
 
   const sourceChainFeeError: boolean = useMemo(() => {

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -921,7 +921,7 @@ export const Swap = ({
             visible={showLedgerModal}
             chain={chain}
             description={intl.formatMessage({ id: 'swap.ledger.sign' })}
-            bchAddresses={FP.pipe(
+            addresses={FP.pipe(
               oSwapParams,
               O.chain(({ poolAddress, sender }) => {
                 const recipient = poolAddress.address

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -921,14 +921,13 @@ export const Swap = ({
             visible={showLedgerModal}
             chain={chain}
             description={intl.formatMessage({ id: 'swap.ledger.sign' })}
-            addresses={FP.pipe(
+            bchAddresses={FP.pipe(
               oSwapParams,
               O.chain(({ poolAddress, sender }) => {
                 const recipient = poolAddress.address
                 if (useSourceAssetLedger) return O.some({ recipient, sender })
                 return O.none
-              }),
-              O.toUndefined
+              })
             )}
           />
         )),
@@ -1462,7 +1461,7 @@ export const Swap = ({
           {!lockedWallet && (
             <Styled.TargetAddressContainer>
               <Row>
-                <Styled.ValueTitle>{intl.formatMessage({ id: 'swap.recipient' })}</Styled.ValueTitle>
+                <Styled.ValueTitle>{intl.formatMessage({ id: 'common.recipient' })}</Styled.ValueTitle>
                 {renderTargetWalletType}
               </Row>
               {renderCustomAddressInput}

--- a/src/renderer/components/uielements/label/CopyLabel.stories.tsx
+++ b/src/renderer/components/uielements/label/CopyLabel.stories.tsx
@@ -1,0 +1,39 @@
+import { Story, Meta } from '@storybook/react'
+
+import { CopyLabel as Component } from './CopyLabel'
+
+type Args = {
+  label: string
+  textToCopy: string
+}
+
+const Template: Story<Args> = ({ label, textToCopy }) => {
+  return <Component label={label} textToCopy={textToCopy} />
+}
+
+export const Default = Template.bind({})
+
+Default.storyName = 'default'
+
+const meta: Meta<Args> = {
+  component: Component,
+  title: 'Components/CopyLabel',
+  argTypes: {
+    label: {
+      name: 'label',
+      control: {
+        type: 'text'
+      },
+      defaultValue: 'label'
+    },
+    textToCopy: {
+      name: 'textToCopy',
+      control: {
+        type: 'text'
+      },
+      defaultValue: 'text to copy'
+    }
+  }
+}
+
+export default meta

--- a/src/renderer/components/uielements/label/CopyLabel.styles.ts
+++ b/src/renderer/components/uielements/label/CopyLabel.styles.ts
@@ -1,0 +1,17 @@
+import * as A from 'antd'
+import styled from 'styled-components'
+import { palette } from 'styled-theme'
+
+export const CopyLabel = styled(A.Typography.Text)`
+  display: flex;
+  place-items: center;
+  &,
+  .ant-typography-copy {
+    text-transform: uppercase;
+    font-family: 'MainFontRegular';
+    color: ${palette('primary', 0)} !important;
+  }
+  svg {
+    margin-left: 5px;
+  }
+`

--- a/src/renderer/components/uielements/label/CopyLabel.tsx
+++ b/src/renderer/components/uielements/label/CopyLabel.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { CheckOutlined, CopyOutlined } from '@ant-design/icons'
+
+import * as Styled from './CopyLabel.styles'
+
+type Props = {
+  label: string
+  textToCopy: string
+  className?: string
+}
+
+export const CopyLabel: React.FC<Props> = ({ label, textToCopy, className }): JSX.Element => {
+  return (
+    <Styled.CopyLabel
+      className={className}
+      copyable={{
+        text: textToCopy,
+        icon: [
+          <div key={1}>
+            {label}
+            <CopyOutlined />
+          </div>,
+          <div key={2}>
+            {label}
+            <CheckOutlined />
+          </div>
+        ]
+      }}
+    />
+  )
+}

--- a/src/renderer/components/uielements/label/index.ts
+++ b/src/renderer/components/uielements/label/index.ts
@@ -1,1 +1,2 @@
 export * from './Label'
+export * from './CopyLabel'

--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -8,11 +8,11 @@ import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as S from 'fp-ts/lib/string'
 import { useObservableCallback, useSubscription } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-// import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { Button, RefreshButton } from '../../uielements/button'
 import { InputPassword } from '../../uielements/input'
+import { CopyLabel } from '../../uielements/label'
 import { Phrase } from './index'
 import * as Styled from './NewPhrase.styles'
 import { WordType } from './NewPhraseConfirm'
@@ -81,15 +81,10 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit }: Props): JSX.Ele
     [intl]
   )
 
-  const copyPhraseToClipborad = useCallback(() => {
-    navigator.clipboard.writeText(phrase)
-  }, [phrase])
   return (
     <>
       <Styled.TitleContainer justify="space-between">
-        <Styled.SectionTitle copyable={{ onCopy: copyPhraseToClipborad }}>
-          {intl.formatMessage({ id: 'wallet.create.copy.phrase' })}
-        </Styled.SectionTitle>
+        <CopyLabel textToCopy={phrase} label={intl.formatMessage({ id: 'wallet.create.copy.phrase' })} />
         <RefreshButton clickHandler={clickRefreshButtonHandler} />
       </Styled.TitleContainer>
       <Phrase words={phraseWords} readOnly={true} />

--- a/src/renderer/components/wallet/phrase/PhraseCopyModal.styles.ts
+++ b/src/renderer/components/wallet/phrase/PhraseCopyModal.styles.ts
@@ -1,6 +1,4 @@
-import * as A from 'antd'
 import styled from 'styled-components'
-import { palette } from 'styled-theme'
 
 import { Modal as BaseModal } from '../../uielements/modal'
 
@@ -15,20 +13,6 @@ export const Modal = styled(BaseModal)`
   .ant-modal-footer {
     display: flex;
     justify-content: center;
-  }
-`
-
-export const CopyLabel = styled(A.Typography.Text)`
-  display: flex;
-  place-items: center;
-  &,
-  .ant-typography-copy {
-    text-transform: uppercase;
-    font-family: 'MainFontRegular';
-    color: ${palette('primary', 0)} !important;
-  }
-  svg {
-    margin-left: 5px;
   }
 `
 

--- a/src/renderer/components/wallet/phrase/PhraseCopyModal.tsx
+++ b/src/renderer/components/wallet/phrase/PhraseCopyModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { CheckOutlined, CopyOutlined } from '@ant-design/icons'
 import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
+import { CopyLabel } from '../../uielements/label'
 import * as Styled from './PhraseCopyModal.styles'
 
 type Props = {
@@ -23,23 +23,7 @@ export const PhraseCopyModal: React.FC<Props> = (props): JSX.Element => {
       visible={visible}
       onOk={onClose}
       onCancel={onClose}
-      footer={
-        <Styled.CopyLabel
-          copyable={{
-            text: phrase,
-            icon: [
-              <div key={1}>
-                {intl.formatMessage({ id: 'common.copy' })}
-                <CopyOutlined />
-              </div>,
-              <div key={2}>
-                {intl.formatMessage({ id: 'common.copy' })}
-                <CheckOutlined />
-              </div>
-            ]
-          }}
-        />
-      }>
+      footer={<CopyLabel label={intl.formatMessage({ id: 'common.copy' })} textToCopy={phrase} />}>
       <Styled.PhraseView>
         {phrase.split(' ').map((item, index) => (
           <Styled.Item key={index}>

--- a/src/renderer/components/wallet/txs/interact/InteractForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractForm.tsx
@@ -288,7 +288,7 @@ export const InteractForm: React.FC<Props> = (props) => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/interact/InteractForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractForm.tsx
@@ -288,6 +288,7 @@ export const InteractForm: React.FC<Props> = (props) => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/interact/InteractForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractForm.tsx
@@ -288,7 +288,7 @@ export const InteractForm: React.FC<Props> = (props) => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
@@ -324,7 +324,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BCHChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.some({ sender: walletAddress, recipient: form.getFieldValue('recipient') })}
+          addresses={O.some({ sender: walletAddress, recipient: form.getFieldValue('recipient') })}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
@@ -324,7 +324,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BCHChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={{ sender: walletAddress, recipient: form.getFieldValue('recipient') }}
+          bchAddresses={O.some({ sender: walletAddress, recipient: form.getFieldValue('recipient') })}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBCH.tsx
@@ -324,6 +324,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BCHChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={{ sender: walletAddress, recipient: form.getFieldValue('recipient') }}
         />
       )
     } else if (isKeystoreWallet(walletType)) {
@@ -337,7 +338,7 @@ export const SendFormBCH: React.FC<Props> = (props): JSX.Element => {
     } else {
       return null
     }
-  }, [walletType, submitTx, network, showConfirmationModal, intl, validatePassword$])
+  }, [walletType, submitTx, network, showConfirmationModal, intl, walletAddress, form, validatePassword$])
 
   const renderTxModal = useMemo(
     () =>

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -224,7 +224,7 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BNBChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -224,7 +224,7 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BNBChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBNB.tsx
@@ -224,6 +224,7 @@ export const SendFormBNB: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BNBChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -324,7 +324,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -324,7 +324,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormBTC.tsx
@@ -324,6 +324,7 @@ export const SendFormBTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={BTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
@@ -293,7 +293,7 @@ export const SendFormDOGE: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={DOGEChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
@@ -293,7 +293,7 @@ export const SendFormDOGE: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={DOGEChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormDOGE.tsx
@@ -293,6 +293,7 @@ export const SendFormDOGE: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={DOGEChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
@@ -321,7 +321,7 @@ export const SendFormLTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={LTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
@@ -321,6 +321,7 @@ export const SendFormLTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={LTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormLTC.tsx
@@ -321,7 +321,7 @@ export const SendFormLTC: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={LTCChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     } else if (isKeystoreWallet(walletType)) {

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -233,7 +233,7 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -233,6 +233,7 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTHOR.tsx
@@ -233,7 +233,7 @@ export const SendFormTHOR: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={THORChain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -419,7 +419,7 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={runeAsset.asset.chain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          addresses={undefined}
+          bchAddresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -419,7 +419,7 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={runeAsset.asset.chain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
-          bchAddresses={O.none}
+          addresses={O.none}
         />
       )
     }

--- a/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
+++ b/src/renderer/components/wallet/txs/upgrade/Upgrade.tsx
@@ -419,6 +419,7 @@ export const Upgrade: React.FC<Props> = (props): JSX.Element => {
           visible={showConfirmationModal}
           chain={runeAsset.asset.chain}
           description={intl.formatMessage({ id: 'wallet.ledger.confirm' })}
+          addresses={undefined}
         />
       )
     }

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -95,7 +95,9 @@ const common: CommonMessages = {
   'common.balance': 'Guthaben',
   'common.balance.loading': 'Lade Guthaben',
   'common.custom': 'Benutzerdefiniert',
-  'common.notsupported.fornetwork': 'Nicht unterstützt für {network}'
+  'common.notsupported.fornetwork': 'Nicht unterstützt für {network}',
+  'common.recipient': 'Empfänger',
+  'common.sender': 'Absender'
 }
 
 export default common

--- a/src/renderer/i18n/de/ledger.ts
+++ b/src/renderer/i18n/de/ledger.ts
@@ -23,7 +23,10 @@ const ledger: LedgerMessages = {
   'ledger.error.unknown': 'Unbekannter Fehler',
   'ledger.notsupported': 'Kein Ledger support für {chain}.',
   'ledger.notaddedorzerobalances': 'Ledger für {chain} ist nicht verbunden oder hat kein Guthaben.',
-  'ledger.deposit.oneside': 'Ledger wird aktuell nur für eine Assetseite unterstützt.'
+  'ledger.deposit.oneside': 'Ledger wird aktuell nur für eine Assetseite unterstützt.',
+  'ledger.legacyformat.note': 'Ledger zeigt alle Output Addressen im "Legacy", aber nicht im "CashAddr" Format an.',
+  'ledger.legacyformat.show': 'Addressformate zeigen',
+  'ledger.legacyformat.hide': 'Addressformate verbergen'
 }
 
 export default ledger

--- a/src/renderer/i18n/de/ledger.ts
+++ b/src/renderer/i18n/de/ledger.ts
@@ -25,8 +25,8 @@ const ledger: LedgerMessages = {
   'ledger.notaddedorzerobalances': 'Ledger für {chain} ist nicht verbunden oder hat kein Guthaben.',
   'ledger.deposit.oneside': 'Ledger wird aktuell nur für eine Assetseite unterstützt.',
   'ledger.legacyformat.note': 'Ledger zeigt alle Output Addressen im "Legacy", aber nicht im "CashAddr" Format an.',
-  'ledger.legacyformat.show': 'Addressformate zeigen',
-  'ledger.legacyformat.hide': 'Addressformate verbergen'
+  'ledger.legacyformat.show': 'Adressenformate zeigen',
+  'ledger.legacyformat.hide': 'Adressenformate verbergen'
 }
 
 export default ledger

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -6,7 +6,6 @@ const swap: SwapMessages = {
   'swap.state.success': 'Erfolgreich getauscht',
   'swap.input': 'Eingabe',
   'swap.output': 'Ausgabe',
-  'swap.recipient': 'Empfänger',
   'swap.info.max.fee': 'Gesamtguthaben minus geschätzter Tauschgebühr',
   'swap.slip.title': 'Slip',
   'swap.slip.tolerance': 'Slippage-Toleranz',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -95,7 +95,9 @@ const common: CommonMessages = {
   'common.balance': 'Balance',
   'common.balance.loading': 'Loading balance',
   'common.custom': 'Custom',
-  'common.notsupported.fornetwork': 'Not supported for {network}'
+  'common.notsupported.fornetwork': 'Not supported for {network}',
+  'common.recipient': 'Recipient',
+  'common.sender': 'Sender'
 }
 
 export default common

--- a/src/renderer/i18n/en/ledger.ts
+++ b/src/renderer/i18n/en/ledger.ts
@@ -3,8 +3,7 @@ import { LedgerMessages } from '../types'
 const ledger: LedgerMessages = {
   'ledger.title': 'Ledger',
   'ledger.title.sign': 'Signing with Ledger',
-  'ledger.needsconnected':
-    'Make sure you your Ledger device is connected and the "{chain}" application is up and running.',
+  'ledger.needsconnected': 'Make sure your Ledger device is connected and the "{chain}" application is up and running.',
   'ledger.add.device': 'Add ledger',
   'ledger.error.nodevice': 'No device connected',
   'ledger.error.inuse': 'Ledger is already in use for another app',
@@ -24,7 +23,10 @@ const ledger: LedgerMessages = {
   'ledger.error.unknown': 'Unknown Error',
   'ledger.notsupported': 'No Ledger support for {chain}.',
   'ledger.notaddedorzerobalances': 'Ledger {chain} has not been connected or has zero balances.',
-  'ledger.deposit.oneside': 'Currently Ledger is supported for one asset side only.'
+  'ledger.deposit.oneside': 'Currently Ledger is supported for one asset side only.',
+  'ledger.legacyformat.note': 'Ledger displays all output addresses in "legacy", but not in "CashAddr" format.',
+  'ledger.legacyformat.show': 'Show addresses',
+  'ledger.legacyformat.hide': 'Hide addresses'
 }
 
 export default ledger

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -6,7 +6,6 @@ const swap: SwapMessages = {
   'swap.state.error': 'Swap error',
   'swap.input': 'Input',
   'swap.output': 'Output',
-  'swap.recipient': 'Recipient',
   'swap.info.max.fee': 'Total asset balance substracted by estimated swap fees',
   'swap.slip.title': 'Slip',
   'swap.slip.tolerance': 'Slippage tolerance',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -38,7 +38,7 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'Transaction history',
   'wallet.empty.phrase.import': 'Import an existing wallet with funds on it',
   'wallet.empty.phrase.create': 'Create a new wallet, add funds to it',
-  'wallet.create.copy.phrase': 'Copy phrase below',
+  'wallet.create.copy.phrase': 'Copy phrase',
   'wallet.create.title': 'Create new wallet',
   'wallet.create.enter.phrase': 'Enter phrase correctly',
   'wallet.create.error.phrase': 'Save your phrase at a safety place and enter it in a correct way',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -95,7 +95,9 @@ const common: CommonMessages = {
   'common.balance': 'Solde',
   'common.balance.loading': 'Chargement du solde',
   'common.custom': 'Personnaliser',
-  'common.notsupported.fornetwork': 'Non pris en charge pour {network}'
+  'common.notsupported.fornetwork': 'Non pris en charge pour {network}',
+  'common.recipient': 'Destinataire',
+  'common.sender': 'Sender - FR'
 }
 
 export default common

--- a/src/renderer/i18n/fr/ledger.ts
+++ b/src/renderer/i18n/fr/ledger.ts
@@ -25,7 +25,10 @@ const ledger: LedgerMessages = {
   'ledger.error.unknown': 'Erreur inconnue',
   'ledger.notsupported': 'Pas de prise en charge de Ledger pour {chain}.',
   'ledger.notaddedorzerobalances': "La chaîne {chaîne} n'a pas été connectée sur Ledger ou n'a aucun solde.",
-  'ledger.deposit.oneside': "Actuellement, Ledger ne prend en charge un actif que d'un seul côté."
+  'ledger.deposit.oneside': "Actuellement, Ledger ne prend en charge un actif que d'un seul côté.",
+  'ledger.legacyformat.note': 'Ledger displays all output addresses in "legacy", but not in "CashAddr" format. - FR',
+  'ledger.legacyformat.show': 'Show addresses - FR',
+  'ledger.legacyformat.hide': 'Hide addresses - FR'
 }
 
 export default ledger

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -6,7 +6,6 @@ const swap: SwapMessages = {
   'swap.state.error': "Erreur lors de l'échange",
   'swap.input': 'Entrée',
   'swap.output': 'Sortie',
-  'swap.recipient': 'Destinataire',
   'swap.info.max.fee': "Solde total de l'actif moins les frais d'échange estimés",
   'swap.slip.title': 'Slippage',
   'swap.slip.tolerance': 'Tolérance de slippage',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -95,7 +95,9 @@ const common: CommonMessages = {
   'common.balance': 'Баланс',
   'common.balance.loading': 'Загружаю баланс',
   'common.custom': 'Вручную',
-  'common.notsupported.fornetwork': 'Not supported for {network} - RU'
+  'common.notsupported.fornetwork': 'Not supported for {network} - RU',
+  'common.recipient': 'Получатель',
+  'common.sender': 'Sender - RU'
 }
 
 export default common

--- a/src/renderer/i18n/ru/ledger.ts
+++ b/src/renderer/i18n/ru/ledger.ts
@@ -24,7 +24,10 @@ const ledger: LedgerMessages = {
   'ledger.error.unknown': 'Неизвестная ошибка',
   'ledger.notsupported': 'Ledger не поддерживает {chain}.',
   'ledger.notaddedorzerobalances': 'Ledger {chain} не была подключена или имеет нулевой баланс.',
-  'ledger.deposit.oneside': 'Пока что Ledger поддерживается только для одностороннего добавления активов.'
+  'ledger.deposit.oneside': 'Пока что Ledger поддерживается только для одностороннего добавления активов.',
+  'ledger.legacyformat.note': 'Ledger displays all output addresses in "legacy", but not in "CashAddr" format. - RU',
+  'ledger.legacyformat.show': 'Show addresses - RU',
+  'ledger.legacyformat.hide': 'Hide addresses - RU'
 }
 
 export default ledger

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -6,7 +6,6 @@ const swap: SwapMessages = {
   'swap.state.error': 'Ошибка при обмене',
   'swap.input': 'Отдаете',
   'swap.output': 'Получаете',
-  'swap.recipient': 'Получатель',
   'swap.info.max.fee': 'Баланс актива за вычетом комиссии обмена',
   'swap.slip.title': 'Проскальзывание',
   'swap.slip.tolerance': 'Допуск по проскальзыванию',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -96,6 +96,8 @@ export type CommonMessageKey =
   | 'common.balance.loading'
   | 'common.custom'
   | 'common.notsupported.fornetwork'
+  | 'common.recipient'
+  | 'common.sender'
 
 export type CommonMessages = {
   [key in CommonMessageKey]: string
@@ -295,7 +297,6 @@ export type MidgardMessages = { [key in MidgardMessageKey]: string }
 type SwapMessageKey =
   | 'swap.input'
   | 'swap.output'
-  | 'swap.recipient'
   | 'swap.slip.title'
   | 'swap.slip.tolerance'
   | 'swap.slip.tolerance.info'

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -264,6 +264,9 @@ type LedgerMessageKey =
   | 'ledger.notsupported'
   | 'ledger.notaddedorzerobalances'
   | 'ledger.deposit.oneside'
+  | 'ledger.legacyformat.note'
+  | 'ledger.legacyformat.show'
+  | 'ledger.legacyformat.hide'
 
 export type LedgerMessages = { [key in LedgerMessageKey]: string }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/61792675/158982842-73609e3b-1ec3-4f8d-a40f-b44fa676e11b.mp4

- [x] Use `CashAddr` for Ledger
- [x] Show different address formats in `LedgerConfirmationModal` (all copyable for user)
- [x] Introduce `CopyLabel` (incl. story)
- [x] Update i18n

Close 2147
Part of #2131 