### PR TITLE
Improve data handling of `PoolDetails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # 0.15.0 (2022-xx-xx)
 
+## Update
+
+- [PoolDetail] Improve loading behavior [#2234](https://github.com/thorchain/asgardex-electron/issues/2234)
+
 ## Fix
 
 - White screen with Ledger Terra wallet connected (#2227)[https://github.com/thorchain/asgardex-electron/issues/2227]
 - [Wallet] Locking wallet at Deposit or Withdraw failed (#2233)[https://github.com/thorchain/asgardex-electron/issues/2233]
+- [e2e] Testcafe is failing [#750](https://github.com/thorchain/asgardex-electron/issues/750)
 
 ## Internal
 

--- a/src/renderer/components/pool/PoolCards.styles.ts
+++ b/src/renderer/components/pool/PoolCards.styles.ts
@@ -2,6 +2,7 @@ import * as A from 'antd'
 import styled from 'styled-components'
 
 import { media } from '../../helpers/styleHelper'
+import { ErrorView as ErrorViewUI } from '../shared/error'
 
 const ITEM_GAP = '8px'
 
@@ -35,4 +36,9 @@ export const Col = styled(A.Col).attrs({
       padding-right: ${ITEM_GAP};
     `}
   }
+`
+
+export const ErrorView = styled(ErrorViewUI)`
+  /* height: 100%; */
+  /* width: 100%; */
 `

--- a/src/renderer/components/pool/PoolCards.tsx
+++ b/src/renderer/components/pool/PoolCards.tsx
@@ -1,118 +1,180 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 
+import * as RD from '@devexperts/remote-data-ts'
 import { AssetAmount, formatAssetAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import * as FP from 'fp-ts/lib/function'
 import { useIntl } from 'react-intl'
 
+import { ZERO_ASSET_AMOUNT, ZERO_BN } from '../../const'
+import { sequenceTRD } from '../../helpers/fpHelpers'
 import { abbreviateNumber } from '../../helpers/numberHelper'
-import { PoolDetail, PoolStatsDetail } from '../../types/generated/midgard/models'
+import { PoolDetailRD, PoolStatsDetailRD } from '../../services/midgard/types'
+import { ErrorView } from '../shared/error'
+import { Button } from '../uielements/button'
 import { PoolStatus } from '../uielements/poolStatus'
 import * as Styled from './PoolCards.styles'
 import * as H from './PoolDetails.helpers'
 
 export type Props = {
-  poolDetail: PoolDetail
-  poolStatsDetail: PoolStatsDetail
-  priceSymbol?: string
-  isLoading?: boolean
+  poolDetail: PoolDetailRD
+  poolStatsDetail: PoolStatsDetailRD
+  reloadData: FP.Lazy<void>
+  priceSymbol: string
   priceRatio: BigNumber
 }
 
-export const PoolCards: React.FC<Props> = ({
-  poolStatsDetail,
-  priceSymbol = '',
-  poolDetail,
-  priceRatio,
-  isLoading
-}) => {
+export const PoolCards: React.FC<Props> = (props) => {
+  const { poolStatsDetail: poolStatsDetailRD, priceSymbol, poolDetail: poolDetailRD, priceRatio, reloadData } = props
   const intl = useIntl()
-
-  const liquidity = useMemo(() => H.getLiquidity(poolDetail, priceRatio), [poolDetail, priceRatio])
-  const volume24 = useMemo(() => H.getVolume24(poolDetail, priceRatio), [poolDetail, priceRatio])
-  const volumeTotal = useMemo(() => H.getVolumeTotal(poolStatsDetail, priceRatio), [poolStatsDetail, priceRatio])
-  const apy = useMemo(() => H.getAPY(poolDetail), [poolDetail])
-
-  const fees = useMemo(() => H.getFees(poolStatsDetail, priceRatio), [poolStatsDetail, priceRatio])
-  const totalTx = useMemo(() => H.getTotalTx(poolStatsDetail), [poolStatsDetail])
-  const members = useMemo(() => H.getMembers(poolStatsDetail), [poolStatsDetail])
-
-  const ilpPaid = useMemo(() => H.getILPPaid(poolStatsDetail, priceRatio), [poolStatsDetail, priceRatio])
 
   const getFullValue = useCallback(
     (amount: AssetAmount): string => `${priceSymbol} ${formatAssetAmount({ amount: amount, trimZeros: true })}`,
     [priceSymbol]
   )
 
-  return (
-    <Styled.Container>
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          fullValue={getFullValue(liquidity)}
-          label={intl.formatMessage({ id: 'common.liquidity' })}
-          displayValue={`${priceSymbol} ${abbreviateNumber(liquidity.amount().toNumber(), 2)}`}
-        />
-      </Styled.Col>
+  const renderCards = useCallback(
+    ({
+      isLoading,
+      liquidity,
+      volume24,
+      volumeTotal,
+      apy,
+      fees,
+      totalTx,
+      members,
+      ilpPaid
+    }: {
+      isLoading: boolean
+      liquidity: AssetAmount
+      volume24: AssetAmount
+      volumeTotal: AssetAmount
+      apy: BigNumber
+      fees: AssetAmount
+      totalTx: BigNumber
+      members: BigNumber
+      ilpPaid: AssetAmount
+    }) => (
+      <Styled.Container>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            fullValue={getFullValue(liquidity)}
+            label={intl.formatMessage({ id: 'common.liquidity' })}
+            displayValue={`${priceSymbol} ${abbreviateNumber(liquidity.amount().toNumber(), 2)}`}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.members' })}
-          displayValue={abbreviateNumber(members.toNumber())}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.members' })}
+            displayValue={abbreviateNumber(members.toNumber())}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          fullValue={getFullValue(volumeTotal)}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.volumeTotal' })}
-          displayValue={`${priceSymbol} ${abbreviateNumber(volumeTotal.amount().toNumber(), 2)}`}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            fullValue={getFullValue(volumeTotal)}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.volumeTotal' })}
+            displayValue={`${priceSymbol} ${abbreviateNumber(volumeTotal.amount().toNumber(), 2)}`}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          fullValue={getFullValue(volume24)}
-          label={intl.formatMessage({ id: 'common.volume24' })}
-          displayValue={`${priceSymbol} ${abbreviateNumber(volume24.amount().toNumber(), 2)}`}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            fullValue={getFullValue(volume24)}
+            label={intl.formatMessage({ id: 'common.volume24' })}
+            displayValue={`${priceSymbol} ${abbreviateNumber(volume24.amount().toNumber(), 2)}`}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          fullValue={getFullValue(fees)}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.totalFees' })}
-          displayValue={`${priceSymbol} ${abbreviateNumber(fees.amount().toNumber(), 2)}`}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            fullValue={getFullValue(fees)}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.totalFees' })}
+            displayValue={`${priceSymbol} ${abbreviateNumber(fees.amount().toNumber(), 2)}`}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.totalTx' })}
-          displayValue={abbreviateNumber(totalTx.toNumber(), 3)}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.totalTx' })}
+            displayValue={abbreviateNumber(totalTx.toNumber(), 3)}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.apy' })}
-          displayValue={`${abbreviateNumber(apy.toNumber(), 2)} %`}
-        />
-      </Styled.Col>
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.apy' })}
+            displayValue={`${abbreviateNumber(apy.toNumber(), 2)} %`}
+          />
+        </Styled.Col>
 
-      <Styled.Col>
-        <PoolStatus
-          isLoading={isLoading}
-          fullValue={getFullValue(ilpPaid)}
-          label={intl.formatMessage({ id: 'deposit.poolDetails.ilpPaid' })}
-          displayValue={`${priceSymbol} ${abbreviateNumber(ilpPaid.amount().toNumber(), 2)}`}
+        <Styled.Col>
+          <PoolStatus
+            isLoading={isLoading}
+            fullValue={getFullValue(ilpPaid)}
+            label={intl.formatMessage({ id: 'deposit.poolDetails.ilpPaid' })}
+            displayValue={`${priceSymbol} ${abbreviateNumber(ilpPaid.amount().toNumber(), 2)}`}
+          />
+        </Styled.Col>
+      </Styled.Container>
+    ),
+    [getFullValue, intl, priceSymbol]
+  )
+
+  return FP.pipe(
+    sequenceTRD(poolDetailRD, poolStatsDetailRD),
+    RD.fold(
+      () =>
+        renderCards({
+          isLoading: true,
+          liquidity: ZERO_ASSET_AMOUNT,
+          volume24: ZERO_ASSET_AMOUNT,
+          volumeTotal: ZERO_ASSET_AMOUNT,
+          apy: ZERO_BN,
+          fees: ZERO_ASSET_AMOUNT,
+          totalTx: ZERO_BN,
+          members: ZERO_BN,
+          ilpPaid: ZERO_ASSET_AMOUNT
+        }),
+      () =>
+        renderCards({
+          isLoading: true,
+          liquidity: ZERO_ASSET_AMOUNT,
+          volume24: ZERO_ASSET_AMOUNT,
+          volumeTotal: ZERO_ASSET_AMOUNT,
+          apy: ZERO_BN,
+          fees: ZERO_ASSET_AMOUNT,
+          totalTx: ZERO_BN,
+          members: ZERO_BN,
+          ilpPaid: ZERO_ASSET_AMOUNT
+        }),
+      (error) => (
+        <ErrorView
+          title={intl.formatMessage({ id: 'common.error' })}
+          subTitle={error?.message ?? error.toString()}
+          extra={<Button onClick={reloadData}>{intl.formatMessage({ id: 'common.retry' })}</Button>}
         />
-      </Styled.Col>
-    </Styled.Container>
+      ),
+      ([poolDetail, poolStatsDetail]) =>
+        renderCards({
+          isLoading: false,
+          liquidity: H.getLiquidity(poolDetail, priceRatio),
+          volume24: H.getVolume24(poolDetail, priceRatio),
+          volumeTotal: H.getVolumeTotal(poolStatsDetail, priceRatio),
+          apy: H.getAPY(poolDetail),
+          fees: H.getFees(poolStatsDetail, priceRatio),
+          totalTx: H.getTotalTx(poolStatsDetail),
+          ilpPaid: H.getILPPaid(poolStatsDetail, priceRatio),
+          members: H.getMembers(poolStatsDetail)
+        })
+    )
   )
 }

--- a/src/renderer/components/pool/PoolDetails.helpers.ts
+++ b/src/renderer/components/pool/PoolDetails.helpers.ts
@@ -3,7 +3,10 @@ import BigNumber from 'bignumber.js'
 
 import { PoolDetail, PoolStatsDetail } from '../../types/generated/midgard'
 
-export const getLiquidity = ({ runeDepth }: Pick<PoolDetail, 'runeDepth'>, priceRatio: BigNumber = bn(1)) =>
+export const getLiquidity = (
+  { runeDepth }: Pick<PoolDetail, 'runeDepth'>,
+  priceRatio: BigNumber = bn(1)
+): AssetAmount =>
   baseToAsset(
     baseAmount(
       bnOrZero(runeDepth)
@@ -30,25 +33,27 @@ export const getVolumeTotal = (
       .times(priceRatio)
   )
 
-export const getAPY = (data: Pick<PoolDetail, 'poolAPY'>) => bnOrZero(data.poolAPY).multipliedBy(100)
+export const getAPY = (data: Pick<PoolDetail, 'poolAPY'>): BigNumber => bnOrZero(data.poolAPY).multipliedBy(100)
 
-export const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)) =>
+export const getPrice = (data: Pick<PoolDetail, 'assetPrice'>, priceRatio: BigNumber = bn(1)): AssetAmount =>
   assetAmount(bnOrZero(data.assetPrice).multipliedBy(priceRatio))
 
 export const getTotalSwaps = (data: Pick<PoolStatsDetail, 'swapCount'>) => bnOrZero(data.swapCount)
 
-export const getTotalTx = (data: Pick<PoolStatsDetail, 'swapCount' | 'addLiquidityCount' | 'withdrawCount'>) =>
-  bnOrZero(data.swapCount).plus(bnOrZero(data.addLiquidityCount)).plus(bnOrZero(data.withdrawCount))
+export const getTotalTx = (
+  data: Pick<PoolStatsDetail, 'swapCount' | 'addLiquidityCount' | 'withdrawCount'>
+): BigNumber => bnOrZero(data.swapCount).plus(bnOrZero(data.addLiquidityCount)).plus(bnOrZero(data.withdrawCount))
 
-export const getMembers = (data: Pick<PoolStatsDetail, 'uniqueMemberCount'>) => bnOrZero(data.uniqueMemberCount)
+export const getMembers = (data: Pick<PoolStatsDetail, 'uniqueMemberCount'>): BigNumber =>
+  bnOrZero(data.uniqueMemberCount)
 
-export const getFees = (data: Pick<PoolStatsDetail, 'totalFees'>, priceRatio: BigNumber = bn(1)) =>
+export const getFees = (data: Pick<PoolStatsDetail, 'totalFees'>, priceRatio: BigNumber = bn(1)): AssetAmount =>
   baseToAsset(baseAmount(bnOrZero(data.totalFees).multipliedBy(priceRatio)))
 
 export const getILPPaid = (
   { impermanentLossProtectionPaid }: Pick<PoolStatsDetail, 'impermanentLossProtectionPaid'>,
   priceRatio: BigNumber = bn(1)
-) => baseToAsset(baseAmount(bnOrZero(impermanentLossProtectionPaid).multipliedBy(priceRatio)))
+): AssetAmount => baseToAsset(baseAmount(bnOrZero(impermanentLossProtectionPaid).multipliedBy(priceRatio)))
 
 export const getEmptyPoolDetail = (): PoolDetail => ({
   asset: 'asset',

--- a/src/renderer/components/pool/PoolDetails.stories.tsx
+++ b/src/renderer/components/pool/PoolDetails.stories.tsx
@@ -15,6 +15,7 @@ export const historyActions: PoolHistoryActions = {
   loadHistory: (params) => console.log('load history', params),
   setFilter: (filter) => console.log('filter', filter),
   setPage: (page) => console.log('page', page),
+  reloadHistory: () => console.log('reloadHistory'),
   historyPage: RD.initial,
   prevHistoryPage: O.none
 }
@@ -23,10 +24,11 @@ export const PoolDetailsStory = () => {
   return (
     <PoolDetails
       historyActions={historyActions}
-      poolDetail={getEmptyPoolDetail()}
-      poolStatsDetail={getEmptyPoolStatsDetail()}
+      poolDetail={RD.success(getEmptyPoolDetail())}
+      reloadPoolDetail={() => console.log('reloadPoolDetail')}
+      poolStatsDetail={RD.success(getEmptyPoolStatsDetail())}
+      reloadPoolStatsDetail={() => console.log('reloadPoolStatsDetail')}
       network={'testnet'}
-      earningsHistory={O.none}
       priceSymbol={'R'}
       asset={AssetETH}
       priceRatio={ONE_BN}

--- a/src/renderer/components/pool/PoolTitle.styles.ts
+++ b/src/renderer/components/pool/PoolTitle.styles.ts
@@ -53,14 +53,19 @@ export const TitleContainer = styled.div`
 `
 
 export const AssetWrapper = styled.div`
