### PR TITLE
Fix: `Fast Refresh`

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "node-abi": "^3.15.0",
     "nodemon": "^2.0.16",
     "prettier": "^2.6.2",
+    "react-error-overlay": "6.0.9",
     "rimraf": "^3.0.2",
     "source-map-explorer": "^2.5.2",
     "testcafe": "^1.18.6",
@@ -185,6 +186,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.253f8c1.0"
+    "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.253f8c1.0",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16433,10 +16433,10 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-error-overlay@^6.0.9:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
by using a previous version of `react-error-overlay@6.0.9` to avoid `process is not defined` error after first refresh. Based on https://bobbyhadz.com/blog/react-referenceerror-process-not-defined

Fix #2258 