### PR TITLE
Resolve: [Pools] ERC20 filter includes BNB.ETH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.15.2 (2022-xx-xx)
+
+## Fix
+
+- [Pools] ERC20 filter includes BNB.ETH [#2273](https://github.com/thorchain/asgardex-electron/issues/2273)
+
 # 0.15.1 (2022-05-29)
 
 ## Fix

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -217,6 +217,7 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
   const renderPoolsTable = useCallback(
     (tableData: PoolTableRowData[], loading = false) => {
       const columns = isDesktopView ? desktopPoolsColumns : mobilePoolsColumns
+      const dataSource = FP.pipe(tableData, filterTableData(poolFilter))
 
       return (
         <>
@@ -232,7 +233,7 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
           <IncentivePendulum incentivePendulum={incentivePendulumRD} />
           <Table
             columns={columns}
-            dataSource={FP.pipe(tableData, filterTableData(poolFilter))}
+            dataSource={dataSource}
             loading={loading}
             rowKey="key"
             onRow={({ pool }: PoolTableRowData) => {

--- a/src/renderer/views/pools/PendingPools.tsx
+++ b/src/renderer/views/pools/PendingPools.tsx
@@ -162,6 +162,8 @@ export const PendingPools: React.FC<PoolsComponentProps> = ({ haltedChains, mimi
   const renderPoolsTable = useCallback(
     (tableData: PoolTableRowData[], loading = false) => {
       const columns = isDesktopView ? desktopPoolsColumns : mobilePoolsColumns
+      const dataSource = FP.pipe(tableData, filterTableData(poolFilter))
+
       return (
         <>
           <Styled.AssetsFilter
@@ -176,7 +178,7 @@ export const PendingPools: React.FC<PoolsComponentProps> = ({ haltedChains, mimi
           <IncentivePendulum incentivePendulum={incentivePendulumRD} />
           <Table
             columns={columns}
-            dataSource={FP.pipe(tableData, filterTableData(poolFilter))}
+            dataSource={dataSource}
             loading={loading}
             rowKey="key"
             onRow={({ pool }: PoolTableRowData) => {

--- a/src/renderer/views/pools/Pools.util.test.ts
+++ b/src/renderer/views/pools/Pools.util.test.ts
@@ -28,7 +28,8 @@ import {
   filterTableData,
   minPoolTxAmountUSD,
   stringToGetPoolsStatus,
-  isEmptyPool
+  isEmptyPool,
+  FilterTableData
 } from './Pools.utils'
 
 describe('views/pools/utils', () => {
@@ -131,7 +132,7 @@ describe('views/pools/utils', () => {
   })
 
   describe('filterTableData', () => {
-    const tableData = [
+    const tableData: FilterTableData[] = [
       {
         pool: {
           asset: AssetRuneNative,
@@ -185,6 +186,12 @@ describe('views/pools/utils', () => {
           asset: AssetRuneNative,
           target: AssetETH
         }
+      },
+      {
+        pool: {
+          asset: AssetRuneNative,
+          target: { chain: BNBChain, symbol: 'BNB.ETH-1C9', ticker: 'ETH', synth: false }
+        }
       }
     ] as PoolTableRowData[]
 
@@ -204,16 +211,13 @@ describe('views/pools/utils', () => {
     })
 
     it('should return BNB assets', () => {
-      expect(filterTableData(O.some(BNBChain))(tableData)).toEqual([tableData[0], tableData[4]])
+      const result = filterTableData(O.some(BNBChain))(tableData)
+      expect(result).toEqual([tableData[4], tableData[9]])
     })
 
     it('should return ETH assets', () => {
-      expect(filterTableData(O.some(ETHChain))(tableData)).toEqual([
-        tableData[5],
-        tableData[6],
-        tableData[7],
-        tableData[8]
-      ])
+      const result = filterTableData(O.some(ETHChain))(tableData)
+      expect(result).toEqual([tableData[5], tableData[6], tableData[7]])
     })
 
     it('should return USD assets', () => {


### PR DESCRIPTION
- [x] Exclude `{NonETH}.ETH` from `ERC20` filter
- [x] Exclude chain assets from `ERC20` + `BEP2` filters

Fix #2273