### PR TITLE
Quick refactor/fix:`Input` + `PasswordInput`

### DIFF
--- a/src/renderer/components/uielements/button/BaseButton.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.tsx
@@ -57,11 +57,11 @@ export const BaseButton: React.FC<BaseButtonProps> = (props): JSX.Element => {
       className={`
       group
       flex appearance-none items-center
-        ${disabled && 'opacity-60'}
+        ${disabled ? 'opacity-60' : 'opcacity-100'}
       justify-center
-        ${disabled && 'cursor-not-allowed'}
+        ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
         ${fontFamily[font]}
-        ${uppercase && 'uppercase'}
+        ${uppercase ? 'uppercase' : 'normal-case'}
         transition
         duration-300
         ease-in-out

--- a/src/renderer/components/uielements/input/Input.stories.tsx
+++ b/src/renderer/components/uielements/input/Input.stories.tsx
@@ -18,8 +18,10 @@ const meta: ComponentMeta<typeof Component> = {
   },
   args: {
     placeholder: 'Placeholder',
-    error: '',
-    disabled: false
+    size: 'normal',
+    error: false,
+    disabled: false,
+    uppercase: true
   },
   decorators: [
     (Story) => (

--- a/src/renderer/components/uielements/input/Input.tsx
+++ b/src/renderer/components/uielements/input/Input.tsx
@@ -4,19 +4,18 @@ import type { Size } from './Input.types'
 
 const sizeClasses: Record<Size, string> = {
   small: 'px-[3px] py-[1px] text-[11px]',
-  normal: 'px-[5px] py-[3px] text-[14px]',
+  normal: 'px-[6px] py-[3px] text-[14px]',
   large: 'px-[10px] py-[4px] text-[16px]'
 }
 
-export type InputProps = {
-  size?: Size
+export type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  size?: Size // overridden
   id?: string
-  error?: string
+  error?: boolean
+  uppercase?: boolean
   disabled?: boolean
   autoFocus?: boolean
-  classNameInput?: string
-  classNameError?: string
-} & React.HTMLAttributes<HTMLInputElement>
+}
 
 export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref): JSX.Element => {
   const {
@@ -24,20 +23,18 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref): JSX.
     size = 'normal',
     disabled = false,
     autoFocus = false,
+    uppercase = true,
     error = '',
     className = '',
-    classNameInput = '',
-    classNameError = '',
     ...otherProps
   } = props
 
   return (
-    <div className={`${disabled ? 'opacity-50' : ''} ${className}`}>
-      <input
-        ref={ref}
-        id={id}
-        autoFocus={autoFocus}
-        className={`
+    <input
+      ref={ref}
+      id={id}
+      autoFocus={autoFocus}
+      className={`
           w-full
           appearance-none
           ring-1
@@ -45,18 +42,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref): JSX.
             ${error ? 'ring-error0' : 'ring-turquoise'}
             bg-bg0
             text-text0
-            placeholder:uppercase placeholder:text-gray-300 dark:bg-bg0d
+            ${uppercase ? 'placeholder:uppercase' : ''}
+             placeholder:text-gray-300 dark:bg-bg0d
             dark:text-text0d
             dark:placeholder:text-gray-400
             ${sizeClasses[size]}
+            ${uppercase ? 'uppercase' : 'normal-case'}
             font-main
-            ${classNameInput}
-            `}
-        type="text"
-        autoComplete="off"
-        {...otherProps}
-      />
-      {error && <p className={`mt-2 font-main text-sm uppercase text-error0 ${classNameError}`}>{error}</p>}
-    </div>
+            ${disabled ? 'opacity-50' : 'opacity-100'}
+            ${className}`}
+      type="text"
+      autoComplete="off"
+      disabled={disabled}
+      {...otherProps}
+    />
   )
 })

--- a/src/renderer/components/uielements/input/InputPassword.stories.tsx
+++ b/src/renderer/components/uielements/input/InputPassword.stories.tsx
@@ -18,6 +18,7 @@ const meta: ComponentMeta<typeof Component> = {
   },
   args: {
     placeholder: 'Placeholder',
+    size: 'normal',
     error: '',
     disabled: false
   },

--- a/src/renderer/components/uielements/input/InputPassword.tsx
+++ b/src/renderer/components/uielements/input/InputPassword.tsx
@@ -1,69 +1,41 @@
 import React, { forwardRef, useState } from 'react'
 
 import { EyeHideIcon, EyeIcon } from '../../icons'
-import type { Size } from './Input.types'
+import { Input, InputProps } from './Input'
 
-const sizeClasses: Record<Size, string> = {
-  small: 'px-2 py-1 text-sm',
-  normal: 'px-4 py-2 text-normal',
-  large: 'px-8 py-3 text-lg'
-}
-
-export type PasswordProps = {
-  size: Size
-  id?: string
-  error?: string
-  disabled?: boolean
-  autoFocus?: boolean
-} & React.HTMLAttributes<HTMLInputElement>
+export type PasswordProps = { error: string } & Omit<InputProps, 'error' | 'uppercase'>
 
 export const InputPassword = forwardRef<HTMLInputElement, PasswordProps>((props, ref): JSX.Element => {
-  const {
-    id = 'input-pw',
-    size = 'normal',
-    disabled = false,
-    autoFocus = false,
-    error = '',
-    className = '',
-    ...otherProps
-  } = props
+  const { id = 'input-pw', disabled = false, error = false, className = '', ...otherProps } = props
 
   const [showPw, setShowPw] = useState(false)
 
   const Icon = showPw ? EyeIcon : EyeHideIcon
 
   return (
-    <div className={`${disabled ? 'opacity-50' : ''} ${className}`}>
+    <div className={`${className}`}>
       <div className="relative">
         <div className="bg:bg0 dark:bg:bg0d absolute right-0 flex h-full cursor-pointer items-center px-10px">
           <Icon
             className={`h-20px w-20px
-            ${error ? 'text-error0' : 'text-turquoise'}`}
+            ${error ? 'text-error0' : 'text-turquoise'}
+            ${disabled ? 'opacity-50' : ''}
+            ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
+            `}
             onClick={() => {
               setShowPw((current) => !current)
             }}
           />
         </div>
-        <input
+        <Input
+          className="placeholder:uppercase"
           ref={ref}
+          error={!!error}
           id={id}
-          autoFocus={autoFocus}
-          className={`
-          w-full
-          appearance-none
-          ring-1
-            focus:outline-none
-            ${error ? 'ring-error0' : 'ring-turquoise'}
-            bg-bg0
-            text-text0
-            placeholder:uppercase placeholder:text-gray-300 dark:bg-bg0d
-            dark:text-text0d
-            dark:placeholder:text-gray-400
-            ${sizeClasses[size]}
-            font-main
-            `}
+          disabled={disabled}
           type={showPw ? 'text' : 'password'}
           autoComplete="off"
+          uppercase={false}
           {...otherProps}
         />
       </div>

--- a/src/renderer/components/uielements/wallet/EditableWalletName.tsx
+++ b/src/renderer/components/uielements/wallet/EditableWalletName.tsx
@@ -43,7 +43,7 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
         className={`flex cursor-pointer items-center font-main text-[18px] text-text0 dark:text-text0d`}
         onClick={edit}>
         {name}
-        <PencilAltIcon className="dark:text0d ml-[5px] h-[20px] w-[20px]  text-text0 dark:text-text0d" />
+        <PencilAltIcon className="dark:text0d ml-[5px] h-[20px] w-[20px] text-turquoise" />
       </div>
     )
   }, [name])
