### PR TITLE
[Terra] Few updates needed for `transfer` implementation

### DIFF
--- a/src/renderer/components/wallet/txs/TxForm.helpers.tsx
+++ b/src/renderer/components/wallet/txs/TxForm.helpers.tsx
@@ -1,6 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Address } from '@xchainjs/xchain-client'
 import { Asset } from '@xchainjs/xchain-util'
+import { FormInstance } from 'antd'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import { IntlShape } from 'react-intl'
@@ -68,3 +69,6 @@ export const getSendTxDescription = ({
       () => intl.formatMessage({ id: 'common.tx.success' })
     )
   )
+
+export const hasFormErrors = (form: FormInstance) =>
+  !!form.getFieldsError().filter(({ errors }) => errors.length).length

--- a/src/renderer/components/wallet/txs/send/SendFormETH.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormETH.tsx
@@ -139,7 +139,7 @@ export const SendFormETH: React.FC<Props> = (props): JSX.Element => {
       O.fold(
         // Missing (or loading) fees does not mean we can't sent something. No error then.
         () => false,
-        ([fee, ethAmount]) => ethAmount.amount().isLessThan(baseToAsset(fee).amount())
+        ([fee, ethAmount]) => ethAmount.lt(fee)
       )
     )
   }, [oEthAmount, selectedFee])

--- a/src/renderer/components/wallet/txs/send/SendFormTERRA.styles.ts
+++ b/src/renderer/components/wallet/txs/send/SendFormTERRA.styles.ts
@@ -3,10 +3,10 @@ import Text from 'antd/lib/typography/Text'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
-export const MenuItem = styled(A.Menu.Item)`
+export const MenuItemContainer = styled.div`
   display: flex;
   align-items: center;
-  padding: 8px 10px;
+  padding: 8px 0px;
 `
 
 export const DropdownContentWrapper = styled(A.Row)`
@@ -22,4 +22,5 @@ export const MenuItemText = styled(Text)`
   font-family: 'MainFontRegular';
   color: ${palette('text', 1)};
   font-size: 15px;
+  margin-left: 5px;
 `

--- a/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
@@ -17,7 +17,7 @@ import {
   TerraChain,
   eqAsset
 } from '@xchainjs/xchain-util'
-import { Row, Form, Dropdown, Menu } from 'antd'
+import { Row, Form, Dropdown } from 'antd'
 import { MenuProps } from 'antd/lib/menu'
 import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
@@ -40,6 +40,8 @@ import { ValidatePasswordHandler } from '../../../../services/wallet/types'
 import { WalletBalance } from '../../../../services/wallet/types'
 import { DownIcon } from '../../../icons'
 import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../modal/confirmation'
+import { Menu } from '../../../shared/menu/Menu'
+import { AssetIcon } from '../../../uielements/assets/assetIcon'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { UIFeesRD } from '../../../uielements/fees'
 import { Input, InputBigNumber } from '../../../uielements/input'
@@ -386,25 +388,29 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
           balances,
           A.filter(({ asset }) => isTerraChain(asset.chain)),
           A.map(({ asset }) => (
-            <CStyled.MenuItem key={assetToString(asset)}>
-              <CStyled.MenuItemText>{asset.ticker}</CStyled.MenuItemText>
-            </CStyled.MenuItem>
+            <Menu.Item key={assetToString(asset)}>
+              <CStyled.MenuItemContainer>
+                <AssetIcon size="xsmall" asset={asset} network={network} />
+                <CStyled.MenuItemText>{asset.ticker}</CStyled.MenuItemText>
+              </CStyled.MenuItemContainer>
+            </Menu.Item>
           ))
         )}
       </Menu>
     ),
