### PR TITLE
Another fix for guards `isBaseAmount` and `isBaseAmountEncoded`

### DIFF
--- a/src/shared/api/io.test.ts
+++ b/src/shared/api/io.test.ts
@@ -5,9 +5,44 @@ import * as FP from 'fp-ts/lib/function'
 
 import { ZERO_BASE_AMOUNT } from '../../renderer/const'
 import { eqBaseAmount } from '../../renderer/helpers/fp/eq'
-import { BaseAmountEncoded, baseAmountIO, ipcLedgerSendTxParamsIO, poolsWatchListsIO } from './io'
+import { BaseAmountEncoded, baseAmountIO, ipcLedgerSendTxParamsIO, isBaseAmountEncoded, poolsWatchListsIO } from './io'
 
 describe('shared/io', () => {
+  describe('isBaseAmountEncoded', () => {
+    it('true', () => {
+      const encoded = {
+        amount: '1',
+        decimal: 10
+      }
+      expect(isBaseAmountEncoded(encoded)).toBeTruthy()
+    })
+    it('false - no amount', () => {
+      const encoded = {
+        decimal: 10
+      }
+      expect(isBaseAmountEncoded(encoded)).toBeFalsy()
+    })
+    it('false - no decimal', () => {
+      const encoded = {
+        amount: '1'
+      }
+      expect(isBaseAmountEncoded(encoded)).toBeFalsy()
+    })
+    it('false misc.', () => {
+      expect(isBaseAmountEncoded(null)).toBeFalsy()
+      expect(isBaseAmountEncoded(undefined)).toBeFalsy()
+      expect(isBaseAmountEncoded(1)).toBeFalsy()
+      expect(isBaseAmountEncoded(true)).toBeFalsy()
+      expect(isBaseAmountEncoded(false)).toBeFalsy()
+      expect(isBaseAmountEncoded('')).toBeFalsy()
+      expect(isBaseAmountEncoded('hello-world')).toBeFalsy()
+      expect(
+        isBaseAmountEncoded({
+          hello: 'world'
+        })
+      ).toBeFalsy()
+    })
+  })
   describe('baseAmountIO', () => {
     it('encode BaseAmount', () => {
       const encoded = baseAmountIO.encode(baseAmount(1, 18))

--- a/src/shared/api/io.ts
+++ b/src/shared/api/io.ts
@@ -38,8 +38,8 @@ export const assetListIO = t.array(assetIO)
 
 export type BaseAmountEncoded = { amount: string; decimal: number }
 
-const isBaseAmountEncoded = (u: unknown): u is BaseAmountEncoded =>
-  !!u && IOG.partial({ amount: IOG.string, decimal: IOG.number }).is(u)
+export const isBaseAmountEncoded = (u: unknown): u is BaseAmountEncoded =>
+  IOG.struct({ amount: IOG.string, decimal: IOG.number }).is(u)
 
 export const baseAmountIO = new t.Type(
   'BaseAmountIO',

--- a/src/shared/utils/guard.test.ts
+++ b/src/shared/utils/guard.test.ts
@@ -57,23 +57,24 @@ describe('shared/utils/guard', () => {
   })
 
   describe('isBaseAmount', () => {
-    it('true for "THOR"', () => {
+    it('true"', () => {
       expect(isBaseAmount(baseAmount(1))).toBeTruthy()
     })
-    it('false for BigNumber', () => {
+    it('false -> BigNumber', () => {
       expect(isBaseAmount(bn('123'))).toBeFalsy()
     })
-    it('false for string', () => {
+    it('false -> string', () => {
       expect(isBaseAmount('123')).toBeFalsy()
+      expect(isBaseAmount('')).toBeFalsy()
     })
-    it('false for number', () => {
+    it('false -> number', () => {
       expect(isBaseAmount(2)).toBeFalsy()
     })
-    it('false for undefined', () => {
+    it('false -> misc.', () => {
       expect(isBaseAmount(undefined)).toBeFalsy()
-    })
-    it('false for null', () => {
       expect(isBaseAmount(null)).toBeFalsy()
+      expect(isBaseAmount({ hello: 'world' })).toBeFalsy()
+      expect(isBaseAmount({})).toBeFalsy()
     })
   })
 

--- a/src/shared/utils/guard.ts
+++ b/src/shared/utils/guard.ts
@@ -44,7 +44,14 @@ const bnGuard: IOG.Guard<unknown, BigNumber> = {
   is: (u: unknown): u is BigNumber => BigNumber.isBigNumber(u)
 }
 
-export const isBaseAmount = (u: unknown): u is BaseAmount =>
-  !!u && IOG.number.is((u as BaseAmount).decimal) && bnGuard.is((u as BaseAmount).amount())
+const baseAmountGuard: IOG.Guard<unknown, BaseAmount> = {
+  is: (u: unknown): u is BaseAmount => {
+    if (u === null && typeof u !== 'object') return false
+
+    return IOG.number.is((u as BaseAmount)?.decimal) && bnGuard.is((u as BaseAmount)?.amount())
+  }
+}
+
+export const isBaseAmount = (u: unknown): u is BaseAmount => baseAmountGuard.is(u)
 
 export const isError = (u: unknown): u is Error => u instanceof Error


### PR DESCRIPTION


Part of #2310