### PR TITLE
Fix: Range of slip tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Update
 
-- Add more slippage options [#2170](https://github.com/thorchain/asgardex-electron/pull/2170) by @WojciechKo, [#2170](https://github.com/thorchain/asgardex-electron/pull/2170), [#2179](https://github.com/thorchain/asgardex-electron/pull/2179)
+- Add more slippage options [#2170](https://github.com/thorchain/asgardex-electron/pull/2170) by @WojciechKo, [#2170](https://github.com/thorchain/asgardex-electron/pull/2170), [#2180](https://github.com/thorchain/asgardex-electron/pull/2180)
 
 ## Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Update
 
-- Add more slippage options [#2170](https://github.com/thorchain/asgardex-electron/pull/2170) by @WojciechKo
+- Add more slippage options [#2170](https://github.com/thorchain/asgardex-electron/pull/2170) by @WojciechKo, [#2170](https://github.com/thorchain/asgardex-electron/pull/2170), [#2179](https://github.com/thorchain/asgardex-electron/pull/2179)
 
 ## Fix
 

--- a/src/renderer/components/currency/CurrencyInfo.styles.ts
+++ b/src/renderer/components/currency/CurrencyInfo.styles.ts
@@ -1,5 +1,5 @@
 import { Row } from 'antd'
-import Text from 'antd/lib/typography/Text'
+import Text, { TextProps } from 'antd/lib/typography/Text'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
@@ -41,15 +41,15 @@ export const DropdownContentWrapper = styled(Row)`
   cursor: pointer;
 `
 
-export const SlipLabel = styled(Text)`
+export const SlipLabel = styled(Text)<TextProps & { active: boolean }>`
   text-transform: uppercase;
   padding: 0;
   font-size: 16px;
   font-family: 'MainFontRegular';
   cursor: pointer;
-  color: ${palette('gray', 2)};
+  color: ${({ active }) => (active ? palette('gray', 2) : palette('gray', 1))};
   &:hover {
-    color: ${palette('text', 0)};
+    color: ${palette('gray', 2)};
   }
 `
 

--- a/src/renderer/components/currency/CurrencyInfo.tsx
+++ b/src/renderer/components/currency/CurrencyInfo.tsx
@@ -26,7 +26,7 @@ type CurrencyInfoProps = {
   disableSlippageMsg: string
 }
 
-export const SLIP_PERCENTAGES: SlipTolerance[] = [3, 5, 10]
+export const SLIP_PERCENTAGES: SlipTolerance[] = [0.5, 1, 3, 5, 10]
 export const SLIP_TOLERANCE_KEY = 'asgdx-slip-tolerance'
 
 export const CurrencyInfo = ({
@@ -56,14 +56,17 @@ export const CurrencyInfo = ({
       <>
         {SLIP_PERCENTAGES.map((slip) => (
           <Row style={{ alignItems: 'center' }} key={slip}>
-            <Styled.SlipLabel key={slip} onClick={() => changeSlipToleranceHandler(slip)}>
+            <Styled.SlipLabel
+              key={slip}
+              active={slip === slipTolerance}
+              onClick={() => changeSlipToleranceHandler(slip)}>
               {slip}%
             </Styled.SlipLabel>
           </Row>
         ))}
       </>
     )
-  }, [changeSlipToleranceHandler])
+  }, [changeSlipToleranceHandler, slipTolerance])
 
   const renderSlipSettings = useMemo(
     () => (
@@ -74,7 +77,7 @@ export const CurrencyInfo = ({
         trigger={['click']}
         placement="bottomCenter">
         <Styled.DropdownContentWrapper style={{ alignItems: 'center', width: '50px' }}>
-          <Styled.SlipLabel>{slipTolerance}%</Styled.SlipLabel>
+          <Styled.SlipLabel active>{slipTolerance}%</Styled.SlipLabel>
           <DownIcon />
         </Styled.DropdownContentWrapper>
       </Dropdown>

--- a/src/renderer/components/currency/CurrencyInfo.tsx
+++ b/src/renderer/components/currency/CurrencyInfo.tsx
@@ -76,7 +76,7 @@ export const CurrencyInfo = ({
         overlay={slipSettings}
         trigger={['click']}
         placement="bottomCenter">
-        <Styled.DropdownContentWrapper style={{ alignItems: 'center', width: '50px' }}>
+        <Styled.DropdownContentWrapper style={{ alignItems: 'center', width: '55px' }}>
           <Styled.SlipLabel active>{slipTolerance}%</Styled.SlipLabel>
           <DownIcon />
         </Styled.DropdownContentWrapper>

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -203,8 +203,8 @@ export const SwapView: React.FC<Props> = (_): JSX.Element => {
       localStorage.getItem(SLIP_TOLERANCE_KEY),
       O.fromNullable,
       O.map((s) => {
-        const itemAsInt = parseInt(s)
-        const slipTolerance = isSlipTolerance(itemAsInt) ? itemAsInt : DEFAULT_SLIP_TOLERANCE
+        const itemAsNumber = Number(s)
+        const slipTolerance = isSlipTolerance(itemAsNumber) ? itemAsNumber : DEFAULT_SLIP_TOLERANCE
         changeSlipTolerance(slipTolerance)
         return slipTolerance
       }),


### PR DESCRIPTION
Add missing ranges to `CurrencyInfo`

![Screenshot from 2022-03-29 13-22-31](https://user-images.githubusercontent.com/61792675/160600956-37d061e6-49c6-48f1-948f-67cd29cbf35e.png)


In addition to #2170