### PR TITLE
Extend wallet creation to consider `walletName`s

### DIFF
--- a/src/renderer/components/settings/WalletSettings.tsx
+++ b/src/renderer/components/settings/WalletSettings.tsx
@@ -574,11 +574,11 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
                   {intl.formatMessage({ id: 'wallet.add.label' })}
                 </FlatButton>
               </div>
-              <div className="flex w-full flex-col items-center justify-center md:w-1/2">
+              <div className="mt-20px flex w-full flex-col items-center justify-center md:mt-0 md:w-1/2">
                 <h2 className="w-full text-center font-main text-[12px] uppercase text-text2 dark:text-text2d">
                   {intl.formatMessage({ id: 'wallet.change.title' })}
                 </h2>
-                <WalletSelector wallets={wallets} onChange={changeWalletHandler} className="min-w-[100px]" />
+                <WalletSelector wallets={wallets} onChange={changeWalletHandler} className="min-w-[200px]" />
                 {renderChangeWalletError}
               </div>
             </div>

--- a/src/renderer/components/uielements/button/BaseButton.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.tsx
@@ -6,6 +6,7 @@ import type { Size } from './Button.types'
 export type BaseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: Size
   loading?: boolean
+  uppercase?: boolean
 }
 
 export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
@@ -15,6 +16,7 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
     className = '',
     disabled = false,
     type = 'button',
+    uppercase = true, // by default all texts are uppercase in ASDGX
     children,
     ...restProps
   } = props