@@ -68,25 +68,34 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
         }
       }
 
+      const error = !!errors.name
+
       return (
-        <form className="items-top flex w-full justify-center" onSubmit={handleSubmit(submit)}>
-          <Input
-            className="w-full !max-w-[380px] pl-[60px]" // 60px offset of icons width to stay in center
-            classNameInput="text-[18px] ring-gray1 dark:ring-gray1d"
-            size="large"
-            defaultValue={name}
-            autoFocus
-            maxLength={MAX_WALLET_NAME_CHARS}
-            {...register('name', { required: true })}
-            error={errors.name ? intl.formatMessage({ id: 'wallet.name.error.empty' }) : ''}
-            onKeyDown={keyDownHandler}
-          />
-          <div className="flex h-[35px] items-center">
-            <BaseButton className="!p-0 text-turquoise" onClick={confirm} type="submit">
-              <CheckCircleIcon className="ml-[5px] h-[24px] w-[24px]" />
+        <form className="items-top flex w-full flex-col items-center" onSubmit={handleSubmit(submit)}>
+          <div className="flex w-full items-center justify-center">
+            <Input
+              // 60px offset of icons width to stay in center
+              className={`${error ? 'ring-error0' : 'dark:gray1d ring-gray1'} w-full max-w-[380px] text-[18px]
+              `}
+              size="large"
+              defaultValue={name}
+              autoFocus
+              uppercase={false}
+              maxLength={MAX_WALLET_NAME_CHARS}
+              {...register('name', { required: true })}
+              error={!!errors.name}
+              onKeyDown={keyDownHandler}
+            />
+            <BaseButton className="ml-[5px] h-[24px] w-[24px] !p-0 text-turquoise" onClick={confirm} type="submit">
+              <CheckCircleIcon className="" />
             </BaseButton>
             <XCircleIcon className="ml-[5px] h-[24px] w-[24px] cursor-pointer text-error0" onClick={cancel} />
           </div>
+          {errors.name && (
+            <p className={`mt-10px font-main text-[14px] uppercase text-error0`}>
+              {intl.formatMessage({ id: 'wallet.name.error.empty' })}
+            </p>
+          )}
         </form>
       )
     },

--- a/src/renderer/components/wallet/unlock/UnlockForm.tsx
+++ b/src/renderer/components/wallet/unlock/UnlockForm.tsx
@@ -204,7 +204,7 @@ export const UnlockForm: React.FC<Props> = (props): JSX.Element => {
               className="my-0 mx-auto mb-20px w-full max-w-[400px]"
               {...register('password', { required: true })}
               placeholder={intl.formatMessage({ id: 'common.password' }).toUpperCase()}
-              size={'normal'}
+              size="large"
               autoFocus={true}
               error={errors.password ? intl.formatMessage({ id: 'wallet.password.empty' }) : ''}
               disabled={unlocking}


### PR DESCRIPTION
- [x] Refactor/fix `Input` / `PasswordInput` components to extract error view + to use `Input` in `PasswordInput`
- [x] Fix guard in styles of `BaseButton`

Part of #1601