### PR TITLE
Use `Text|Flat|BorderButtons` to get rid of LegacyButton

### DIFF
--- a/src/renderer/components/deposit/add/Deposit.styles.ts
+++ b/src/renderer/components/deposit/add/Deposit.styles.ts
@@ -137,15 +137,6 @@ export const SubmitContainer = styled.div`
   align-items: center;
 `
 
-export const SubmitButton = styled(UIButton).attrs({
-  type: 'primary',
-  round: 'true'
-})`
-  min-width: 200px !important;
-  padding: 0 30px;
-  margin-bottom: 20px;
-`
-
 export const AssetWarningAssetContainer = styled('div')`
   display: flex;
   flex-direction: row;

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -88,7 +88,7 @@ import { LedgerConfirmationModal } from '../../modal/confirmation'
 import { WalletPasswordConfirmationModal } from '../../modal/confirmation'
 import { TxModal } from '../../modal/tx'
 import { DepositAssets } from '../../modal/tx/extra'
-import { ViewTxButton } from '../../uielements/button'
+import { FlatButton, ViewTxButton } from '../../uielements/button'
 import { Fees, UIFeesRD } from '../../uielements/fees'
 import * as InfoIconStyled from '../../uielements/info/InfoIcon.styles'
 import { AssetMissmatchWarning } from './AssetMissmatchWarning'
@@ -1593,23 +1593,24 @@ export const SymDeposit: React.FC<Props> = (props) => {
           <>
             {renderAssetChainFeeError}
             {renderThorchainFeeError}
-            <Styled.SubmitButton sizevalue="xnormal" onClick={onSubmit} disabled={disableSubmit}>
+            <FlatButton className="mb-20px min-w-[200px]" size="large" onClick={onSubmit} disabled={disableSubmit}>
               {intl.formatMessage({ id: 'common.add' })}
-            </Styled.SubmitButton>
+            </FlatButton>
             <Fees fees={uiFeesRD} reloadFees={reloadFeesHandler} disabled={disabledForm} />
           </>
         ) : (
           <>
             {renderApproveFeeError}
             {renderApproveError}
-            <Styled.SubmitButton
-              sizevalue="xnormal"
+            <FlatButton
+              className="mb-20px min-w-[200px]"
+              size="large"
               color="warning"
               disabled={disableSubmitApprove}
               onClick={onApprove}
               loading={RD.isPending(approveState)}>
               {intl.formatMessage({ id: 'common.approve' })}
-            </Styled.SubmitButton>
+            </FlatButton>
 
             {!RD.isInitial(uiApproveFeesRD) && <Fees fees={uiApproveFeesRD} reloadFees={reloadApproveFeesHandler} />}
           </>

--- a/src/renderer/components/deposit/withdraw/Withdraw.styles.ts
+++ b/src/renderer/components/deposit/withdraw/Withdraw.styles.ts
@@ -5,7 +5,6 @@ import { media } from '../../../helpers/styleHelper'
 import { AssetIcon as AssetIconBase } from '../../uielements/assets/assetIcon'
 import { AssetLabel as AssetLabelUI } from '../../uielements/assets/assetLabel'
 import { ViewTxButton as UIViewTxButton } from '../../uielements/button'
-import { Button as UIButton } from '../../uielements/button'
 import { WalletTypeLabel as WalletTypeLabelUI } from '../../uielements/common/Common.styles'
 import { Label as UILabel } from '../../uielements/label'
 import { Slider as BaseSlider } from '../../uielements/slider'
@@ -155,22 +154,4 @@ export const WalletTypeLabel = styled(WalletTypeLabelUI)`
   ${media.md`
   font-size: 10px;
 `}
-`
-
-export const SubmitButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 20px 0;
-`
-
-export const SubmitButton = styled(UIButton).attrs({
-  type: 'primary',
-  round: 'true'
-})`
-  min-width: 200px !important;
-  margin-bottom: 30px;
-  padding-left: 30px;
-  padding-right: 30px;
 `