@@ -44,11 +46,11 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
       className={`
       group
       flex appearance-none items-center
-        ${disabled && 'opacity-70'}
+        ${disabled && 'opacity-60'}
       justify-center
         ${disabled && 'cursor-not-allowed'}
         font-main
-        uppercase
+        ${uppercase && 'uppercase'}
         transition
         duration-300
         ease-in-out

--- a/src/renderer/components/uielements/button/BorderButton.tsx
+++ b/src/renderer/components/uielements/button/BorderButton.tsx
@@ -22,7 +22,8 @@ export const BorderButton: React.FC<Props> = (props): JSX.Element => {
   const borderColor: Record<Color, string> = {
     primary: 'border-turquoise',
     warning: 'border-warning0',
-    error: 'border-error0'
+    error: 'border-error0',
+    neutral: 'border-text0 dark:border-text0d'
   }
 
   const borderSize: Record<Size, string> = {
@@ -34,7 +35,8 @@ export const BorderButton: React.FC<Props> = (props): JSX.Element => {
   const textColor: Record<Color, string> = {
     primary: 'text-turquoise',
     warning: 'text-warning0 dark:text-warning0d',
-    error: 'text-error0 dark:text-error0d'
+    error: 'text-error0 dark:text-error0d',
+    neutral: 'text-text0 dark:text-text0d'
   }
   const dropShadow: Record<Size, string> = {
     small: 'drop-shadow-lg',

--- a/src/renderer/components/uielements/button/Button.types.ts
+++ b/src/renderer/components/uielements/button/Button.types.ts
@@ -20,4 +20,4 @@ export type ButtonProps = ComponentProps & AB.ButtonProps
 
 // Tailwind based button types
 export type Size = 'small' | 'normal' | 'large'
-export type Color = 'primary' | 'warning' | 'error'
+export type Color = 'primary' | 'warning' | 'error' | 'neutral'

--- a/src/renderer/components/uielements/button/FlatButton.tsx
+++ b/src/renderer/components/uielements/button/FlatButton.tsx
@@ -13,7 +13,15 @@ export const FlatButton: React.FC<Props> = (props): JSX.Element => {
   const bgColor: Record<Color, string> = {
     primary: 'bg-turquoise',
     warning: 'bg-warning0 dark:bg-warning0d',
-    error: 'bg-error0 dark:bg-error0d'
+    error: 'bg-error0 dark:bg-error0d',
+    neutral: 'bg-gray0 dark:bg-gray0d'
+  }
+
+  const textColor: Record<Color, string> = {
+    primary: 'text-white',
+    warning: 'text-white',
+    error: 'text-white',
+    neutral: 'text-text0 dark:text-text0d'
   }
 
   const dropShadow: Record<Size, string> = {
@@ -28,7 +36,7 @@ export const FlatButton: React.FC<Props> = (props): JSX.Element => {
       disabled={disabled}
       className={`
       rounded-full
-      text-white
+        ${textColor[color]}
         ${bgColor[color]}
         ${!disabled && `hover:${dropShadow[size]}`}
         ${!disabled && 'hover:border-opacity-85'}

--- a/src/renderer/components/uielements/button/LinkButton.tsx
+++ b/src/renderer/components/uielements/button/LinkButton.tsx
@@ -13,7 +13,8 @@ export const LinkButton: React.FC<Props> = (props): JSX.Element => {
   const decorationColor: Record<Color, string> = {
     primary: 'decoration-turquoise',
     warning: 'decoration--warning0',
-    error: 'decoration--error0'
+    error: 'decoration--error0',
+    neutral: 'decoration--text0 dark:decoration--text0d'
   }
   const decorationOffset: Record<Size, string> = {
     small: 'underline-offset-1',

--- a/src/renderer/components/uielements/button/TextButton.tsx
+++ b/src/renderer/components/uielements/button/TextButton.tsx
@@ -13,7 +13,8 @@ export const TextButton: React.FC<Props> = (props): JSX.Element => {
   const textColor: Record<Color, string> = {
     primary: 'text-turquoise',
     warning: 'text-warning0',
-    error: 'text-error0'
+    error: 'text-error0',
+    neutral: 'text-text0 dark:text-text0d'
   }
 
   return (

--- a/src/renderer/components/wallet/keystore/ImportKeystore.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.tsx
@@ -14,6 +14,7 @@ import '../../uielements/input/overrides.css'
 import { defaultWalletName } from '../../../../shared/utils/wallet'
 import { KeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
 import { useSubscriptionState } from '../../../hooks/useSubscriptionState'
+import { MAX_WALLET_NAME_CHARS } from '../../../services/wallet/const'
 import { ImportingKeystoreStateRD, ImportKeystoreParams, LoadKeystoreLD } from '../../../services/wallet/types'
 import { InnerForm } from '../../shared/form/Form.styles'
 import { Spin } from '../../shared/loading'
@@ -138,8 +139,23 @@ export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
               <InputPassword className="!text-lg" size="large" />
             </Form.Item>
             {/* name */}
-            <Form.Item className="w-full !max-w-[380px]" name="name" label={intl.formatMessage({ id: 'wallet.name' })}>
-              <Input className="!text-lg" size="large" maxLength={20} placeholder={defaultWalletName(walletId)} />
+            <Form.Item
+              className="w-full !max-w-[380px]"
+              name="name"
+              label={
+                <div>
+                  {intl.formatMessage({ id: 'wallet.name' })}
+                  <span className="pl-5px text-[12px] text-gray1 dark:text-gray1d">
+                    ({intl.formatMessage({ id: 'wallet.name.maxChars' }, { max: MAX_WALLET_NAME_CHARS })})
+                  </span>
+                </div>
+              }>
+              <Input
+                className="!text-lg"
+                size="large"
+                maxLength={MAX_WALLET_NAME_CHARS}
+                placeholder={defaultWalletName(walletId)}
+              />
             </Form.Item>
             {/* submit button */}
             <Button

--- a/src/renderer/components/wallet/phrase/ImportPhrase.tsx
+++ b/src/renderer/components/wallet/phrase/ImportPhrase.tsx
@@ -12,8 +12,8 @@ import { useIntl } from 'react-intl'
 
 import { defaultWalletName } from '../../../../shared/utils/wallet'
 import { KeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
+import { MAX_WALLET_NAME_CHARS } from '../../../services/wallet/const'
 import { AddKeystoreParams } from '../../../services/wallet/types'
-import { generateKeystoreId } from '../../../services/wallet/util'
 import { Spin } from '../../shared/loading'
 import { Button } from '../../uielements/button'
 import { InputPassword, InputTextArea, Input } from '../../uielements/input'
@@ -73,11 +73,9 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
 
   const submitForm = useCallback(
     async ({ phrase: newPhrase, password, name }: Store) => {
-      const id = generateKeystoreId()
-
       setImportError(O.none)
       setImporting(true)
-      await addKeystore({ phrase: newPhrase, name: name || defaultWalletName(walletId), id, password }).catch(
+      await addKeystore({ phrase: newPhrase, name: name || defaultWalletName(walletId), id: walletId, password }).catch(
         (error) => {
           setImporting(false)
           // TODO(@Veado): i18n
@@ -166,8 +164,23 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
             </Form.Item>
 
             {/* name */}
-            <Form.Item name="name" className="w-full !max-w-[380px]" label={intl.formatMessage({ id: 'wallet.name' })}>
-              <Input className="!text-lg" size="large" maxLength={20} placeholder={defaultWalletName(walletId)} />
+            <Form.Item
+              name="name"
+              className="w-full !max-w-[380px]"
+              label={
+                <div>
+                  {intl.formatMessage({ id: 'wallet.name' })}
+                  <span className="pl-5px text-[12px] text-gray1 dark:text-gray1d">
+                    ({intl.formatMessage({ id: 'wallet.name.maxChars' }, { max: MAX_WALLET_NAME_CHARS })})
+                  </span>
+                </div>
+              }>
+              <Input
+                className="!text-lg"
+                size="large"
+                maxLength={MAX_WALLET_NAME_CHARS}
+                placeholder={defaultWalletName(walletId)}
+              />
             </Form.Item>
 
             <Button

--- a/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
+++ b/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
@@ -1,24 +1,10 @@
 import * as A from 'antd'
 import styled from 'styled-components'
-import { palette } from 'styled-theme'
 
 import { InnerForm } from '../../shared/form/Form.styles'
 
 export const TitleContainer = styled(A.Row).attrs({ justify: 'space-between' })`
   margin-bottom: 16px;
-`
-
-export const SectionTitle = styled(A.Typography.Text)`
-  text-transform: uppercase;
-  font-size: 16px;
-  color: ${palette('text', 0)};
-
-  // Copy to Clipboard and reset mnemonic phrase action icons
-  // Keep them here together to avoid inconsistency
-  > [role='button'],
-  button {
-    color: ${palette('primary', 0)};
-  }
 `
 
 export const Form = styled(InnerForm)`

--- a/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
+++ b/src/renderer/components/wallet/phrase/NewPhrase.styles.ts
@@ -1,17 +1,8 @@
 import * as A from 'antd'
 import styled from 'styled-components'
 
-import { InnerForm } from '../../shared/form/Form.styles'
-
 export const TitleContainer = styled(A.Row).attrs({ justify: 'space-between' })`
   margin-bottom: 16px;
-`
-
-export const Form = styled(InnerForm)`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
 `
 
 export const FormItem = styled(A.Form.Item)`
@@ -23,16 +14,5 @@ export const FormItem = styled(A.Form.Item)`
     &-explain-error {
       text-transform: uppercase;
     }
-  }
-`
-
-export const SubmitItem = styled(A.Form.Item)`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-
-  // This is safety 'cause we set it only for submit item's container
-  .ant-col.ant-form-item-control {
-    width: auto !important;
   }
 `

--- a/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
@@ -109,7 +109,7 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
   const handleFormSubmit = useCallback(() => {
     const checkwords = checkPhraseConfirmWords(wordsList, sortedSelectedWords)
 
-    if (checkwords) {
+    if (checkwords && !loading) {
       setLoading(true)
       onConfirm()
         .then(() => {
@@ -127,7 +127,7 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
     else if (wordsList.length === sortedSelectedWords.length) {
       setMnemonicError(intl.formatMessage({ id: 'wallet.create.error.phrase' }))
     }
-  }, [checkPhraseConfirmWords, onConfirm, wordsList, sortedSelectedWords, navigate, intl])
+  }, [checkPhraseConfirmWords, wordsList, sortedSelectedWords, loading, onConfirm, navigate, intl])
 
   return (
     <>
@@ -168,7 +168,13 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
               </div>
             ))}
           </div>
-          <FlatButton className="mt-20px" size="large" color="primary" type="submit" loading={loading}>
+          <FlatButton
+            className="mt-20px"
+            size="large"
+            color="primary"
+            type="submit"
+            loading={loading}
+            disabled={loading}>
             {intl.formatMessage({ id: 'common.finish' })}
           </FlatButton>
         </div>

--- a/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
@@ -1,20 +1,20 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
 import { DeleteOutlined, RedoOutlined } from '@ant-design/icons'
-import { Col, Row, Button as AButton } from 'antd'
+import { Form } from 'antd'
 import shuffleArray from 'lodash.shuffle'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 
+import { isError } from '../../../../shared/utils/guard'
 import { isSelectedFactory, sortedSelected } from '../../../helpers/array'
 import * as walletRoutes from '../../../routes/wallet'
-import { Button } from '../../uielements/button'
+import { FlatButton, TextButton } from '../../uielements/button'
 import { Phrase } from './index'
 import * as NewPhraseStyled from './NewPhrase.styles'
 import { checkPhraseConfirmWordsFactory } from './NewPhraseConfirm.helper'
 import { WordType } from './NewPhraseConfirm.types'
-import * as PhraseStyled from './Phrase.styles'
 
 export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Promise<void> }> = ({
   mnemonic,
@@ -26,6 +26,7 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
   const [initialized, setInitialized] = useState<boolean>(false)
   const intl = useIntl()
   const navigate = useNavigate()
+  const [loading, setLoading] = useState(false)
 
   const updateWordList = useCallback(
     (wordList: WordType[]) => {
@@ -109,12 +110,17 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
     const checkwords = checkPhraseConfirmWords(wordsList, sortedSelectedWords)
 
     if (checkwords) {
+      setLoading(true)
       onConfirm()
         .then(() => {
           navigate(walletRoutes.base.path())
         })
-        .catch(() => {
-          setMnemonicError(intl.formatMessage({ id: 'wallet.create.error' }))
+        .catch((error) => {
+          setLoading(false)
+          const errorMsg = `${intl.formatMessage({ id: 'wallet.create.error' })} (error: ${
+            isError(error) ? error?.message ?? error.toString() : `${error}`
+          })`
+          setMnemonicError(errorMsg)
         })
     }
     // In case ALL words were entered in a wrong set error
@@ -125,49 +131,48 @@ export const NewPhraseConfirm: React.FC<{ mnemonic: string; onConfirm: () => Pro
 
   return (
     <>
-      <NewPhraseStyled.TitleContainer>
-        <NewPhraseStyled.SectionTitle>
+      <Form labelCol={{ span: 24 }} onFinish={handleFormSubmit}>
+        <h2 className="mb-20px text-center font-mainSemiBold text-16 uppercase text-text0 dark:text-text0d">
           {intl.formatMessage({ id: 'wallet.create.enter.phrase' })}
-        </NewPhraseStyled.SectionTitle>
-      </NewPhraseStyled.TitleContainer>
-      <NewPhraseStyled.Form labelCol={{ span: 24 }} onFinish={handleFormSubmit}>
-        <NewPhraseStyled.FormItem
-          name="mnemonic"
-          validateStatus={mnemonicError && 'error'}
-          help={!!mnemonicError && mnemonicError}>
-          <Phrase wordIcon={<DeleteOutlined />} words={sortedSelectedWords} onWordClick={handleRemoveWord} />
-        </NewPhraseStyled.FormItem>
+        </h2>
+        <div className="flex w-full flex-col items-center justify-center">
+          <NewPhraseStyled.FormItem
+            className="w-full"
+            name="mnemonic"
+            validateStatus={mnemonicError && 'error'}
+            help={!!mnemonicError && mnemonicError}>
+            <Phrase wordIcon={<DeleteOutlined />} words={sortedSelectedWords} onWordClick={handleRemoveWord} />
+          </NewPhraseStyled.FormItem>
 
-        <PhraseStyled.EnterPhraseContainer
-          label={
-            <NewPhraseStyled.SectionTitle>
-              {intl.formatMessage({ id: 'wallet.create.words.click' })}
-              <AButton type="link" onClick={handleResetPhrase}>
-                <RedoOutlined />
-              </AButton>
-            </NewPhraseStyled.SectionTitle>
-          }>
-          <Row>
+          <h2 className="flex items-center font-mainSemiBold text-16 uppercase text-text0 dark:text-text0d">
+            {intl.formatMessage({ id: 'wallet.create.words.click' })}
+            <FlatButton onClick={handleResetPhrase} color="neutral" className="ml-10px">
+              <RedoOutlined />
+            </FlatButton>
+          </h2>
+          <div
+            className="my-20px grid
+                gap-4 p-[6p6] sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6
+                ">
             {shuffledWordsList.map((word: WordType) => (
-              <Col sm={{ span: 12 }} md={{ span: 4 }} key={word._id} style={{ padding: '6px' }}>
-                <PhraseStyled.Button
-                  type={'text'}
-                  size={'large'}
+              <div key={word._id} className="text-center">
+                <TextButton
+                  className="m-[6px]"
+                  uppercase={false}
+                  size="large"
+                  color="neutral"
                   disabled={isSelected(word._id)}
-                  onClick={() => handleAddWord(word._id)}
-                  style={{ margin: '6px' }}>
+                  onClick={() => handleAddWord(word._id)}>
                   {word.text}
-                </PhraseStyled.Button>
-              </Col>
+                </TextButton>
+              </div>
             ))}
-          </Row>
-        </PhraseStyled.EnterPhraseContainer>
-        <NewPhraseStyled.SubmitItem>
-          <Button size="large" type="primary" round="true" htmlType="submit">
+          </div>
+          <FlatButton className="mt-20px" size="large" color="primary" type="submit" loading={loading}>
             {intl.formatMessage({ id: 'common.finish' })}
-          </Button>
-        </NewPhraseStyled.SubmitItem>
-      </NewPhraseStyled.Form>
+          </FlatButton>
+        </div>
+      </Form>
     </>
   )
 }

--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -36,7 +36,7 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit, walletId }: Props
 
   const [phrase, setPhrase] = useState(generatePhrase())
 
-  const initiialWalletName = useMemo(() => defaultWalletName(walletId), [walletId])
+  const initialWalletName = useMemo(() => defaultWalletName(walletId), [walletId])
 
   const [clickRefreshButtonHandler, refreshButtonClicked$] = useObservableCallback<React.MouseEvent>((event$) =>
     // Delay clicks to give `generatePhrase` some time to process w/o rendering issues
@@ -61,14 +61,16 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit, walletId }: Props
 
   const handleFormFinish = useCallback(
     ({ password, name }: FormValues) => {
-      try {
-        setLoading(true)
-        onSubmit({ phrase, password, name: name || initiialWalletName })
-      } catch (err) {
-        setLoading(false)
+      if (!loading) {
+        try {
+          setLoading(true)
+          onSubmit({ phrase, password, name: name || initialWalletName })
+        } catch (err) {
+          setLoading(false)
+        }
       }
     },
-    [initiialWalletName, onSubmit, phrase]
+    [initialWalletName, loading, onSubmit, phrase]
   )
 
   const rules: Rule[] = useMemo(
@@ -129,10 +131,16 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit, walletId }: Props
               className="!text-lg"
               size="large"
               maxLength={MAX_WALLET_NAME_CHARS}
-              placeholder={initiialWalletName}
+              placeholder={initialWalletName}
             />
           </Form.Item>
-          <FlatButton className="mt-20px" size="large" color="primary" type="submit" loading={loading}>
+          <FlatButton
+            className="mt-20px"
+            size="large"
+            color="primary"
+            type="submit"
+            loading={loading}
+            disabled={loading}>
             {intl.formatMessage({ id: 'common.next' })}
           </FlatButton>
         </div>

--- a/src/renderer/components/wallet/phrase/Phrase.styles.ts
+++ b/src/renderer/components/wallet/phrase/Phrase.styles.ts
@@ -2,7 +2,6 @@ import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
-import { Button as UIButton } from '../../uielements/button'
 import { Label as UILabel } from '../../uielements/label'
 
 export const Card = styled(A.Card).attrs({
@@ -41,27 +40,6 @@ export const Button = styled(A.Button)<{ readOnly?: boolean }>`
   ${({ disabled }) => disabled && `opacity: 0.5;`}
 `
 
-export const EnterPhraseContainer = styled(A.Form.Item)`
-  flex: 1;
-  flex-direction: column;
-`
-
 export const Row = styled(A.Row)`
   margin-bottom: 32px;
-`
-
-export const PasswordContainer = styled(A.Row)`
-  max-width: 280px;
-`
-export const PasswordItem = styled(A.Form.Item)`
-  width: 100%;
-`
-
-export const SubmitButton = styled(UIButton).attrs({
-  sizevalue: 'normal',
-  type: 'primary',
-  htmlType: 'submit',
-  round: 'true'
-})`
-  min-width: 150px !important;
 `

--- a/src/renderer/components/wallet/phrase/Phrase.styles.ts
+++ b/src/renderer/components/wallet/phrase/Phrase.styles.ts
@@ -2,19 +2,12 @@ import * as A from 'antd'
 import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
-import { Label as UILabel } from '../../uielements/label'
-
 export const Card = styled(A.Card).attrs({
   bodyStyle: { padding: '6px', minHeight: '100px' }
 })`
   border-color: ${palette('primary', 0)};
   background: transparent;
 `
-
-export const Title = styled(UILabel).attrs({
-  textTransform: 'uppercase',
-  size: 'big'
-})``
 
 const iconClassName = 'mnemonic-word__icon'
 export const IconWrapper = styled('span').attrs({ className: iconClassName })`

--- a/src/renderer/components/wallet/phrase/Phrase.tsx
+++ b/src/renderer/components/wallet/phrase/Phrase.tsx
@@ -10,13 +10,14 @@ type Props = {
   onWordClick?: (id: string) => void
   readOnly?: boolean
   wordIcon?: React.ReactNode
+  className?: string
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Phrase = React.forwardRef<any, Props>(
-  ({ words, onWordClick = () => {}, readOnly, wordIcon = null }, ref) => {
+  ({ words, onWordClick = () => {}, readOnly, wordIcon = null, className = '' }, ref) => {
     return (
-      <Styled.Row ref={ref}>
+      <Styled.Row ref={ref} className={className}>
         <Col span={24}>
           <Styled.Card>
             <Row>

--- a/src/renderer/components/wallet/phrase/Phrase.types.ts
+++ b/src/renderer/components/wallet/phrase/Phrase.types.ts
@@ -1,1 +1,1 @@
-export type PhraseInfo = { phrase: string; password: string }
+export type PhraseInfo = { phrase: string; password: string; name: string }

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -2,6 +2,7 @@ import { WalletMessages } from '../types'
 
 const wallet: WalletMessages = {
   'wallet.name': 'Wallet Name',
+  'wallet.name.maxChars': 'Max. {max} Zeichen',
   'wallet.nav.deposits': 'Einzahlungen',
   'wallet.nav.bonds': 'Bonds',
   'wallet.nav.poolshares': 'Anteile',
@@ -50,12 +51,11 @@ const wallet: WalletMessages = {
   'wallet.change.error': 'Error beim Wechseln der Wallet',
   'wallet.selected.title': 'Ausgwählte Wallet',
   'wallet.create.title': 'Erstelle eine Wallet',
-  'wallet.create.enter.phrase': 'Gebe die Phrase richtig ein',
+  'wallet.create.enter.phrase': 'Gebe Deine Phrase in richtiger Reihenfolge ein',
   'wallet.create.words.click': 'Klicke die Wörter in der richtigen Reihenfolge',
   'wallet.create.creating': 'Erstelle eine Wallet ...',
-  'wallet.create.error': 'Fehler beim Abspeichern der Phrase',
-  'wallet.create.error.phrase':
-    'Speicher Deine Phrase an einem sicheren Ort und gebe diese in der richtigen Reihenfolge ein',
+  'wallet.create.error': 'Fehler beim Erstellen der Wallet',
+  'wallet.create.error.phrase': 'Falsche Phrase. Bitte überprüfe Deine Phrase und gebe diese erneut ein.',
   'wallet.receive.address.error': 'Keine Addresse für den Empfang vorhanden',
   'wallet.receive.address.errorQR': 'Error beim Rendern des QR Codes: {error}',
   'wallet.remove.label': 'Wallet entfernen',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -2,6 +2,7 @@ import { WalletMessages } from '../types'
 
 const wallet: WalletMessages = {
   'wallet.name': 'Wallet name',
+  'wallet.name.maxChars': 'Max. {max} chars',
   'wallet.nav.deposits': 'Deposits',
   'wallet.nav.bonds': 'Bonds',
   'wallet.nav.poolshares': 'Shares',
@@ -49,11 +50,11 @@ const wallet: WalletMessages = {
   'wallet.change.error': 'Error while changing a wallet',
   'wallet.selected.title': 'Selected wallet',
   'wallet.create.title': 'Create new wallet',
-  'wallet.create.enter.phrase': 'Enter phrase correctly',
-  'wallet.create.error.phrase': 'Save your phrase at a safety place and enter it in a correct way',
+  'wallet.create.enter.phrase': 'Enter your phrase in a right order',
+  'wallet.create.error.phrase': 'Wrong phrase. Please double check your phrase and re-enter it again.',
   'wallet.create.words.click': 'Click the word in correct order',
   'wallet.create.creating': 'Creating wallet',
-  'wallet.create.error': 'Error while saving a phrase',
+  'wallet.create.error': 'Error while creating a wallet',
   'wallet.receive.address.error': 'No address available to receive funds',
   'wallet.receive.address.errorQR': 'Error while rendering QR code: {error}',
   'wallet.remove.label': 'Forget wallet',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -2,6 +2,7 @@ import { WalletMessages } from '../types'
 
 const wallet: WalletMessages = {
   'wallet.name': 'Wallet name - FR',
+  'wallet.name.maxChars': 'Max. {max} chars - FR',
   'wallet.nav.deposits': 'Dépots',
   'wallet.nav.bonds': 'Cautions',
   'wallet.nav.poolshares': 'Quote-part',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -2,6 +2,7 @@ import { WalletMessages } from '../types'
 
 const wallet: WalletMessages = {
   'wallet.name': 'Wallet name - RU',
+  'wallet.name.maxChars': 'Max. {max} chars - RU',
   'wallet.nav.deposits': 'Вклады',
   'wallet.nav.bonds': 'Бонды',
   'wallet.nav.poolshares': 'Доли',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -150,6 +150,7 @@ export type PoolsMessages = { [key in PoolsMessageKey]: string }
 
 type WalletMessageKey =
   | 'wallet.name'
+  | 'wallet.name.maxChars'
   | 'wallet.nav.deposits'
   | 'wallet.nav.bonds'
   | 'wallet.nav.poolshares'

--- a/src/renderer/routes/wallet/create.ts
+++ b/src/renderer/routes/wallet/create.ts
@@ -20,10 +20,3 @@ export const phrase: Route<void> = {
     return this.template
   }
 }
-
-export const phraseConfirm: Route<void> = {
-  template: `${base.template}/phrase-confirm`,
-  path() {
-    return this.template
-  }
-}

--- a/src/renderer/services/wallet/const.ts
+++ b/src/renderer/services/wallet/const.ts
@@ -63,3 +63,5 @@ export const INITIAL_LEDGER_ADDRESSES_MAP: LedgerAddressesMap = {
   [Chain.Doge]: INITIAL_LEDGER_ADDRESS_MAP,
   [Chain.Terra]: INITIAL_LEDGER_ADDRESS_MAP
 }
+
+export const MAX_WALLET_NAME_CHARS = 20

--- a/src/renderer/views/wallet/CreateView/PhraseView.tsx
+++ b/src/renderer/views/wallet/CreateView/PhraseView.tsx
@@ -1,59 +1,37 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 
-import { Route, useNavigate, Navigate, useLocation, Routes } from 'react-router-dom'
+import * as FP from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
 
-import { defaultWalletName } from '../../../../shared/utils/wallet'
 import { NewPhraseConfirm, NewPhraseGenerate } from '../../../components/wallet/phrase'
 import { PhraseInfo } from '../../../components/wallet/phrase/Phrase.types'
 import { useWalletContext } from '../../../contexts/WalletContext'
-import * as walletRoutes from '../../../routes/wallet'
 import { generateKeystoreId } from '../../../services/wallet/util'
 
-const NewPhraseConfirmView: React.FC = (): JSX.Element => {
-  const location = useLocation()
-  const { keystoreService } = useWalletContext()
-  const phrase = (location.state as PhraseInfo)?.phrase ?? ''
-  const password = (location.state as PhraseInfo)?.password ?? ''
-
-  if (!phrase || !password) {
-    return <Navigate to={walletRoutes.create.phrase.path()} replace />
-  }
-
-  const id = generateKeystoreId()
-  // TODO (@veado) Get name from route
-  const name = defaultWalletName(id)
-
-  return (
-    <NewPhraseConfirm
-      mnemonic={phrase}
-      onConfirm={() => keystoreService.addKeystoreWallet({ phrase, password, id, name })}
-    />
-  )
-}
-
-export default NewPhraseConfirmView
-
 export const PhraseView: React.FC = () => {
-  const navigate = useNavigate()
+  const { keystoreService } = useWalletContext()
 
-  return (
-    <Routes>
-      <Route
-        // Nested route - last part of `walletRoutes.create.phraseConfirm.template` needed only
-        path="phrase-confirm"
-        element={<NewPhraseConfirmView />}
-      />
-      <Route
-        // Nested route - last part of `walletRoutes.create.phrase.template` needed only
-        path="phrase"
-        element={
-          <NewPhraseGenerate
-            onSubmit={({ phrase, password }) => {
-              navigate(walletRoutes.create.phraseConfirm.path(), { state: { phrase, password } })
-            }}
-          />
-        }
-      />
-    </Routes>
+  const [phraseInfo, setPhraseInfo] = useState<O.Option<PhraseInfo>>(O.none)
+
+  const walletId = useMemo(() => generateKeystoreId(), [])
+
+  return FP.pipe(
+    phraseInfo,
+    O.fold(
+      () => (
+        <NewPhraseGenerate
+          walletId={walletId}
+          onSubmit={(phraseInfo) => {
+            setPhraseInfo(O.some(phraseInfo))
+          }}
+        />
+      ),
+      ({ phrase, password, name }) => (
+        <NewPhraseConfirm
+          mnemonic={phrase}
+          onConfirm={() => keystoreService.addKeystoreWallet({ phrase, password, id: walletId, name })}
+        />
+      )
+    )
   )
 }


### PR DESCRIPTION
- [x] Refactor `Phrase` components/views to add `walletName` and to get rid of extra routing
- [x] Update `Base|Link|Text|FlatButtons`: (add `neutral` color, option for `uppercase`)
- [x] Misc. style fixes
- [x] Update `i18n`


Part of #1601