### PR TITLE
Terra: Show address + balances

### DIFF
--- a/src/main/api/url.ts
+++ b/src/main/api/url.ts
@@ -35,7 +35,8 @@ const EXTERNALS_WHITELIST = [
   'thornode.thorchain.info',
   'testnet.thornode.thorchain.info',
   'stagenet-thornode.ninerealms.com',
-  'stagenet-rpc.ninerealms.com'
+  'stagenet-rpc.ninerealms.com',
+  'finder.terra.money'
 ]
 
 const openExternal = (target: string) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { EthereumProvider } from './contexts/EthereumContext'
 import { I18nProvider } from './contexts/I18nContext'
 import { LitecoinProvider } from './contexts/LitecoinContext'
 import { MidgardProvider } from './contexts/MidgardContext'
+import { TerraProvider } from './contexts/TerraContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { ThorchainProvider } from './contexts/ThorchainContext'
 import { UserNodesProvider } from './contexts/UserNodesContext'
@@ -30,17 +31,19 @@ export const App: React.FC = (): JSX.Element => {
                   <BitcoinCashProvider>
                     <EthereumProvider>
                       <DogeProvider>
-                        <MidgardProvider>
-                          <UserNodesProvider>
-                            <I18nProvider>
-                              <Router>
-                                <ThemeProvider>
-                                  <AppView />
-                                </ThemeProvider>
-                              </Router>
-                            </I18nProvider>
-                          </UserNodesProvider>
-                        </MidgardProvider>
+                        <TerraProvider>
+                          <MidgardProvider>
+                            <UserNodesProvider>
+                              <I18nProvider>
+                                <Router>
+                                  <ThemeProvider>
+                                    <AppView />
+                                  </ThemeProvider>
+                                </Router>
+                              </I18nProvider>
+                            </UserNodesProvider>
+                          </MidgardProvider>
+                        </TerraProvider>
                       </DogeProvider>
                     </EthereumProvider>
                   </BitcoinCashProvider>

--- a/src/renderer/contexts/TerraContext.tsx
+++ b/src/renderer/contexts/TerraContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext } from 'react'
+
+import { client$, clientState$, address$, addressUI$, explorerUrl$, reloadBalances, balances$ } from '../services/terra'
+
+export type TerraContextValue = {
+  client$: typeof client$
+  clientState$: typeof clientState$
+  address$: typeof address$
+  addressUI$: typeof addressUI$
+  explorerUrl$: typeof explorerUrl$
+  reloadBalances: typeof reloadBalances
+  balances$: typeof balances$
+}
+
+const initialContext: TerraContextValue = {
+  client$,
+  clientState$,
+  address$,
+  addressUI$,
+  explorerUrl$,
+  reloadBalances,
+  balances$
+}
+
+const TerraContext = createContext<TerraContextValue | null>(null)
+
+export const TerraProvider: React.FC = ({ children }): JSX.Element => {
+  return <TerraContext.Provider value={initialContext}>{children}</TerraContext.Provider>
+}
+
+export const useTerraContext = () => {
+  const context = useContext(TerraContext)
+  if (!context) {
+    throw new Error('Context must be used within a TerraProvider.')
+  }
+  return context
+}

--- a/src/renderer/helpers/addressHelper.test.ts
+++ b/src/renderer/helpers/addressHelper.test.ts
@@ -1,4 +1,4 @@
-import { BCHChain, BNBChain, BTCChain, LTCChain, THORChain } from '@xchainjs/xchain-util'
+import { BCHChain, BNBChain, BTCChain, LTCChain, TerraChain, THORChain } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 
 import { getEthChecksumAddress, removeAddressPrefix, truncateAddress } from './addressHelper'
@@ -54,6 +54,11 @@ describe('helpers/addressHelper', () => {
       const result = truncateAddress('ltc1qtephp596jhpwrawlp67junuk347zl2cwpucctk', LTCChain, 'mainnet')
       expect(result).toEqual('ltc1qte...ctk')
     })
