### PR TITLE
Update Button sizes + moore `FlatButtons`

### DIFF
--- a/src/renderer/components/header/lock/HeaderLock.tsx
+++ b/src/renderer/components/header/lock/HeaderLock.tsx
@@ -38,7 +38,7 @@ export const HeaderLock: React.FC<Props> = (props): JSX.Element => {
             () => <></>,
             (name) => (
               <p
-                className="dark:text2d w-min-[60px] absolute -bottom-[6px] whitespace-nowrap
+                className="dark:text2d absolute -bottom-[6px] whitespace-nowrap
                 rounded-full bg-gray0 px-[8px] py-[3px]
                   font-main text-[9px] uppercase leading-none
                   text-text2 dark:bg-gray0d

--- a/src/renderer/components/swap/Swap.styles.tsx
+++ b/src/renderer/components/swap/Swap.styles.tsx
@@ -7,7 +7,6 @@ import { transition } from '../../settings/style-util'
 import { Tabs as TabsUI } from '../tabs/Tabs'
 import { AssetInput as AssetInputBase } from '../uielements/assets/assetInput'
 import { AssetSelect as AssetSelectUI } from '../uielements/assets/assetSelect'
-import { Button as UIButton } from '../uielements/button'
 import { CheckButton as CheckButtonUI } from '../uielements/button/CheckButton'
 import { Label as UILabel, CopyLabel as CopyLabelUI } from '../uielements/label'
 
@@ -273,15 +272,6 @@ export const SubmitContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-`
-
-export const SubmitButton = styled(UIButton).attrs({
-  type: 'primary',
-  round: 'true'
-})`
-  min-width: 200px !important;
-  padding: 0 30px;
-  margin: 30px 0;
 `
 
 export const CheckButton = styled(CheckButtonUI)`

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -92,7 +92,7 @@ import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../mod
 import { TxModal } from '../modal/tx'
 import { SwapAssets } from '../modal/tx/extra'
 import { LoadingView } from '../shared/loading'
-import { ViewTxButton } from '../uielements/button'
+import { FlatButton, ViewTxButton } from '../uielements/button'
 import { WalletTypeLabel } from '../uielements/common/Common.styles'
 import { Fees, UIFeesRD } from '../uielements/fees'
 import { InfoIcon } from '../uielements/info'
@@ -1635,13 +1635,14 @@ export const Swap = ({
                 {!isLocked(keystore) ? (
                   isApproved ? (
                     <>
-                      <Styled.SubmitButton
-                        color="success"
-                        sizevalue="xnormal"
+                      <FlatButton
+                        className="my-30px min-w-[200px]"
+                        size="large"
+                        color="primary"
                         onClick={onSubmit}
                         disabled={disableSubmit}>
                         {intl.formatMessage({ id: 'common.swap' })}
-                      </Styled.SubmitButton>
+                      </FlatButton>
                       {!RD.isInitial(uiFees) && <Fees fees={uiFees} reloadFees={reloadFeesHandler} />}
                       {sourceChainFeeErrorLabel}
                     </>
@@ -1649,14 +1650,15 @@ export const Swap = ({
                     <>
                       {renderApproveFeeError}
                       {renderApproveError}
-                      <Styled.SubmitButton
-                        sizevalue="xnormal"
+                      <FlatButton
+                        className="my-30px min-w-[200px]"
+                        size="large"
                         color="warning"
                         disabled={disableSubmitApprove}
                         onClick={onApprove}
                         loading={RD.isPending(approveState)}>
                         {intl.formatMessage({ id: 'common.approve' })}
-                      </Styled.SubmitButton>
+                      </FlatButton>
 
                       {!RD.isInitial(uiApproveFeesRD) && (
                         <Fees fees={uiApproveFeesRD} reloadFees={reloadApproveFeesHandler} />
@@ -1670,11 +1672,11 @@ export const Swap = ({
                         ? intl.formatMessage({ id: 'swap.note.nowallet' })
                         : isLocked(keystore) && intl.formatMessage({ id: 'swap.note.lockedWallet' })}
                     </Styled.NoteLabel>
-                    <Styled.SubmitButton sizevalue="xnormal" color="success" onClick={importWalletHandler}>
+                    <FlatButton className="my-30px min-w-[200px]" size="large" onClick={importWalletHandler}>
                       {!hasImportedKeystore(keystore)
                         ? intl.formatMessage({ id: 'wallet.imports.label' })
                         : isLocked(keystore) && intl.formatMessage({ id: 'wallet.unlock.label' })}
-                    </Styled.SubmitButton>
+                    </FlatButton>
                   </>
                 )}
               </Styled.SubmitContainer>

--- a/src/renderer/components/uielements/button/BaseButton.stories.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.stories.tsx
@@ -2,8 +2,8 @@ import { ComponentMeta } from '@storybook/react'
 
 import { BaseButton as Component, BaseButtonProps } from './BaseButton'
 
-export const BaseButton = ({ size, loading, disabled, children }: BaseButtonProps) => (
-  <Component size={size} loading={loading} disabled={disabled}>
+export const BaseButton = ({ size, loading, disabled, font, children }: BaseButtonProps) => (
+  <Component size={size} loading={loading} font={font} disabled={disabled}>
     {children}
   </Component>
 )
@@ -13,10 +13,15 @@ const meta: ComponentMeta<typeof Component> = {
   title: 'Components/button/BaseButton',
   argTypes: {
     size: {
-      name: 'size',
       control: {
         type: 'select',
-        options: ['small', 'normal', 'large']
+        options: ['small', 'medium', 'normal', 'large']
+      }
+    },
+    font: {
+      control: {
+        type: 'select',
+        options: ['normal', 'semi', 'bold']
       }
     },
     children: {
@@ -28,6 +33,7 @@ const meta: ComponentMeta<typeof Component> = {
   args: {
     children: 'Button label',
     size: 'normal',
+    font: 'normal',
     loading: false,
     disabled: false,
     uppercase: true

--- a/src/renderer/components/uielements/button/BaseButton.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
 import { LoadingIcon } from '../../icons'
-import type { Size } from './Button.types'
+import type { Size, Font } from './Button.types'
 
 export type BaseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: Size
   loading?: boolean
   uppercase?: boolean
+  font?: Font
 }
 
 export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
@@ -16,27 +17,37 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
     className = '',
     disabled = false,
     type = 'button',
-    uppercase = true, // by default all texts are uppercase in ASDGX
+    font = 'normal',
+    uppercase = true, // by default all labels are uppercase in ASDGX
     children,
     ...restProps
   } = props
 
   const sizeClasses: Record<Size, string> = {
-    small: 'px-2 py-1 text-[10px]',
-    normal: 'px-4 py-1 text-[12px]',
-    large: 'px-6 py-2 text-[16px]'
+    small: 'px-[10px] py-[1px] text-[10px]',
+    medium: 'px-[12px] py-[2px] text-[11px]',
+    normal: 'px-[15px] py-[3px] text-[14px]',
+    large: 'px-[20px] py-[4px] text-[16px]'
   }
 
   const iconSize: Record<Size, string> = {
     small: 'w-10px h-10px',
-    normal: 'w-[12px] h-[12px]',
+    medium: 'w-[11px] h-[11px]',
+    normal: 'w-[14px] h-[14px]',
     large: 'w-[17px] h-[17px]'
   }
 
   const iconMargin: Record<Size, string> = {
-    small: 'mr-[6px]',
+    small: 'mr-[4px]',
+    medium: 'mr-[6px]',
     normal: 'mr-[8px]',
     large: 'mr-[12px]'
+  }
+
+  const fontFamily: Record<Font, string> = {
+    normal: 'font-main',
+    semi: 'font-mainSemiBold',
+    bold: 'font-mainBold'
   }
 
   return (
@@ -49,7 +60,7 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
         ${disabled && 'opacity-60'}
       justify-center
         ${disabled && 'cursor-not-allowed'}
-        font-main
+        ${fontFamily[font]}
         ${uppercase && 'uppercase'}
         transition
         duration-300

--- a/src/renderer/components/uielements/button/BorderButton.tsx
+++ b/src/renderer/components/uielements/button/BorderButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { BaseButton, BaseButtonProps } from './BaseButton'
-import type { Color, Size } from './Button.types'
+import { borderSize, dropShadow, borderColor } from './Button.shared'
+import type { Color } from './Button.types'
 
 export type Props = BaseButtonProps & {
   color?: Color
@@ -19,29 +20,11 @@ export const BorderButton: React.FC<Props> = (props): JSX.Element => {
     ...restProps
   } = props
 
-  const borderColor: Record<Color, string> = {
-    primary: 'border-turquoise',
-    warning: 'border-warning0',
-    error: 'border-error0',
-    neutral: 'border-text0 dark:border-text0d'
-  }
-
-  const borderSize: Record<Size, string> = {
-    small: 'border',
-    normal: 'border-2',
-    large: 'border-2'
-  }
-
   const textColor: Record<Color, string> = {
     primary: 'text-turquoise',
     warning: 'text-warning0 dark:text-warning0d',
     error: 'text-error0 dark:text-error0d',
     neutral: 'text-text0 dark:text-text0d'
-  }
-  const dropShadow: Record<Size, string> = {
-    small: 'drop-shadow-lg',
-    normal: 'drop-shadow-lg',
-    large: 'drop-shadow-lg'
   }
 
   return (

--- a/src/renderer/components/uielements/button/Button.shared.tsx
+++ b/src/renderer/components/uielements/button/Button.shared.tsx
@@ -1,0 +1,22 @@
+import { Size, Color } from './Button.types'
+
+export const dropShadow: Record<Size, string> = {
+  small: 'drop-shadow-md',
+  medium: 'drop-shadow-lg',
+  normal: 'drop-shadow-lg',
+  large: 'drop-shadow-lg'
+}
+
+export const borderSize: Record<Size, string> = {
+  small: 'border',
+  medium: 'border',
+  normal: 'border',
+  large: 'border-2'
+}
+
+export const borderColor: Record<Color, string> = {
+  primary: 'border-turquoise',
+  warning: 'border-warning0',
+  error: 'border-error0',
+  neutral: 'border-text0 dark:border-text0d'
+}

--- a/src/renderer/components/uielements/button/Button.types.ts
+++ b/src/renderer/components/uielements/button/Button.types.ts
@@ -19,5 +19,6 @@ export type ComponentProps = {
 export type ButtonProps = ComponentProps & AB.ButtonProps
 
 // Tailwind based button types
-export type Size = 'small' | 'normal' | 'large'
+export type Size = 'small' | 'medium' | 'normal' | 'large'
+export type Font = 'normal' | 'semi' | 'bold'
 export type Color = 'primary' | 'warning' | 'error' | 'neutral'

--- a/src/renderer/components/uielements/button/FlatButton.tsx
+++ b/src/renderer/components/uielements/button/FlatButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { BaseButton, BaseButtonProps } from './BaseButton'
-import type { Color, Size } from './Button.types'
+import * as S from './Button.shared'
+import type { Color } from './Button.types'
 
 export type Props = BaseButtonProps & {
   color?: Color
@@ -9,19 +10,6 @@ export type Props = BaseButtonProps & {
 
 export const FlatButton: React.FC<Props> = (props): JSX.Element => {
   const { color = 'primary', size = 'normal', disabled = false, className = '', children, ...restProps } = props
-
-  const borderColor: Record<Color, string> = {
-    primary: 'border-turquoise',
-    warning: 'border-warning0',
-    error: 'border-error0',
-    neutral: 'border-text0 dark:border-text0d'
-  }
-
-  const borderSize: Record<Size, string> = {
-    small: 'border',
-    normal: 'border-2',
-    large: 'border-2'
-  }
 
   const bgColor: Record<Color, string> = {
     primary: 'bg-turquoise',
@@ -37,11 +25,7 @@ export const FlatButton: React.FC<Props> = (props): JSX.Element => {
     neutral: 'text-text0 dark:text-text0d'
   }
 
-  const dropShadow: Record<Size, string> = {
-    small: 'drop-shadow-lg',
-    normal: 'drop-shadow-lg',
-    large: 'drop-shadow-lg'
-  }
+  const borderColor = { ...S.borderColor, neutral: 'border-gray0 dark:border-gray0d' }
 
   return (
     <BaseButton
@@ -51,10 +35,10 @@ export const FlatButton: React.FC<Props> = (props): JSX.Element => {
       rounded-full
         ${textColor[color]}
         ${bgColor[color]}
-        ${borderSize[size]}
+        ${S.borderSize[size]}
         ${textColor[color]}
         ${borderColor[color]}
-        ${!disabled && `hover:${dropShadow[size]}`}
+        ${!disabled && `hover:${S.dropShadow[size]}`}
         ${!disabled && 'hover:border-opacity-85'}
         ${!disabled && 'hover:scale-105'}
         ${className}

--- a/src/renderer/components/uielements/button/LinkButton.tsx
+++ b/src/renderer/components/uielements/button/LinkButton.tsx
@@ -18,12 +18,14 @@ export const LinkButton: React.FC<Props> = (props): JSX.Element => {
   }
   const decorationOffset: Record<Size, string> = {
     small: 'underline-offset-1',
+    medium: 'underline-offset-1',
     normal: 'underline-offset-2',
     large: 'underline-offset-4'
   }
 
   const thickness: Record<Size, string> = {
     small: 'decoration-1',
+    medium: 'decoration-1',
     normal: 'decoration-2',
     large: 'decoration-3'
   }

--- a/src/renderer/components/uielements/modal/Modal.styles.ts
+++ b/src/renderer/components/uielements/modal/Modal.styles.ts
@@ -13,7 +13,6 @@ export const Modal = styled(A.Modal)`
     border: none;
     text-transform: uppercase;
     font-family: 'MainFontRegular';
-    letter-spacing: 1.5px;
     .ant-modal-title {
       color: ${palette('text', 3)};
     }
@@ -34,9 +33,9 @@ export const Modal = styled(A.Modal)`
   }
   .ant-modal-close {
     .ant-modal-close-x {
-      width: 44px;
-      height: 48px;
-      line-height: 48px;
+      width: 40px;
+      height: 40px;
+      line-height: 40px;
       color: ${palette('text', 3)};
     }
   }

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.styles.ts
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.styles.ts
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { palette } from 'styled-theme'
 
 import { Label as UILabel } from '../../../components/uielements/label'
-import { Button as UIButton } from '../../uielements/button'
 import {
   WalletTypeLabel as WalletTypeLabelUI,
   AssetSynthLabel as AssetSynthLabelUI
@@ -139,17 +138,6 @@ export const AssetTickerWrapper = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-`
-
-export const UpgradeButton = styled(UIButton).attrs({
-  type: 'primary',
-  round: 'true',
-  color: 'warning'
-})`
-  &.ant-btn {
-    min-width: auto;
-    margin-left: 10px;
-  }
 `
 
 export const WalletTypeLabel = styled(WalletTypeLabelUI)`

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
@@ -34,6 +34,7 @@ import { walletTypeToI18n } from '../../../services/wallet/util'
 import { PricePool } from '../../../views/pools/Pools.types'
 import { ErrorView } from '../../shared/error/'
 import { AssetIcon } from '../../uielements/assets/assetIcon'
+import { FlatButton } from '../../uielements/button'
 import { QRCodeModal } from '../../uielements/qrCodeModal/QRCodeModal'
 import * as Styled from './AssetsTableCollapsable.styles'
 
@@ -163,11 +164,14 @@ export const AssetsTableCollapsable: React.FC<Props> = (props): JSX.Element => {
               </Styled.ChainLabelWrapper>
             </Styled.Label>
             {isNonNativeRuneAsset(asset, network) && (
-              <Styled.UpgradeButton
+              <FlatButton
+                className="ml-20px"
+                size="normal"
+                color="warning"
                 onClick={disableUpgradeButton ? undefined : onClickUpgradeButtonHandler}
                 disabled={disableUpgradeButton}>
                 {intl.formatMessage({ id: 'wallet.action.upgrade' })}
-              </Styled.UpgradeButton>
+              </FlatButton>
             )}
           </Styled.AssetTickerWrapper>
         )


### PR DESCRIPTION
- [x] Update button sizes
- [x] Extract common button props to `Button.shared`
- [x] Use FlatButton in Swap / AssetTableCollapsable
- [x] Quick fixes: Modal styles (close icon) / Invalid style in HeaderLock

As part of #2336