-    [balances, changeFeeHandler]
+    [balances, changeFeeHandler, network]
   )
 
   const renderFeeAssetSelector = useMemo(
     () => (
-      <Row style={{ alignItems: 'center' }}>
+      <Row align="middle">
         <Styled.CustomLabel size="big" style={{ width: 'auto' }}>
-          Fee asset
+          {intl.formatMessage({ id: 'common.fee.asset' })}
         </Styled.CustomLabel>
         <Dropdown overlay={feeAssetMenu} trigger={['click']} placement="bottomCenter">
           <CStyled.DropdownContentWrapper>
-            <Row style={{ alignItems: 'center' }}>
+            <Row align="middle">
+              <AssetIcon size="xsmall" asset={feeAsset} network={network} />
               <CStyled.MenuItemText>{feeAsset.ticker}</CStyled.MenuItemText>
               <DownIcon />
             </Row>
@@ -412,7 +418,7 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
         </Dropdown>
       </Row>
     ),
-    [feeAsset.ticker, feeAssetMenu]
+    [feeAsset, feeAssetMenu, intl, network]
   )
 
   const uiFeesRD: UIFeesRD = useMemo(

--- a/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
@@ -332,7 +332,6 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
     (overrideFeeAsset?: Asset) => {
       // Check validation errors
       // Note: Never use a memorized `H.hasFormErrors` here - it will re-load fees with errors otherwise
-      // if (form.getFieldsError().filter(({ errors }) => errors.length).length) return {}
       if (H.hasFormErrors(form)) return {}
       // If not amount is set, use `1` BaseAmount (needed to calcu)
       const amount = FP.pipe(

--- a/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormTERRA.tsx
@@ -212,6 +212,17 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
     },
     [setSendAddress, addressValidator]
   )
+
+  const memoValidator = useCallback(
+    async (_: unknown, value: string) => {
+      const max = 256
+      if (!!value && value.length > max) {
+        return Promise.reject(intl.formatMessage({ id: 'wallet.errors.memo.max' }, { max: 256 }))
+      }
+    },
+    [intl]
+  )
+
   // Send tx start time
   const [sendTxStartTime, setSendTxStartTime] = useState<number>(0)
 
@@ -411,6 +422,11 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
 
   const renderWalletType = useMemo(() => H.renderedWalletType(oMatchedWalletType), [oMatchedWalletType])
 
+  const disableSubmit = useMemo(
+    () => isFeeError || RD.isPending(feeRD) || !!form.getFieldsError().filter(({ errors }) => errors.length).length,
+    [feeRD, form, isFeeError]
+  )
+
   return (
     <>
       <Row>
@@ -458,12 +474,12 @@ export const SendFormTERRA: React.FC<Props> = (props): JSX.Element => {
               <Styled.Fees fees={uiFeesRD} reloadFees={reloadFees} disabled={isLoading} />
               {renderFeeError}
               <Styled.CustomLabel size="big">{intl.formatMessage({ id: 'common.memo' })}</Styled.CustomLabel>
-              <Form.Item name="memo">
+              <Form.Item rules={[{ required: true, validator: memoValidator }]} name="memo">
                 <Input size="large" disabled={isLoading} onBlur={() => reloadFees(feeAsset)} />
               </Form.Item>
             </Styled.SubForm>
             <Styled.SubmitContainer>
-              <Styled.Button loading={isLoading} disabled={isFeeError} htmlType="submit">
+              <Styled.Button loading={isLoading} disabled={disableSubmit} htmlType="submit">
                 {intl.formatMessage({ id: 'wallet.action.send' })}
               </Styled.Button>
             </Styled.SubmitContainer>

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -44,6 +44,7 @@ const common: CommonMessages = {
   'common.viewTransaction': 'Transaktion ansehen',
   'common.copyTxUrl': 'Transaktion URL kopieren',
   'common.fee': 'Gebühr',
+  'common.fee.asset': 'Gebühr Asset',
   'common.fees': 'Gebühren',
   'common.fee.estimated': 'Voraussichtliche Gebühr',
   'common.fees.estimated': 'Voraussichtliche Gebühren',

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -76,7 +76,8 @@ const wallet: WalletMessages = {
   'wallet.errors.amount.shouldBeLessThanBalanceAndFee':
     'Der eingegebene Wert sollte nicht höher als Dein Guthaben abzgl. Gebühren sein',
   'wallet.errors.fee.notCovered': 'Die Gebühren sind nicht über Dein Guthaben ({balance}) gedeckt',
-  'wallet.errors.invalidChain': 'Invalide Chain: {chain}',
+  'wallet.errors.invalidChain': 'Ungültige Chain: {chain}',
+  'wallet.errors.memo.max': 'Memo darf nicht mehr als {max} Zeichen beinhalten',
   'wallet.password.confirmation.title': 'Wallet Passwort bestätigen',
   'wallet.password.confirmation.description': 'Bitte gebe zur Bestätigung Dein Wallet Password ein.',
   'wallet.password.confirmation.pending': 'Überprüfe Passwort',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -47,6 +47,7 @@ const common: CommonMessages = {
   'common.fees': 'Fees',
   'common.fee.estimated': 'Estimated fee',
   'common.fees.estimated': 'Estimated fees',
+  'common.fee.asset': 'Fee asset',
   'common.max': 'Max',
   'common.min': 'Min',
   'common.search': 'Search',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -73,6 +73,7 @@ const wallet: WalletMessages = {
   'wallet.errors.amount.shouldBeLessThanBalanceAndFee': 'Amount should be less than your balance minus fee',
   'wallet.errors.fee.notCovered': 'Fees are not covered by your balance ({balance})',
   'wallet.errors.invalidChain': 'Invalid chain: {chain}',
+  'wallet.errors.memo.max': "Length of memo can't be more than {max}",
   'wallet.password.confirmation.title': 'Wallet password confirmation',
   'wallet.password.confirmation.description': 'Please enter your wallet password.',
   'wallet.password.confirmation.pending': 'Validating password',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -73,7 +73,7 @@ const wallet: WalletMessages = {
   'wallet.errors.amount.shouldBeLessThanBalanceAndFee': 'Amount should be less than your balance minus fee',
   'wallet.errors.fee.notCovered': 'Fees are not covered by your balance ({balance})',
   'wallet.errors.invalidChain': 'Invalid chain: {chain}',
-  'wallet.errors.memo.max': "Length of memo can't be more than {max}",
+  'wallet.errors.memo.max': "Length of memo can't be greater than {max}",
   'wallet.password.confirmation.title': 'Wallet password confirmation',
   'wallet.password.confirmation.description': 'Please enter your wallet password.',
   'wallet.password.confirmation.pending': 'Validating password',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -44,6 +44,7 @@ const common: CommonMessages = {
   'common.viewTransaction': 'Afficher la transaction',
   'common.copyTxUrl': "Copier l'URL de la transaction",
   'common.fee': 'Frais',
+  'common.fee.asset': 'Fee asset - FR',
   'common.fees': 'Frais',
   'common.fee.estimated': 'Frais estimé',
   'common.fees.estimated': 'Frais estimés',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -75,6 +75,7 @@ const wallet: WalletMessages = {
   'wallet.errors.amount.shouldBeLessThanBalanceAndFee': 'Le montant doit être inférieur à votre solde moins les frais',
   'wallet.errors.fee.notCovered': 'Les frais ne sont pas couverts par votre solde de ({balance})',
   'wallet.errors.invalidChain': 'Chaîne non valide : {chain}',
+  'wallet.errors.memo.max': "Length of memo can't be more than {max} - FR",
   'wallet.password.confirmation.title': 'Confirmation du mot de passe',
   'wallet.password.confirmation.description': 'Veuillez saisir le mot de passe de votre portefeuille.',
   'wallet.password.confirmation.pending': 'Validation du mot de passe',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -75,7 +75,7 @@ const wallet: WalletMessages = {
   'wallet.errors.amount.shouldBeLessThanBalanceAndFee': 'Le montant doit être inférieur à votre solde moins les frais',
   'wallet.errors.fee.notCovered': 'Les frais ne sont pas couverts par votre solde de ({balance})',
   'wallet.errors.invalidChain': 'Chaîne non valide : {chain}',
-  'wallet.errors.memo.max': "Length of memo can't be more than {max} - FR",
+  'wallet.errors.memo.max': "Length of memo can't be greater than {max} - FR",
   'wallet.password.confirmation.title': 'Confirmation du mot de passe',
   'wallet.password.confirmation.description': 'Veuillez saisir le mot de passe de votre portefeuille.',
   'wallet.password.confirmation.pending': 'Validation du mot de passe',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -44,6 +44,7 @@ const common: CommonMessages = {
   'common.viewTransaction': 'Посмотреть транзакцию',
   'common.copyTxUrl': 'Copy transaction url - RU',
   'common.fee': 'Комиссия',
+  'common.fee.asset': 'Fee asset - RU',
   'common.fees': 'Комиссии',
   'common.fee.estimated': 'Ориентировочная комиссия',
   'common.fees.estimated': 'Ориентировочные комиссии',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -74,6 +74,7 @@ const wallet: WalletMessages = {
     'Количество должно быть меньше, чем ваш баланс после вычета комиссии',
   'wallet.errors.fee.notCovered': 'Комиссия не покрывается вашим банаслом ({balance})',
   'wallet.errors.invalidChain': 'Неверная цепочка: {chain}',
+  'wallet.errors.memo.max': "Length of memo can't be more than {max} - RU",
   'wallet.password.confirmation.title': 'Подтверждение пароля',
   'wallet.password.confirmation.description': 'пожалуйста введите свой пароль.',
   'wallet.password.confirmation.pending': 'Проверяю пароль',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -74,7 +74,7 @@ const wallet: WalletMessages = {
     'Количество должно быть меньше, чем ваш баланс после вычета комиссии',
   'wallet.errors.fee.notCovered': 'Комиссия не покрывается вашим банаслом ({balance})',
   'wallet.errors.invalidChain': 'Неверная цепочка: {chain}',
-  'wallet.errors.memo.max': "Length of memo can't be more than {max} - RU",
+  'wallet.errors.memo.max': "Length of memo can't be greater than {max} - RU",
   'wallet.password.confirmation.title': 'Подтверждение пароля',
   'wallet.password.confirmation.description': 'пожалуйста введите свой пароль.',
   'wallet.password.confirmation.pending': 'Проверяю пароль',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -43,6 +43,7 @@ export type CommonMessageKey =
   | 'common.viewTransaction'
   | 'common.copyTxUrl'
   | 'common.fee'
+  | 'common.fee.asset'
   | 'common.fees'
   | 'common.fee.estimated'
   | 'common.fees.estimated'

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -212,6 +212,7 @@ type WalletMessageKey =
   | 'wallet.errors.amount.shouldBeLessThanBalanceAndFee'
   | 'wallet.errors.fee.notCovered'
   | 'wallet.errors.invalidChain'
+  | 'wallet.errors.memo.max'
   | 'wallet.send.error'
   | 'wallet.upgrade.pending'
   | 'wallet.upgrade.success'

--- a/src/renderer/services/terra/fees.ts
+++ b/src/renderer/services/terra/fees.ts
@@ -1,7 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { FeeType, singleFee } from '@xchainjs/xchain-client'
-import { FeeParams, TERRA_DECIMAL } from '@xchainjs/xchain-terra'
-import { baseAmount } from '@xchainjs/xchain-util'
+import { FeeParams } from '@xchainjs/xchain-terra'
 import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
@@ -29,7 +27,9 @@ export const createFeesService = (client$: Client$): FeesService => {
             (client) =>
               Rx.from(client.getFees(feeParams)).pipe(
                 RxOp.map(RD.success),
-                RxOp.catchError((_) => Rx.of(RD.success(singleFee(FeeType.PerByte, baseAmount(0, TERRA_DECIMAL))))),
+                RxOp.catchError((error) =>
+                  Rx.of(RD.failure(Error(`Error to load fee (${error?.messagee ?? error.toString()})`)))
+                ),
                 RxOp.startWith(RD.pending)
               )
           )


### PR DESCRIPTION
- [x] Fix max amount
- [x] Add `memo` validation
- [x] Always error estimation of fees, but no default fees (estimated fees always needed to `transfer`)
- [x] Quick fix `SendFormETH`: Fee in `isFeeError` is `BaseAmount`, not `AssetAmount`
- [x] Fix styles for fee asset + use icon

Part of #2002