-  margin-left: 10px;
+  margin-left: 25px;
   flex-direction: column;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
 
+  ${media.md`
+  margin-left: 35px;
+  `}
+
   ${media.lg`
     width: auto;
+    margin-left: 15px;
   `}
 `
 
@@ -71,6 +76,12 @@ export const AssetTitle = styled.p`
   font-family: 'MainFontRegular';
   color: ${palette('text', 0)};
   text-transform: uppercase;
+
+  ${media.md`
+  font-size: 23px;
+  line-height: 31px;
+  `}
+
   ${media.lg`
   font-size: 27px;
   line-height: 31px;
@@ -83,6 +94,10 @@ export const AssetSubtitle = styled.p`
   font-family: 'MainFontRegular';
   color: ${palette('text', 2)};
   text-transform: uppercase;
+
+  ${media.md`
+  font-size: 11px;
+  `}
 
   ${media.lg`
   font-size: 13px;

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -1,140 +1,109 @@
 import React, { useMemo } from 'react'
 
 import { SwapOutlined } from '@ant-design/icons'
+import * as RD from '@devexperts/remote-data-ts'
 import { Asset, AssetAmount, AssetRuneNative, assetToString, formatAssetAmount } from '@xchainjs/xchain-util'
 import { Grid } from 'antd'
 import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 
 import { Network } from '../../../shared/api/types'
 import { loadingString } from '../../helpers/stringHelper'
 import * as poolsRoutes from '../../routes/pools'
-import { GetPoolsStatusEnum } from '../../types/generated/midgard'
 import { ManageButton } from '../manageButton'
 import { AssetIcon } from '../uielements/assets/assetIcon'
 import { Button } from '../uielements/button'
 import * as Styled from './PoolTitle.styles'
 
 export type Props = {
-  asset: O.Option<Asset>
-  price: AssetAmount
-  priceSymbol?: string
+  asset: Asset
+  price: RD.RemoteData<Error, { amount: AssetAmount; symbol: string }>
   isLoading?: boolean
   disableTradingPoolAction: boolean
   disableAllPoolActions: boolean
   disablePoolActions: boolean
   network: Network
-  status: GetPoolsStatusEnum
+  isAvailablePool: boolean
 }
 
 export const PoolTitle: React.FC<Props> = ({
-  asset: oAsset,
-  price,
-  priceSymbol,
+  asset,
+  price: priceRD,
   disableTradingPoolAction,
   disableAllPoolActions,
   disablePoolActions,
   network,
-  isLoading,
-  status
+  isAvailablePool
 }) => {
   const navigate = useNavigate()
   const intl = useIntl()
   const isDesktopView = Grid.useBreakpoint()?.md ?? false
 
   const title = useMemo(
-    () =>
-      FP.pipe(
-        oAsset,
-        O.fold(
-          () => <>--</>,
-          (asset) => (
-            <>
-              <AssetIcon
-                asset={asset}
-                size={isDesktopView ? 'big' : 'normal'}
-                key={assetToString(asset)}
-                network={network}
-              />
-
-              <Styled.AssetWrapper>
-                <Styled.AssetTitle>
-                  {FP.pipe(
-                    oAsset,
-                    O.map(({ ticker }) => ticker),
-                    O.getOrElse(() => loadingString)
-                  )}
-                </Styled.AssetTitle>
-                <Styled.AssetSubtitle>
-                  {FP.pipe(
-                    oAsset,
-                    O.map((asset) => asset.chain),
-                    O.getOrElse(() => loadingString)
-                  )}
-                </Styled.AssetSubtitle>
-              </Styled.AssetWrapper>
-            </>
-          )
-        )
-      ),
-    [oAsset, isDesktopView, network]
+    () => (
+      <>
+        <AssetIcon asset={asset} size={isDesktopView ? 'big' : 'normal'} key={assetToString(asset)} network={network} />
+        <Styled.AssetWrapper>
+          <Styled.AssetTitle>{asset.ticker}</Styled.AssetTitle>
+          <Styled.AssetSubtitle>{asset.chain}</Styled.AssetSubtitle>
+        </Styled.AssetWrapper>
+      </>
+    ),
+    [asset, isDesktopView, network]
   )
 
-  const priceStr = useMemo(() => {
-    if (isLoading) return loadingString
-
-    return FP.pipe(
-      oAsset,
-      O.fold(
-        () => '',
-        () => `${priceSymbol} ${formatAssetAmount({ amount: price, decimal: 3 })}`
-      )
-    )
-  }, [isLoading, oAsset, price, priceSymbol])
-
-  const buttons = useMemo(
+  const priceStr = useMemo(
     () =>
       FP.pipe(
-        oAsset,
-        O.fold(
-          () => <></>,
-          (asset) => {
-            return (
-              <Styled.ButtonActions>
-                <ManageButton
-                  disabled={disableAllPoolActions || disablePoolActions}
-                  asset={asset}
-                  sizevalue={isDesktopView ? 'normal' : 'small'}
-                  isTextView={isDesktopView}
-                />
-                {status === GetPoolsStatusEnum.Available && (
-                  <Button
-                    disabled={disableAllPoolActions || disableTradingPoolAction}
-                    round="true"
-                    sizevalue={isDesktopView ? 'normal' : 'small'}
-                    style={{ height: 30 }}
-                    onClick={(event) => {
-                      event.preventDefault()
-                      event.stopPropagation()
-                      navigate(
-                        poolsRoutes.swap.path({
-                          source: assetToString(asset),
-                          target: assetToString(AssetRuneNative)
-                        })
-                      )
-                    }}>
-                    <SwapOutlined />
-                    {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
-                  </Button>
-                )}
-              </Styled.ButtonActions>
-            )
-          }
-        )
+        priceRD,
+        RD.map(({ amount, symbol }) => `${symbol} ${formatAssetAmount({ amount, decimal: 3 })}`),
+        RD.getOrElse(() => loadingString)
       ),
-    [oAsset, disableAllPoolActions, disablePoolActions, isDesktopView, status, disableTradingPoolAction, intl, navigate]
+    [priceRD]
+  )
+
+  const buttons = useMemo(
+    () => (
+      <Styled.ButtonActions>
+        <ManageButton
+          disabled={disableAllPoolActions || disablePoolActions}
+          asset={asset}
+          sizevalue={isDesktopView ? 'normal' : 'small'}
+          isTextView={isDesktopView}
+        />
+        {isAvailablePool && (
+          <Button
+            disabled={disableAllPoolActions || disableTradingPoolAction}
+            round="true"
+            sizevalue={isDesktopView ? 'normal' : 'small'}
+            style={{ height: 30 }}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              navigate(
+                poolsRoutes.swap.path({
+                  source: assetToString(asset),
+                  target: assetToString(AssetRuneNative)
+                })
+              )
+            }}>
+            <SwapOutlined />
+            {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
+          </Button>
+        )}
+      </Styled.ButtonActions>
+    ),
+    [
+      disableAllPoolActions,
+      disablePoolActions,
+      asset,
+      isDesktopView,
+      isAvailablePool,
+      disableTradingPoolAction,
+      intl,
+      navigate
+    ]
   )
 
   return (

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.stories.tsx
@@ -169,6 +169,7 @@ export const History: Story<{ dataStatus: RDStatus }> = ({ dataStatus }) => {
         console.log(`Open explorer - tx hash ${txHash}`)
         return Promise.resolve(true)
       }}
+      reloadHistory={() => console.log(`reloadHistory`)}
       historyPageRD={res}
       changePaginationHandler={setCurrentPage}
       currentPage={currentPage}

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistory.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistory.tsx
@@ -20,6 +20,7 @@ type Props = {
   prevHistoryPage?: O.Option<ActionsPage>
   openExplorerTxUrl: OpenExplorerTxUrl
   changePaginationHandler: (page: number) => void
+  reloadHistory: FP.Lazy<void>
   className?: string
 }
 
@@ -31,7 +32,8 @@ export const PoolActionsHistory: React.FC<Props> = (props) => {
     currentPage,
     prevHistoryPage,
     changePaginationHandler,
-    openExplorerTxUrl
+    openExplorerTxUrl,
+    reloadHistory
   } = props
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
   // store previous data of Txs to render these while reloading
@@ -53,7 +55,8 @@ export const PoolActionsHistory: React.FC<Props> = (props) => {
     prevHistoryPage,
     openExplorerTxUrl,
     changePaginationHandler,
-    network
+    network,
+    reloadHistory
   }
 
   return (

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryList.tsx
@@ -4,11 +4,13 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Grid } from 'antd'
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
+import { useIntl } from 'react-intl'
 
 import { Network } from '../../../shared/api/types'
 import { OpenExplorerTxUrl } from '../../services/clients'
 import { Action, ActionsPage, ActionsPageRD } from '../../services/midgard/types'
 import { ErrorView } from '../shared/error'
+import { Button } from '../uielements/button'
 import { Pagination } from '../uielements/pagination'
 import { TxDetail } from '../uielements/txDetail'
 import { DEFAULT_PAGE_SIZE } from './PoolActionsHistory.const'
@@ -22,6 +24,7 @@ type Props = {
   prevHistoryPage?: O.Option<ActionsPage>
   openExplorerTxUrl: OpenExplorerTxUrl
   changePaginationHandler: (page: number) => void
+  reloadHistory: FP.Lazy<void>
   className?: string
 }
 
@@ -32,9 +35,12 @@ export const PoolActionsHistoryList: React.FC<Props> = ({
   prevHistoryPage = O.none,
   openExplorerTxUrl: goToTx,
   currentPage,
+  reloadHistory,
   className
 }) => {
   const isDesktopView = Grid.useBreakpoint()?.lg ?? false
+
+  const intl = useIntl()
 
   const renderListItem = useCallback(
     (action: Action, index: number, goToTx: OpenExplorerTxUrl) => {
@@ -112,7 +118,13 @@ export const PoolActionsHistoryList: React.FC<Props> = ({
             )
             return renderList(data, true)
           },
-          ({ msg }) => <ErrorView key="error view" title={msg} />,
+          ({ msg }) => (
+            <ErrorView
+              title={intl.formatMessage({ id: 'common.error' })}
+              subTitle={msg}
+              extra={<Button onClick={reloadHistory}>{intl.formatMessage({ id: 'common.retry' })}</Button>}
+            />
+          ),
           renderList
         )
       )}

--- a/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
+++ b/src/renderer/components/poolActionsHistory/PoolActionsHistoryTable.tsx
@@ -12,6 +12,7 @@ import { OpenExplorerTxUrl } from '../../services/clients'
 import { ActionsPage, Action, ActionsPageRD } from '../../services/midgard/types'
 import { ApiError } from '../../services/wallet/types'
 import { ErrorView } from '../shared/error'
+import { Button } from '../uielements/button'
 import * as CommonStyled from '../uielements/common/Common.styles'
 import { Pagination } from '../uielements/pagination'
 import { TxDetail } from '../uielements/txDetail'
@@ -26,6 +27,7 @@ export type Props = {
   prevHistoryPage?: O.Option<ActionsPage>
   openExplorerTxUrl: OpenExplorerTxUrl
   changePaginationHandler: (page: number) => void
+  reloadHistory: FP.Lazy<void>
   className?: string
 }
 
@@ -35,6 +37,7 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
   changePaginationHandler,
   historyPageRD,
   prevHistoryPage = O.none,
+  reloadHistory,
   currentPage
 }) => {
   const intl = useIntl()
@@ -144,20 +147,29 @@ export const PoolActionsHistoryTable: React.FC<Props> = ({
   return useMemo(
     () => (
       <>
-        {RD.fold(
-          () => renderTable(H.emptyData, true),
-          () => {
-            const data = FP.pipe(
-              prevHistoryPage,
-              O.getOrElse(() => H.emptyData)
-            )
-            return renderTable(data, true)
-          },
-          ({ msg }: ApiError) => <ErrorView title={msg} />,
-          renderTable
-        )(historyPageRD)}
+        {FP.pipe(
+          historyPageRD,
+          RD.fold(
+            () => renderTable(H.emptyData, true),
+            () => {
+              const data = FP.pipe(
+                prevHistoryPage,
+                O.getOrElse(() => H.emptyData)
+              )
+              return renderTable(data, true)
+            },
+            ({ msg }: ApiError) => (
+              <ErrorView
+                title={intl.formatMessage({ id: 'common.error' })}
+                subTitle={msg}
+                extra={<Button onClick={reloadHistory}>{intl.formatMessage({ id: 'common.retry' })}</Button>}
+              />
+            ),
+            renderTable
+          )
+        )}
       </>
     ),
-    [historyPageRD, renderTable, prevHistoryPage]
+    [renderTable, historyPageRD, prevHistoryPage, intl, reloadHistory]
   )
 }

--- a/src/renderer/components/uielements/chart/PoolDetailsChart.styles.ts
+++ b/src/renderer/components/uielements/chart/PoolDetailsChart.styles.ts
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import { media } from '../../../helpers/styleHelper'
+import { ErrorView as ErrorViewUI } from '../../shared/error'
 
 // https://www.chartjs.org/docs/latest/general/fonts.html#missing-fonts
 Chart.defaults.font.size = 12
@@ -19,10 +20,12 @@ type ChartContainerProps = {
   gradientStop: string
 }
 
+// const MAX_HEIGHT = 312
+
 export const ChartContainer = styled.div`
   background: transparent;
   border: 1px solid ${palette('gray', 0)};
-  padding: 5px;
+  padding: 10px 20px;
   border-radius: 4px;
   width: 100%;
   height: 100%;
@@ -30,6 +33,7 @@ export const ChartContainer = styled.div`
     padding: 10px 20px;
     height: 312px;
   `}
+
   background-image: ${(props: ChartContainerProps) =>
     `linear-gradient(to bottom, ${transparentize(0.7, props.gradientStart)}, ${transparentize(
       1,
@@ -108,4 +112,12 @@ export const BarChart = styled(Bar).attrs({
   type: 'bar'
 })`
   width: 100%;
+`
+
+export const ErrorView = styled(ErrorViewUI)`
+  height: 100%;
+
+  ${media.md`
+  padding: 30px 0;
+  `}
 `

--- a/src/renderer/hooks/useMidgardHistoryActions.ts
+++ b/src/renderer/hooks/useMidgardHistoryActions.ts
@@ -135,11 +135,11 @@ export const useMidgardHistoryActions = (itemsPerPage = 10) => {
 
   return {
     loadHistory,
+    reloadHistory,
     historyPage,
     loading,
     requestParams,
     prevHistoryPage: prevHistoryPage.current,
-    reloadHistory,
     setPage,
     setFilter,
     setAddress

--- a/src/renderer/services/midgard/types.ts
+++ b/src/renderer/services/midgard/types.ts
@@ -191,9 +191,11 @@ export type PoolsService = {
   reloadInboundAddresses: FP.Lazy<void>
   selectedPoolDetail$: PoolDetailLD
   reloadSelectedPoolDetail: (delay?: number) => void
-  reloadPoolStatsDetail: FP.Lazy<void>
+  reloadLiquidityHistory: FP.Lazy<void>
   poolStatsDetail$: PoolStatsDetailLD
+  reloadPoolStatsDetail: FP.Lazy<void>
   poolEarningHistory$: PoolEarningHistoryLD
+  reloadPoolEarningHistory: FP.Lazy<void>
   getPoolLiquidityHistory$: (parmas: PoolLiquidityHistoryParams) => PoolLiquidityHistoryLD
   getSelectedPoolSwapHistory$: (params: GetSwapHistoryParams) => SwapHistoryLD
   apiGetSwapHistory$: (params: ApiGetSwapHistoryParams) => SwapHistoryLD

--- a/src/renderer/views/pool/PoolChartView.tsx
+++ b/src/renderer/views/pool/PoolChartView.tsx
@@ -22,16 +22,30 @@ import {
 } from '../../types/generated/midgard'
 import { getLiquidityFromHistoryItems, getVolumeFromHistoryItems } from './PoolChartView.helper'
 
-type Props = {
+export type Props = {
   priceRatio: BigNumber
 }
 
 export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
   const {
     service: {
-      pools: { selectedPricePoolAsset$, getSelectedPoolSwapHistory$, getDepthHistory$, getPoolLiquidityHistory$ }
+      pools: {
+        selectedPricePoolAsset$,
+        getSelectedPoolSwapHistory$,
+        reloadSwapHistory,
+        getDepthHistory$,
+        reloadDepthHistory,
+        getPoolLiquidityHistory$,
+        reloadLiquidityHistory
+      }
     }
   } = useMidgardContext()
+
+  const reloadData = useCallback(() => {
+    reloadDepthHistory()
+    reloadSwapHistory()
+    reloadLiquidityHistory()
+  }, [reloadDepthHistory, reloadLiquidityHistory, reloadSwapHistory])
 
   const selectedPricePoolAsset = useObservableState<SelectedPricePoolAsset>(selectedPricePoolAsset$, O.none)
   const unit = FP.pipe(
@@ -112,6 +126,7 @@ export const PoolChartView: React.FC<Props> = ({ priceRatio }) => {
     <PoolDetailsChart
       dataTypes={['liquidity', 'volume']}
       selectedDataType={savedParams.current.dataType}
+      reloadData={reloadData}
       setDataType={setDataTypeCallback}
       chartDetails={chartDataRDPriced}
       chartType={savedParams.current.dataType === 'liquidity' ? 'line' : 'bar'}

--- a/src/renderer/views/pool/PoolHistoryView.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.tsx
@@ -26,7 +26,7 @@ type Props = {
 const HISTORY_FILTERS: Filter[] = ['ALL', 'DEPOSIT', 'SWAP', 'WITHDRAW', 'DONATE', 'REFUND']
 
 export const PoolHistoryView: React.FC<Props> = ({ className, poolAsset, historyActions }) => {
-  const { loadHistory, requestParams, historyPage, prevHistoryPage, setFilter, setPage } = historyActions
+  const { loadHistory, reloadHistory, requestParams, historyPage, prevHistoryPage, setFilter, setPage } = historyActions
 
   const stringAsset = useMemo(() => assetToString(poolAsset), [poolAsset])
 
@@ -87,6 +87,7 @@ export const PoolHistoryView: React.FC<Props> = ({ className, poolAsset, history
       prevHistoryPage={prevHistoryPage}
       openExplorerTxUrl={openExplorerTxUrlHandler}
       changePaginationHandler={setPage}
+      reloadHistory={reloadHistory}
     />
   )
 }

--- a/src/renderer/views/pool/PoolHistoryView.types.tsx
+++ b/src/renderer/views/pool/PoolHistoryView.types.tsx
@@ -2,5 +2,5 @@ import { UseMidgardHistoryActions } from '../../hooks/useMidgardHistoryActions'
 
 export type PoolHistoryActions = Pick<
   UseMidgardHistoryActions,
-  'requestParams' | 'loadHistory' | 'historyPage' | 'prevHistoryPage' | 'setFilter' | 'setPage'
+  'requestParams' | 'loadHistory' | 'reloadHistory' | 'historyPage' | 'prevHistoryPage' | 'setFilter' | 'setPage'
 >

--- a/src/renderer/views/wallet/history/WalletHistoryView.tsx
+++ b/src/renderer/views/wallet/history/WalletHistoryView.tsx
@@ -166,6 +166,7 @@ export const WalletHistoryView: React.FC = () => {
         prevHistoryPage={prevHistoryPage}
         openExplorerTxUrl={openExplorerTxUrl}
         changePaginationHandler={setPage}
+        reloadHistory={reloadHistory}
       />
     </>
   )


### PR DESCRIPTION
- [x] Improve data handling of `PoolDetails` to show data as soon as possible
- [x] Each section has its own `ErrorView` - users can re-load (failing) data of this section 
- [x] Fix global `reload` action in `PoolDetails` to reload ALL data

Close #2234 