### PR TITLE
Fix guards `isBaseAmount` and `isBaseAmountEncoded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# 1.17.1 (2022-07-xx)
+
+## Fix
+
+[Ledger] THORChain tx does not send, but failed silently w/o error [#2310](https://github.com/thorchain/asgardex-electron/issues/2310)
+
 # 1.17.0 (2022-07-01)
 
 ## ADD
 
-- [Ledger] Support Cosmos (ATOM) [#2301](https://github.com/thorchain/asgardex-electron/issues/2301), [#2302](https://github.com/thorchain/asgardex-electron/pull/2302), [#2303](https://github.com/thorchain/asgardex-electron/pull/2303), [2304](https://github.com/thorchain/asgardex-electron/pull/2304), [2304](https://github.com/thorchain/asgardex-electron/pull/2304)
+- [Ledger] Support Cosmos (ATOM) [#2301](https://github.com/thorchain/asgardex-electron/issues/2301), [#2302](https://github.com/thorchain/asgardex-electron/pull/2302), [#2303](https://github.com/thorchain/asgardex-electron/pull/2303), [#2304](https://github.com/thorchain/asgardex-electron/pull/2304), [#2304](https://github.com/thorchain/asgardex-electron/pull/2304)
 
 ## Fix
 

--- a/src/shared/api/io.test.ts
+++ b/src/shared/api/io.test.ts
@@ -62,6 +62,39 @@ describe('shared/io', () => {
         feeAmount: { amount: '1', decimal: 6 }
       })
     })
+
+    it('encode IPCLedgerSendTxParams - undefined fee option / fee amount', () => {
+      const encoded = ipcLedgerSendTxParamsIO.encode({
+        chain: BNBChain,
+        network: 'mainnet',
+        asset: AssetBNB,
+        feeAsset: AssetBNB,
+        amount: baseAmount(10),
+        sender: 'address-abc',
+        recipient: 'address-abc',
+        memo: 'memo-abc',
+        walletIndex: 0,
+        feeRate: 1,
+        feeOption: undefined,
+        feeAmount: undefined
+      })
+
+      expect(encoded).toEqual({
+        chain: 'BNB',
+        network: 'mainnet',
+        asset: 'BNB.BNB',
+        feeAsset: 'BNB.BNB',
+        amount: { amount: '10', decimal: 8 },
+        sender: 'address-abc',
+        recipient: 'address-abc',
+        memo: 'memo-abc',
+        walletIndex: 0,
+        feeRate: 1,
+        feeOption: undefined,
+        feeAmount: undefined
+      })
+    })
+
     it('decode IPCLedgerSendTxParams', () => {
       const encoded = {
         chain: 'BNB',
@@ -92,6 +125,34 @@ describe('shared/io', () => {
             expect(r.memo).toEqual('memo-abc')
             expect(r.feeRate).toEqual(1)
             expect(eqBaseAmount.equals(r?.feeAmount ?? ZERO_BASE_AMOUNT, baseAmount(1, 6))).toBeTruthy()
+          }
+        )
+      )
+    })
+    it('decode IPCLedgerSendTxParams - feeAmount undefined', () => {
+      const encoded = {
+        chain: 'BNB',
+        network: 'mainnet',
+        asset: 'BNB.BNB',
+        amount: { amount: '10', decimal: 8 },
+        sender: 'address-abc',
+        recipient: 'address-abc',
+        memo: 'memo-abc',
+        walletIndex: 0,
+        feeRate: 1,
+        feeAmount: undefined
+      }
+      const decoded = ipcLedgerSendTxParamsIO.decode(encoded)
+      expect(E.isRight(decoded)).toBeTruthy()
+
+      FP.pipe(
+        decoded,
+        E.fold(
+          (error) => {
+            fail(error)
+          },
+          (r) => {
+            expect(r?.feeAmount).toBeUndefined()
           }
         )
       )

--- a/src/shared/api/io.ts
+++ b/src/shared/api/io.ts
@@ -39,7 +39,7 @@ export const assetListIO = t.array(assetIO)
 export type BaseAmountEncoded = { amount: string; decimal: number }
 
 const isBaseAmountEncoded = (u: unknown): u is BaseAmountEncoded =>
-  IOG.partial({ amount: IOG.string, decimal: IOG.number }).is(u)
+  !!u && IOG.partial({ amount: IOG.string, decimal: IOG.number }).is(u)
 
 export const baseAmountIO = new t.Type(
   'BaseAmountIO',

--- a/src/shared/utils/guard.test.ts
+++ b/src/shared/utils/guard.test.ts
@@ -69,6 +69,12 @@ describe('shared/utils/guard', () => {
     it('false for number', () => {
       expect(isBaseAmount(2)).toBeFalsy()
     })
+    it('false for undefined', () => {
+      expect(isBaseAmount(undefined)).toBeFalsy()
+    })
+    it('false for null', () => {
+      expect(isBaseAmount(null)).toBeFalsy()
+    })
   })
 
   describe('isWalletType', () => {

--- a/src/shared/utils/guard.ts
+++ b/src/shared/utils/guard.ts
@@ -45,6 +45,6 @@ const bnGuard: IOG.Guard<unknown, BigNumber> = {
 }
 
 export const isBaseAmount = (u: unknown): u is BaseAmount =>
-  IOG.number.is((u as BaseAmount).decimal) && bnGuard.is((u as BaseAmount).amount())
+  !!u && IOG.number.is((u as BaseAmount).decimal) && bnGuard.is((u as BaseAmount).amount())
 
 export const isError = (u: unknown): u is Error => u instanceof Error


### PR DESCRIPTION
which breaks sending `MsgSend` txs for Ledger THORChain.

Fix #2310