### PR TITLE
Quick fix: Disable `manage` button in `PoolsDetails`

### DIFF
--- a/src/renderer/components/pool/PoolDetails.tsx
+++ b/src/renderer/components/pool/PoolDetails.tsx
@@ -35,6 +35,7 @@ export type Props = {
   disableTradingPoolAction: boolean
   disableAllPoolActions: boolean
   disablePoolActions: boolean
+  walletLocked: boolean
   network: Network
 }
 
@@ -56,6 +57,7 @@ export const PoolDetails: React.FC<Props> = ({
   disableTradingPoolAction,
   disableAllPoolActions,
   disablePoolActions,
+  walletLocked,
   network
 }) => {
   const renderTitle = useMemo(() => {
@@ -79,6 +81,7 @@ export const PoolDetails: React.FC<Props> = ({
         disableAllPoolActions={disableAllPoolActions}
         disableTradingPoolAction={disableTradingPoolAction}
         disablePoolActions={disablePoolActions}
+        walletLocked={walletLocked}
         asset={asset}
         watched={watched}
         watch={watch}
@@ -99,6 +102,7 @@ export const PoolDetails: React.FC<Props> = ({
     priceRatio,
     priceSymbol,
     unwatch,
+    walletLocked,
     watch,
     watched
   ])

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -26,6 +26,7 @@ export type Props = {
   disableTradingPoolAction: boolean
   disableAllPoolActions: boolean
   disablePoolActions: boolean
+  walletLocked: boolean
   network: Network
   isAvailablePool: boolean
 }
@@ -39,6 +40,7 @@ export const PoolTitle: React.FC<Props> = ({
   disableTradingPoolAction,
   disableAllPoolActions,
   disablePoolActions,
+  walletLocked,
   network,
   isAvailablePool
 }) => {
@@ -77,7 +79,7 @@ export const PoolTitle: React.FC<Props> = ({
     () => (
       <Styled.ButtonActions>
         <ManageButton
-          disabled={disableAllPoolActions || disablePoolActions}
+          disabled={disableAllPoolActions || disablePoolActions || walletLocked}
           asset={asset}
           size="normal"
           isTextView={isDesktopView}
@@ -105,6 +107,7 @@ export const PoolTitle: React.FC<Props> = ({
     [
       disableAllPoolActions,
       disablePoolActions,
+      walletLocked,
       asset,
       isDesktopView,
       isAvailablePool,

--- a/src/renderer/hooks/useKeystoreState.ts
+++ b/src/renderer/hooks/useKeystoreState.ts
@@ -11,7 +11,7 @@ import {
   RemoveKeystoreWalletHandler,
   ChangeKeystoreWalletHandler
 } from '../services/wallet/types'
-import { getPhrase, getWalletName } from '../services/wallet/util'
+import { getPhrase, getWalletName, isLocked } from '../services/wallet/util'
 
 export const useKeystoreState = (): {
   state: KeystoreState
@@ -21,6 +21,7 @@ export const useKeystoreState = (): {
   change$: ChangeKeystoreWalletHandler
   unlock: (password: string) => Promise<void>
   lock: FP.Lazy<void>
+  locked: boolean
 } => {
   const {
     keystoreService: { keystore$, unlock, lock, removeKeystoreWallet: remove, changeKeystoreWallet: change$ }
@@ -30,6 +31,7 @@ export const useKeystoreState = (): {
 
   const [phrase] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(getPhrase))), O.none)
   const [walletName] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(getWalletName))), O.none)
+  const [locked] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(isLocked))), false)
 
-  return { state, phrase, walletName, unlock, lock, remove, change$ }
+  return { state, phrase, walletName, unlock, lock, locked, remove, change$ }
 }

--- a/src/renderer/views/pool/PoolDetailsView.tsx
+++ b/src/renderer/views/pool/PoolDetailsView.tsx
@@ -19,6 +19,7 @@ import { useMidgardContext } from '../../contexts/MidgardContext'
 import { getAssetFromNullableString } from '../../helpers/assetHelper'
 import { eqAsset } from '../../helpers/fp/eq'
 import * as PoolHelpers from '../../helpers/poolHelper'
+import { useKeystoreState } from '../../hooks/useKeystoreState'
 import { useMidgardHistoryActions } from '../../hooks/useMidgardHistoryActions'
 import { useMimirHalt } from '../../hooks/useMimirHalt'
 import { usePoolWatchlist } from '../../hooks/usePoolWatchlist'
@@ -44,7 +45,8 @@ const defaultDetailsProps: TargetPoolDetailProps = {
   network: DEFAULT_NETWORK,
   disableAllPoolActions: false,
   disableTradingPoolAction: false,
-  disablePoolActions: false
+  disablePoolActions: false,
+  walletLocked: false
 }
 
 export const PoolDetailsView: React.FC = () => {
@@ -68,6 +70,8 @@ export const PoolDetailsView: React.FC = () => {
   const network = useObservableState(network$, DEFAULT_NETWORK)
 
   const intl = useIntl()
+
+  const { locked: walletLocked } = useKeystoreState()
 
   const { asset } = useParams<PoolDetailRouteParams>()
 
@@ -152,7 +156,8 @@ export const PoolDetailsView: React.FC = () => {
               ChartView: PoolChartView,
               disableAllPoolActions: getDisableAllPoolActions(asset.chain),
               disableTradingPoolAction: getDisableTradingPoolAction(asset.chain),
-              disablePoolActions: getDisablePoolActions(asset.chain)
+              disablePoolActions: getDisablePoolActions(asset.chain),
+              walletLocked
             }
 
             const watched = FP.pipe(watchedList, A.elem(eqAsset)(asset))

--- a/src/renderer/views/pools/PoolsOverview.tsx
+++ b/src/renderer/views/pools/PoolsOverview.tsx
@@ -3,16 +3,14 @@ import React, { useCallback, useMemo, useState } from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { Chain } from '@xchainjs/xchain-util'
 import * as FP from 'fp-ts/function'
-import * as O from 'fp-ts/lib/Option'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import * as RxOp from 'rxjs/operators'
 
 import { useMidgardContext } from '../../contexts/MidgardContext'
-import { useWalletContext } from '../../contexts/WalletContext'
+import { useKeystoreState } from '../../hooks/useKeystoreState'
 import { useMimirHalt } from '../../hooks/useMimirHalt'
 import { PoolType } from '../../services/midgard/types'
-import { isLocked } from '../../services/wallet/util'
 import { ActivePools } from './ActivePools'
 import { PendingPools } from './PendingPools'
 import * as Styled from './PoolsOverview.styles'
@@ -26,8 +24,7 @@ type Tab = {
 export const PoolsOverview: React.FC = (): JSX.Element => {
   const intl = useIntl()
 
-  const { keystoreService } = useWalletContext()
-  const keystore = useObservableState(keystoreService.keystore$, O.none)
+  const { locked: walletLocked } = useKeystoreState()
 
   const [activeTabKey, setActiveTabKey] = useState<PoolType>('active')
 
@@ -46,15 +43,15 @@ export const PoolsOverview: React.FC = (): JSX.Element => {
       {
         key: 'active',
         label: intl.formatMessage({ id: 'pools.available' }),
-        content: <ActivePools haltedChains={haltedChains} mimirHalt={mimirHalt} walletLocked={isLocked(keystore)} />
+        content: <ActivePools haltedChains={haltedChains} mimirHalt={mimirHalt} walletLocked={walletLocked} />
       },
       {
         key: 'pending',
         label: intl.formatMessage({ id: 'pools.pending' }),
-        content: <PendingPools haltedChains={haltedChains} mimirHalt={mimirHalt} walletLocked={isLocked(keystore)} />
+        content: <PendingPools haltedChains={haltedChains} mimirHalt={mimirHalt} walletLocked={walletLocked} />
       }
     ],
-    [intl, haltedChains, mimirHalt, keystore]
+    [intl, haltedChains, mimirHalt, walletLocked]
   )
 
   const renderTabBar = useCallback(


### PR DESCRIPTION
while wallet is locked

In addition:
- [x] Extend `useKeystoreState` by `locked` state
- [x] Use `useKeystoreState` in `PoolsOverview` / `PoolDetailsView`