--- a/src/renderer/components/deposit/withdraw/Withdraw.tsx
+++ b/src/renderer/components/deposit/withdraw/Withdraw.tsx
@@ -47,6 +47,7 @@ import { AssetWithDecimal } from '../../../types/asgardex'
 import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../modal/confirmation'
 import { TxModal } from '../../modal/tx'
 import { DepositAssets } from '../../modal/tx/extra'
+import { FlatButton } from '../../uielements/button'
 import { TooltipAddress } from '../../uielements/common/Common.styles'
 import { Fees, UIFeesRD } from '../../uielements/fees'
 import * as Helper from './Withdraw.helper'
@@ -560,11 +561,11 @@ export const Withdraw: React.FC<Props> = ({
           </Styled.FeeErrorRow>
         </Col>
       </Styled.FeesRow>
-      <Styled.SubmitButtonWrapper>
-        <Styled.SubmitButton sizevalue="xnormal" onClick={onSubmit} disabled={disabledSubmit}>
+      <div className="flex flex-col items-center justify-center py-20px">
+        <FlatButton className="mb-30px min-w-[200px] px-20px" size="large" onClick={onSubmit} disabled={disabledSubmit}>
           {intl.formatMessage({ id: 'common.withdraw' })}
-        </Styled.SubmitButton>
-      </Styled.SubmitButtonWrapper>
+        </FlatButton>
+      </div>
       {renderPasswordConfirmationModal}
       {renderLedgerConfirmationModal}
       {renderTxModal}

--- a/src/renderer/components/manageButton/ManageButton.stories.tsx
+++ b/src/renderer/components/manageButton/ManageButton.stories.tsx
@@ -9,10 +9,10 @@ export const Default = Template.bind({})
 const meta: ComponentMeta<typeof Component> = {
   title: 'Components/ManageButton',
   argTypes: {
-    sizevalue: {
+    size: {
       control: {
         type: 'select',
-        options: ['small', 'normal', 'xnormal', 'big']
+        options: ['small', 'normal', 'large']
       }
     }
   },
@@ -20,7 +20,7 @@ const meta: ComponentMeta<typeof Component> = {
     isTextView: true,
     asset: AssetRuneNative,
     disabled: false,
-    sizevalue: 'normal'
+    size: 'normal'
   }
 }
 

--- a/src/renderer/components/manageButton/ManageButton.tsx
+++ b/src/renderer/components/manageButton/ManageButton.tsx
@@ -6,23 +6,15 @@ import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 
 import * as poolsRoutes from '../../routes/pools'
-import { Button, ButtonProps, ButtonSize } from '../uielements/button'
+import { BorderButton } from '../uielements/button'
+import type { Props as BorderButtonProps } from '../uielements/button/BorderButton'
 
-export type Props = ButtonProps & {
+export type Props = BorderButtonProps & {
   className?: string
   asset: Asset
-  sizevalue?: ButtonSize
   isTextView: boolean
-  disabled?: boolean
 }
-export const ManageButton: React.FC<Props> = ({
-  disabled,
-  className,
-  asset,
-  sizevalue = 'normal',
-  isTextView,
-  ...otherProps
-}) => {
+export const ManageButton: React.FC<Props> = ({ asset, isTextView, ...otherProps }) => {
   const intl = useIntl()
   const navigate = useNavigate()
 
@@ -36,17 +28,9 @@ export const ManageButton: React.FC<Props> = ({
   )
 
   return (
-    <Button
-      disabled={disabled}
-      round="true"
-      typevalue="outline"
-      sizevalue={sizevalue}
-      className={className}
-      onClick={onClick}
-      style={{ height: 30 }}
-      {...otherProps}>
-      <PlusOutlined />
+    <BorderButton onClick={onClick} {...otherProps}>
+      <PlusOutlined className={isTextView ? `mr-[8px]` : ''} />
       {isTextView && intl.formatMessage({ id: 'common.manage' })}
-    </Button>
+    </BorderButton>
   )
 }

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -13,7 +13,7 @@ import { loadingString } from '../../helpers/stringHelper'
 import * as poolsRoutes from '../../routes/pools'
 import { ManageButton } from '../manageButton'
 import { AssetIcon } from '../uielements/assets/assetIcon'
-import { Button } from '../uielements/button'
+import { FlatButton } from '../uielements/button'
 import * as Styled from './PoolTitle.styles'
 
 export type Props = {
@@ -79,15 +79,13 @@ export const PoolTitle: React.FC<Props> = ({
         <ManageButton
           disabled={disableAllPoolActions || disablePoolActions}
           asset={asset}
-          sizevalue={isDesktopView ? 'normal' : 'small'}
+          size="normal"
           isTextView={isDesktopView}
         />
         {isAvailablePool && (
-          <Button
+          <FlatButton
             disabled={disableAllPoolActions || disableTradingPoolAction}
-            round="true"
-            sizevalue={isDesktopView ? 'normal' : 'small'}
-            style={{ height: 30 }}
+            size="normal"
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()
@@ -98,9 +96,9 @@ export const PoolTitle: React.FC<Props> = ({
                 })
               )
             }}>
-            <SwapOutlined />
+            <SwapOutlined className="md:mr-[8px]" />
             {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
-          </Button>
+          </FlatButton>
         )}
       </Styled.ButtonActions>
     ),

--- a/src/renderer/components/settings/AppSettings.tsx
+++ b/src/renderer/components/settings/AppSettings.tsx
@@ -203,7 +203,7 @@ export const AppSettings: React.FC<Props> = (props): JSX.Element => {
                 <Styled.Section>
                   <Styled.SubTitle>{intl.formatMessage({ id: 'setting.version' })}</Styled.SubTitle>
                   <Styled.Label>v{version}</Styled.Label>
-                  <BorderButton className="my-10px" {...checkUpdatesProps} />
+                  <BorderButton size="normal" className="my-10px" {...checkUpdatesProps} />
                   {renderVersionUpdateResult}
                 </Styled.Section>
               </Styled.SectionsWrapper>

--- a/src/renderer/components/settings/WalletSettings.tsx
+++ b/src/renderer/components/settings/WalletSettings.tsx
@@ -567,7 +567,7 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
                   {intl.formatMessage({ id: 'wallet.add.another' })}
                 </h2>
                 <FlatButton
-                  className="min-w-[200px]"
+                  className="mt-5px min-w-[200px]"
                   size="normal"
                   color="primary"
                   onClick={() => navigate(walletRoutes.noWallet.path())}>

--- a/src/renderer/components/uielements/button/BaseButton.stories.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.stories.tsx
@@ -29,7 +29,8 @@ const meta: ComponentMeta<typeof Component> = {
     children: 'Button label',
     size: 'normal',
     loading: false,
-    disabled: false
+    disabled: false,
+    uppercase: true
   },
   decorators: [
     (S) => (

--- a/src/renderer/components/uielements/button/BaseButton.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.tsx
@@ -22,14 +22,14 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
   } = props
 
   const sizeClasses: Record<Size, string> = {
-    small: 'px-4 py-1 text-11',
-    normal: 'px-5 py-2 text-14',
-    large: 'px-6 py-2 text-16'
+    small: 'px-2 py-1 text-[10px]',
+    normal: 'px-4 py-1 text-[12px]',
+    large: 'px-6 py-2 text-[16px]'
   }
 
   const iconSize: Record<Size, string> = {
     small: 'w-10px h-10px',
-    normal: 'w-[13px] h-[13px]',
+    normal: 'w-[12px] h-[12px]',
     large: 'w-[17px] h-[17px]'
   }
 

--- a/src/renderer/components/uielements/button/BorderButton.stories.tsx
+++ b/src/renderer/components/uielements/button/BorderButton.stories.tsx
@@ -14,7 +14,7 @@ const meta: ComponentMeta<typeof Component> = {
       name: 'color',
       control: {
         type: 'select',
-        options: ['primary', 'warning', 'error']
+        options: ['primary', 'warning', 'error', 'neutral']
       }
     }
   },

--- a/src/renderer/components/uielements/button/FlatButton.stories.tsx
+++ b/src/renderer/components/uielements/button/FlatButton.stories.tsx
@@ -14,7 +14,7 @@ const meta: ComponentMeta<typeof Component> = {
       name: 'color',
       control: {
         type: 'select',
-        options: ['primary', 'warning', 'error']
+        options: ['primary', 'warning', 'error', 'neutral']
       }
     }
   },

--- a/src/renderer/components/uielements/button/FlatButton.tsx
+++ b/src/renderer/components/uielements/button/FlatButton.tsx
@@ -10,6 +10,19 @@ export type Props = BaseButtonProps & {
 export const FlatButton: React.FC<Props> = (props): JSX.Element => {
   const { color = 'primary', size = 'normal', disabled = false, className = '', children, ...restProps } = props
 
+  const borderColor: Record<Color, string> = {
+    primary: 'border-turquoise',
+    warning: 'border-warning0',
+    error: 'border-error0',
+    neutral: 'border-text0 dark:border-text0d'
+  }
+
+  const borderSize: Record<Size, string> = {
+    small: 'border',
+    normal: 'border-2',
+    large: 'border-2'
+  }
+
   const bgColor: Record<Color, string> = {
     primary: 'bg-turquoise',
     warning: 'bg-warning0 dark:bg-warning0d',
@@ -38,6 +51,9 @@ export const FlatButton: React.FC<Props> = (props): JSX.Element => {
       rounded-full
         ${textColor[color]}
         ${bgColor[color]}
+        ${borderSize[size]}
+        ${textColor[color]}
+        ${borderColor[color]}
         ${!disabled && `hover:${dropShadow[size]}`}
         ${!disabled && 'hover:border-opacity-85'}
         ${!disabled && 'hover:scale-105'}

--- a/src/renderer/components/uielements/button/TextButton.stories.tsx
+++ b/src/renderer/components/uielements/button/TextButton.stories.tsx
@@ -1,13 +1,13 @@
 import { ComponentMeta } from '@storybook/react'
 
 import baseMeta from './BaseButton.stories'
-import { LinkButton as Component, Props } from './LinkButton'
+import { TextButton as Component, Props } from './TextButton'
 
-export const LinkButton = ({ children, ...otherProps }: Props) => <Component {...otherProps}>{children}</Component>
+export const TextButton = ({ children, ...otherProps }: Props) => <Component {...otherProps}>{children}</Component>
 
 const meta: ComponentMeta<typeof Component> = {
   component: Component,
-  title: 'Components/button/LinkButton',
+  title: 'Components/button/TextButton',
   argTypes: {
     ...baseMeta.argTypes,
     color: {

--- a/src/renderer/components/uielements/reloadButton/ReloadButton.stories.tsx
+++ b/src/renderer/components/uielements/reloadButton/ReloadButton.stories.tsx
@@ -18,7 +18,8 @@ const meta: ComponentMeta<typeof Component> = {
         none: null,
         text: 'Reload child text'
       }
-    }
+    },
+    onClick: { action: 'onClick' }
   },
   args: { children: 'text' }
 }

--- a/src/renderer/components/wallet/keystore/ImportKeystore.tsx
+++ b/src/renderer/components/wallet/keystore/ImportKeystore.tsx
@@ -18,7 +18,7 @@ import { MAX_WALLET_NAME_CHARS } from '../../../services/wallet/const'
 import { ImportingKeystoreStateRD, ImportKeystoreParams, LoadKeystoreLD } from '../../../services/wallet/types'
 import { InnerForm } from '../../shared/form/Form.styles'
 import { Spin } from '../../shared/loading'
-import { Button } from '../../uielements/button'
+import { BorderButton, FlatButton } from '../../uielements/button'
 import { InputPassword, Input } from '../../uielements/input'
 import { Label } from '../../uielements/label'
 
@@ -119,14 +119,10 @@ export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
               {intl.formatMessage({ id: 'wallet.imports.keystore.title' })}
             </Label>
             {/* import button */}
-            <Button
-              className="mb-30px h-30px min-w-full cursor-pointer py-5px px-10px text-base"
-              typevalue="outline"
-              sizevalue="normal"
-              onClick={uploadKeystore}>
+            <BorderButton className="mb-30px cursor-pointer !rounded-none" size="normal" onClick={uploadKeystore}>
               {RD.isSuccess(loadKeystoreState) ? <CheckCircleTwoTone twoToneColor="#50e3c2" /> : <UploadOutlined />}
-              {intl.formatMessage({ id: 'wallet.imports.keystore.select' })}
-            </Button>
+              <span className="ml-10px">{intl.formatMessage({ id: 'wallet.imports.keystore.select' })}</span>
+            </BorderButton>
             {renderLoadError}
             {renderImportError}
             {/* password */}
@@ -158,15 +154,14 @@ export const ImportKeystore: React.FC<Props> = (props): JSX.Element => {
               />
             </Form.Item>
             {/* submit button */}
-            <Button
+            <FlatButton
               className="mt-50px min-w-[150px]"
-              sizevalue="xnormal"
-              type="primary"
-              htmlType="submit"
-              round="true"
+              size="large"
+              color="primary"
+              type="submit"
               disabled={!RD.isSuccess(loadKeystoreState) || RD.isPending(importingKeystoreState)}>
               {intl.formatMessage({ id: 'wallet.action.import' })}
-            </Button>
+            </FlatButton>
           </div>
         </Spin>
       </InnerForm>

--- a/src/renderer/components/wallet/phrase/ImportPhrase.tsx
+++ b/src/renderer/components/wallet/phrase/ImportPhrase.tsx
@@ -15,7 +15,7 @@ import { KeystoreClientStates } from '../../../hooks/useKeystoreClientStates'
 import { MAX_WALLET_NAME_CHARS } from '../../../services/wallet/const'
 import { AddKeystoreParams } from '../../../services/wallet/types'
 import { Spin } from '../../shared/loading'
-import { Button } from '../../uielements/button'
+import { FlatButton } from '../../uielements/button'
 import { InputPassword, InputTextArea, Input } from '../../uielements/input'
 import { Label } from '../../uielements/label'
 
@@ -183,15 +183,14 @@ export const ImportPhrase: React.FC<Props> = (props): JSX.Element => {
               />
             </Form.Item>
 
-            <Button
+            <FlatButton
               className="mt-50px min-w-[150px]"
-              sizevalue="xnormal"
-              type="primary"
-              htmlType="submit"
-              round="true"
+              size="large"
+              color="primary"
+              type="submit"
               disabled={!validPhrase || importing}>
               {intl.formatMessage({ id: 'wallet.action.import' })}
-            </Button>
+            </FlatButton>
           </div>
         </Spin>
       </Form>

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from 'react-router-dom'
 import { Network } from '../../../shared/api/types'
 import { ManageButton } from '../../components/manageButton'
 import { ProtocolLimit, IncentivePendulum } from '../../components/pool'
-import { Button } from '../../components/uielements/button'
+import { FlatButton } from '../../components/uielements/button'
 import { Table } from '../../components/uielements/table'
 import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
@@ -94,14 +94,13 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
           <ManageButton
             disabled={disableAllPoolActions || disablePoolActions || walletLocked}
             asset={pool.target}
-            sizevalue={isDesktopView ? 'normal' : 'small'}
+            size={isDesktopView ? 'normal' : 'large'}
             isTextView={isDesktopView}
           />
-          <Button
-            round="true"
-            sizevalue={isDesktopView ? 'normal' : 'small'}
+          <FlatButton
+            className="ml-10px"
+            size={isDesktopView ? 'normal' : 'large'}
             disabled={disableAllPoolActions || disableTradingActions}
-            style={{ height: 30 }}
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()
@@ -110,9 +109,9 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
                 target: assetToString(pool.target)
               })
             }}>
-            <SwapOutlined />
+            <SwapOutlined className="lg:mr-[8px]" />
             {isDesktopView && intl.formatMessage({ id: 'common.swap' })}
-          </Button>
+          </FlatButton>
         </Styled.TableAction>
       )
     },
@@ -123,11 +122,15 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
   const btnPoolsColumn = useMemo(
     () => ({
       key: 'btn',
-      title: Shared.renderRefreshBtnColTitle(intl.formatMessage({ id: 'common.refresh' }), refreshHandler),
+      title: Shared.renderRefreshBtnColTitle({
+        title: intl.formatMessage({ id: 'common.refresh' }),
+        clickHandler: refreshHandler,
+        iconOnly: !isDesktopView
+      }),
       width: 280,
       render: renderBtnPoolsColumn
     }),
-    [refreshHandler, intl, renderBtnPoolsColumn]
+    [refreshHandler, intl, renderBtnPoolsColumn, isDesktopView]
   )
 
   const renderVolumeColumn = useCallback(

--- a/src/renderer/views/pools/PendingPools.tsx
+++ b/src/renderer/views/pools/PendingPools.tsx
@@ -93,11 +93,15 @@ export const PendingPools: React.FC<PoolsComponentProps> = ({ haltedChains, mimi
   const btnPendingPoolsColumn: ColumnType<PoolTableRowData> = useMemo(
     () => ({
       key: 'btn',
-      title: Shared.renderRefreshBtnColTitle(intl.formatMessage({ id: 'common.refresh' }), refreshHandler),
+      title: Shared.renderRefreshBtnColTitle({
+        title: intl.formatMessage({ id: 'common.refresh' }),
+        clickHandler: refreshHandler,
+        iconOnly: !isDesktopView
+      }),
       width: 200,
       render: renderBtnPoolsColumn
     }),
-    [refreshHandler, intl, renderBtnPoolsColumn]
+    [intl, refreshHandler, isDesktopView, renderBtnPoolsColumn]
   )
 
   const renderBlockLeftColumn = useCallback(

--- a/src/renderer/views/pools/PoolsOverview.shared.tsx
+++ b/src/renderer/views/pools/PoolsOverview.shared.tsx
@@ -1,3 +1,4 @@
+import { SyncOutlined } from '@ant-design/icons'
 import { Asset, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
 import { ColumnType } from 'antd/lib/table'
@@ -6,6 +7,7 @@ import * as FP from 'fp-ts/function'
 import { ErrorView } from '../../components/shared/error'
 import { AssetIcon } from '../../components/uielements/assets/assetIcon'
 import { AssetLabel } from '../../components/uielements/assets/assetLabel'
+import { TextButton } from '../../components/uielements/button'
 import { ReloadButton } from '../../components/uielements/reloadButton'
 import { ordBaseAmount } from '../../helpers/fp/ord'
 import { sortByDepth } from '../../helpers/poolHelper'
@@ -134,10 +136,22 @@ export const depthColumn = (title: string, pricePoolAsset: Asset): ColumnType<Po
   defaultSortOrder: 'descend'
 })
 
-export const renderRefreshBtnColTitle = (title: string, clickHandler: FP.Lazy<void>) => (
-  <Styled.ActionColumn>
-    <ReloadButton onClick={clickHandler}>{title}</ReloadButton>
-  </Styled.ActionColumn>
+export const renderRefreshBtnColTitle = ({
+  title,
+  clickHandler,
+  iconOnly
+}: {
+  title: string
+  clickHandler: FP.Lazy<void>
+  iconOnly: boolean
+}) => (
+  <div className="flex items-center justify-center">
+    <TextButton size={iconOnly ? 'large' : 'normal'} onClick={clickHandler} className="">
+      <div className="flex items-center">
+        <SyncOutlined className={iconOnly ? 'mr-0' : 'mr-[8px]'} /> {!iconOnly && title}
+      </div>
+    </TextButton>
+  </div>
 )
 
 export const renderTableError = (reloadBtnLabel: string, reloadBtnAction: FP.Lazy<void>) => (error: Error) =>

--- a/src/renderer/views/pools/PoolsOverview.styles.ts
+++ b/src/renderer/views/pools/PoolsOverview.styles.ts
@@ -56,12 +56,6 @@ export const TableAction = styled.div`
   }
 `
 
-export const ActionColumn = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
-
 export const BlockLeftLabel = styled(UILabel)`
   display: inline-block;
   width: 100px;

--- a/src/renderer/views/wallet/importsView/ImportsView.tsx
+++ b/src/renderer/views/wallet/importsView/ImportsView.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
-import { useLocation, useMatch, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import { PageTitle } from '../../../components/page/PageTitle'
 import { Tabs } from '../../../components/tabs'
@@ -23,7 +23,6 @@ enum TabKey {
 export const ImportsView: React.FC = (): JSX.Element => {
   const intl = useIntl()
   const navigate = useNavigate()
-  const location = useLocation()
 
   const { keystoreService } = useWalletContext()
   const { importKeystore, loadKeystore$, addKeystoreWallet, importingKeystoreState$, resetImportingKeystoreState } =
@@ -48,17 +47,11 @@ export const ImportsView: React.FC = (): JSX.Element => {
 
   const walletId = useMemo(() => generateKeystoreId(), [])
 
-  const [activeTab, setActiveTab] = useState(TabKey.KEYSTORE)
-
   const items = useMemo(
     () => [
       {
         key: TabKey.KEYSTORE,
-        label: (
-          <span onClick={() => navigate(walletRoutes.imports.keystore.path())}>
-            {intl.formatMessage({ id: 'common.keystore' })}
-          </span>
-        ),
+        label: intl.formatMessage({ id: 'common.keystore' }),
         content: (
           <ImportKeystore
             walletId={walletId}
@@ -71,36 +64,30 @@ export const ImportsView: React.FC = (): JSX.Element => {
       },
       {
         key: TabKey.PHRASE,
-        label: (
-          <span onClick={() => navigate(walletRoutes.imports.phrase.path())}>
-            {intl.formatMessage({ id: 'common.phrase' })}
-          </span>
-        ),
+        label: intl.formatMessage({ id: 'common.phrase' }),
         content: <ImportPhrase walletId={walletId} clientStates={clientStates} addKeystore={addKeystoreWallet} />
       }
     ],
-    [intl, walletId, loadKeystore$, importKeystore, importingKeystoreState, clientStates, addKeystoreWallet, navigate]
+    [intl, walletId, loadKeystore$, importKeystore, importingKeystoreState, clientStates, addKeystoreWallet]
   )
-  const matchKeystorePath = useMatch({ path: walletRoutes.imports.keystore.path(), end: false })
-  const matchPhrasePath = useMatch({ path: walletRoutes.imports.phrase.path(), end: false })
 
-  /**
-   * Need to sync tabs' state with history
-   */
-  useEffect(() => {
-    if (matchKeystorePath) {
-      setActiveTab(TabKey.KEYSTORE)
-    } else if (matchPhrasePath) {
-      setActiveTab(TabKey.PHRASE)
-    } else {
-      // nothing to do
-    }
-  }, [navigate, activeTab, location.pathname, matchKeystorePath, matchPhrasePath])
+  const tabsChangeHandler = useCallback(
+    (key: string) => {
+      if (key === TabKey.PHRASE) {
+        navigate(walletRoutes.imports.phrase.path())
+      } else if (key === TabKey.KEYSTORE) {
+        navigate(walletRoutes.imports.keystore.path())
+      } else {
+        // nothing}
+      }
+    },
+    [navigate]
+  )
 
   return (
     <Styled.ImportsViewWrapper>
       <PageTitle>{intl.formatMessage({ id: 'wallet.imports.wallet' })}</PageTitle>
-      <Tabs tabs={items} defaultTabIndex={1} activeTabKey={activeTab} />
+      <Tabs tabs={items} defaultActiveKey={TabKey.KEYSTORE} onChange={tabsChangeHandler} />
     </Styled.ImportsViewWrapper>
   )
 }


### PR DESCRIPTION
- [x] Use `Text|FlatButtons` in `PoolsOverview`, `PoolDetails`, `Swap`, `Deposit`, `Withdraw`, `ImportKeystore, `ImportPhrase`
- [x] Update `ManageButton` to use `BorderButton`
- [x] Update value of `normal` size in `BaseButton`
- [x] Add `neutral` color to `Text|Flat|BorderButton`
- [x] Add `border` to `FlatButton` to have as same sizes as `BorderButton`
- [x] Refactor `ImportsView` to remove extra routing + fix tab handling/styles
- [x] Update stories

Part of #2336