+
+    it('terra', () => {
+      const result = truncateAddress('terra15h6vd5f0wqps26zjlwrc6chah08ryu4hzzdwhc', TerraChain, 'mainnet')
+      expect(result).toEqual('terra15h...whc')
+    })
   })
 
   describe('removeAddressPrefix', () => {
@@ -105,6 +110,12 @@ describe('helpers/addressHelper', () => {
     it('litecoin mainnet', () => {
       const result = removeAddressPrefix('ltc1qtephp596jhpwrawlp67junuk347zl2cwpucctk')
       expect(result).toEqual('ltc1qtephp596jhpwrawlp67junuk347zl2cwpucctk')
+    })
+
+    it('terra', () => {
+      const address = 'terra15h6vd5f0wqps26zjlwrc6chah08ryu4hzzdwhc'
+      const result = removeAddressPrefix(address)
+      expect(result).toEqual(address)
     })
   })
 

--- a/src/renderer/helpers/addressHelper.ts
+++ b/src/renderer/helpers/addressHelper.ts
@@ -28,8 +28,8 @@ import { Network } from '../../shared/api/types'
 import { toClientNetwork } from '../../shared/utils/client'
 
 export const truncateAddress = (addr: Address, chain: Chain, network: Network): string => {
-  const first = addr.substr(0, Math.max(getAddressPrefixLength(chain, network) + 3, 6))
-  const last = addr.substr(addr.length - 3, 3)
+  const first = addr.substring(0, Math.max(getAddressPrefixLength(chain, network) + 3, 6))
+  const last = addr.substring(addr.length - 3, addr.length)
   return `${first}...${last}`
 }
 
@@ -59,9 +59,13 @@ export const getAddressPrefixLength = (chain: Chain, network: Network): number =
   }
 }
 
+/**
+ * Removes a prefix from an address, if the prefix ends with ':'
+ * (currently needed for BCH only)
+ */
 export const removeAddressPrefix = (address: Address): Address => {
   const prefixIndex = address.indexOf(':') + 1
-  return address.substr(prefixIndex > 0 ? prefixIndex : 0)
+  return address.substring(prefixIndex > 0 ? prefixIndex : 0)
 }
 
 /**

--- a/src/renderer/services/terra/balances.ts
+++ b/src/renderer/services/terra/balances.ts
@@ -1,0 +1,28 @@
+import { WalletType } from '../../../shared/wallet/types'
+import { observableState } from '../../helpers/stateHelper'
+import * as C from '../clients'
+import { client$ } from './common'
+
+/**
+ * `ObservableState` to reload `Balances`
+ * Sometimes we need to have a way to understand if it simple "load" or "reload" action
+ * e.g. @see src/renderer/services/wallet/balances.ts:getChainBalance$
+ */
+const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolean>(false)
+
+const resetReloadBalances = () => {
+  setReloadBalances(false)
+}
+
+const reloadBalances = () => {
+  setReloadBalances(true)
+}
+
+// State of balances loaded by Client
+const balances$ = (walletType: WalletType, walletIndex: number): C.WalletBalancesLD =>
+  C.balances$({ client$, trigger$: reloadBalances$, walletType, walletIndex, walletBalanceType: 'all' })
+
+// State of balances loaded by Client and Address
+const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
+
+export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/terra/index.ts
+++ b/src/renderer/services/terra/index.ts
@@ -1,3 +1,15 @@
+import { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances } from './balances'
 import { client$, clientState$, address$, addressUI$, explorerUrl$ } from './common'
 
-export { client$, clientState$, address$, addressUI$, explorerUrl$ }
+export {
+  client$,
+  clientState$,
+  address$,
+  addressUI$,
+  explorerUrl$,
+  balances$,
+  reloadBalances,
+  getBalanceByAddress$,
+  reloadBalances$,
+  resetReloadBalances
+}

--- a/src/renderer/views/wallet/WalletSettingsView.tsx
+++ b/src/renderer/views/wallet/WalletSettingsView.tsx
@@ -3,7 +3,17 @@ import React, { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Address, XChainClient } from '@xchainjs/xchain-client'
-import { BCHChain, BNBChain, BTCChain, Chain, DOGEChain, ETHChain, LTCChain, THORChain } from '@xchainjs/xchain-util'
+import {
+  BCHChain,
+  BNBChain,
+  BTCChain,
+  Chain,
+  DOGEChain,
+  ETHChain,
+  LTCChain,
+  TerraChain,
+  THORChain
+} from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
 import * as A from 'fp-ts/lib/Array'
 import * as O from 'fp-ts/lib/Option'
@@ -23,6 +33,7 @@ import { useChainContext } from '../../contexts/ChainContext'
 import { useDogeContext } from '../../contexts/DogeContext'
 import { useEthereumContext } from '../../contexts/EthereumContext'
 import { useLitecoinContext } from '../../contexts/LitecoinContext'
+import { useTerraContext } from '../../contexts/TerraContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
 import {
@@ -57,6 +68,7 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
   const { addressUI$: ltcAddressUI$ } = useLitecoinContext()
   const { addressUI$: bchAddressUI$ } = useBitcoinCashContext()
   const { addressUI$: dogeAddressUI$ } = useDogeContext()
+  const { addressUI$: terraAddressUI$ } = useTerraContext()
   const oRuneNativeAddress: O.Option<WalletAddress> = useObservableState(thorAddressUI$, O.none)
   const runeNativeAddress = FP.pipe(
     oRuneNativeAddress,
@@ -153,6 +165,7 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
   const oTHORClient = useObservableState(clientByChain$(THORChain), O.none)
   const oLTCClient = useObservableState(clientByChain$(LTCChain), O.none)
   const oDOGEClient = useObservableState(clientByChain$(DOGEChain), O.none)
+  const oTerraClient = useObservableState(clientByChain$(TerraChain), O.none)
 
   const clickAddressLinkHandler = (chain: Chain, address: Address) => {
     const openExplorerAddressUrl = (client: XChainClient) => {
@@ -181,6 +194,9 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
         break
       case DOGEChain:
         FP.pipe(oDOGEClient, O.map(openExplorerAddressUrl))
+        break
+      case TerraChain:
+        FP.pipe(oTerraClient, O.map(openExplorerAddressUrl))
         break
       default:
         console.warn(`Chain ${chain} has not been implemented`)
@@ -285,6 +301,10 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
       ledgerAddress: dogeLedgerWalletAddress,
       chain: DOGEChain
     })
+    const terraWalletAccount$ = walletAccount$({
+      addressUI$: terraAddressUI$,
+      chain: TerraChain
+    })
 
     return FP.pipe(
       // combineLatest is for the future additional accounts
@@ -296,7 +316,8 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
           BNB: [bnbWalletAccount$],
           BCH: [bchWalletAccount$],
           LTC: [ltcWalletAccount$],
-          DOGE: [dogeWalletAccount$]
+          DOGE: [dogeWalletAccount$],
+          TERRA: [terraWalletAccount$]
         })
       ),
       RxOp.map(A.filter(O.isSome)),
@@ -315,7 +336,8 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     ltcAddressUI$,
     ltcLedgerWalletAddress,
     dogeAddressUI$,
-    dogeLedgerWalletAddress
+    dogeLedgerWalletAddress,
+    terraAddressUI$
   ])
   const walletAccounts = useObservableState(walletAccounts$, O.none)
 


### PR DESCRIPTION
- [x] Add `TERRA` account to `WalletSettings`
- [x] `TerraContext` + `TerraProvider`
- [x] Add `TERRA` explorer url to `EXTERNAL_WHITELIST`
- [x] Add `TERRA` balances to `wallet` -> `assets`
- [x] Fix deprecated usage of `string.substr`

Part of #2002