### PR TITLE
Business logic for renaming wallets

### DIFF
--- a/src/renderer/components/header/lock/HeaderLock.tsx
+++ b/src/renderer/components/header/lock/HeaderLock.tsx
@@ -44,7 +44,7 @@ export const HeaderLock: React.FC<Props> = (props): JSX.Element => {
                   text-text2 dark:bg-gray0d
                   dark:text-text2d
                   ">
-                {truncateMiddle(name, { start: 4, end: 4, max: 16 })}
+                {truncateMiddle(name, { start: 3, end: 3, max: 11 })}
               </p>
             )
           )

--- a/src/renderer/components/uielements/wallet/EditableWalletName.tsx
+++ b/src/renderer/components/uielements/wallet/EditableWalletName.tsx
@@ -90,12 +90,10 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
               error={!!errors.name}
               onKeyDown={keyDownHandler}
             />
-            <div className="flex h-[35px] items-center">
-              <BaseButton className="!p-0 text-turquoise" onClick={handleSubmit(submit)} type="submit">
-                <CheckCircleIcon className="ml-[5px] h-[24px] w-[24px]" />
-              </BaseButton>
-              <XCircleIcon className="ml-[5px] h-[24px] w-[24px] cursor-pointer text-error0" onClick={cancel} />
-            </div>
+            <BaseButton className="!p-0 text-turquoise" onClick={handleSubmit(submit)} type="submit">
+              <CheckCircleIcon className="ml-[5px] h-[24px] w-[24px]" />
+            </BaseButton>
+            <XCircleIcon className="ml-[5px] h-[24px] w-[24px] cursor-pointer text-error0" onClick={cancel} />
           </div>
           {errors.name && (
             <p className={`mt-10px font-main text-[14px] uppercase text-error0`}>

--- a/src/renderer/components/uielements/wallet/EditableWalletName.tsx
+++ b/src/renderer/components/uielements/wallet/EditableWalletName.tsx
@@ -7,11 +7,13 @@ import { useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 
 import { MAX_WALLET_NAME_CHARS } from '../../../services/wallet/const'
-import { BaseButton } from '../button'
+// import { LoadingIcon } from '../../icons'
+import { BaseButton, TextButton } from '../button'
 import { Input } from '../input/Input'
 
 export type Props = {
   name: string
+  loading?: boolean
   onChange: (name: string) => void
   className?: string
 }
@@ -21,9 +23,10 @@ type FormData = {
 }
 
 export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
-  const { name, onChange, className = '' } = props
+  const { name: initialName, onChange, loading = false, className = '' } = props
 
   const [editableName, setEditableName] = useState<O.Option<string>>(O.none)
+  const [name, setName] = useState<string>(initialName)
 
   const intl = useIntl()
 
@@ -39,18 +42,22 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
       setEditableName(O.some(name))
     }
     return (
-      <div
-        className={`flex cursor-pointer items-center font-main text-[18px] text-text0 dark:text-text0d`}
+      <TextButton
+        color="neutral"
+        uppercase={false}
+        disabled={loading}
+        size="large"
+        loading={loading}
+        className={`flex ${loading ? 'cursor-not-allowed' : 'cursor-pointer'} items-center text-[18px]`}
         onClick={edit}>
         {name}
-        <PencilAltIcon className="dark:text0d ml-[5px] h-[20px] w-[20px]  text-text0 dark:text-text0d" />
-      </div>
+        <PencilAltIcon className="dark:text0d ml-[5px] h-[20px] w-[20px] text-text0 dark:text-text0d" />
+      </TextButton>
     )
-  }, [name])
+  }, [loading, name])
 
   const renderEditableName = useCallback(
     (name: string) => {
-      const confirm = () => FP.pipe(editableName, O.fold(FP.constVoid, onChange))
       const cancel = () => {
         reset()
         setEditableName(O.none)
@@ -58,11 +65,11 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
       const submit = ({ name }: FormData) => {
         setEditableName(O.none)
         onChange(name)
+        setName(name)
         reset()
       }
 
       const keyDownHandler = (e: React.KeyboardEvent<HTMLElement>) => {
-        console.log('key down', e.key)
         if (e.key === 'Escape') {
           cancel()
         }
@@ -71,9 +78,11 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
       return (
         <form className="items-top flex w-full justify-center" onSubmit={handleSubmit(submit)}>
           <Input
+            id="name"
             className="w-full !max-w-[380px] pl-[60px]" // 60px offset of icons width to stay in center
             classNameInput="text-[18px] ring-gray1 dark:ring-gray1d"
             size="large"
+            disabled={loading}
             defaultValue={name}
             autoFocus
             maxLength={MAX_WALLET_NAME_CHARS}
@@ -82,7 +91,7 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
             onKeyDown={keyDownHandler}
           />
           <div className="flex h-[35px] items-center">
-            <BaseButton className="!p-0 text-turquoise" onClick={confirm} type="submit">
+            <BaseButton className="!p-0 text-turquoise" onClick={handleSubmit(submit)} type="submit">
               <CheckCircleIcon className="ml-[5px] h-[24px] w-[24px]" />
             </BaseButton>
             <XCircleIcon className="ml-[5px] h-[24px] w-[24px] cursor-pointer text-error0" onClick={cancel} />
@@ -90,13 +99,14 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
         </form>
       )
     },
-    [editableName, errors.name, handleSubmit, intl, onChange, register, reset]
+    [loading, errors.name, handleSubmit, intl, onChange, register, reset]
   )
 
   return (
     <div className={`flex w-full flex-col items-center justify-center ${className}`}>
       <h2 className="w-full text-center font-main text-[12px] uppercase text-text2 dark:text-text2d">
-        {intl.formatMessage({ id: 'wallet.name' })}{' '}
+        {intl.formatMessage({ id: 'wallet.name' })}
+        {/* show info about max. chars in editable mode only  */}
         {FP.pipe(
           editableName,
           O.fold(
@@ -109,7 +119,11 @@ export const EditableWalletName: React.FC<Props> = (props): JSX.Element => {
           )
         )}
       </h2>
-      {FP.pipe(editableName, O.fold(renderName, renderEditableName))}
+      <div className={`flex items-center ${loading ? 'opacity-65' : 'opacity-100'}`}>
+        {/* show loading icon */}
+        {/* {loading && <LoadingIcon className={`mr-[12px] h-[17px] w-[17px] animate-spin group-hover:opacity-70`} />} */}
+        {FP.pipe(editableName, O.fold(renderName, renderEditableName))}
+      </div>
     </div>
   )
 }

--- a/src/renderer/hooks/useKeystoreState.ts
+++ b/src/renderer/hooks/useKeystoreState.ts
@@ -9,7 +9,8 @@ import {
   KeystoreState,
   Phrase,
   RemoveKeystoreWalletHandler,
-  ChangeKeystoreWalletHandler
+  ChangeKeystoreWalletHandler,
+  RenameKeystoreWalletHandler
 } from '../services/wallet/types'
 import { getPhrase, getWalletName, isLocked } from '../services/wallet/util'
 
@@ -19,12 +20,20 @@ export const useKeystoreState = (): {
   walletName: O.Option<string>
   remove: RemoveKeystoreWalletHandler
   change$: ChangeKeystoreWalletHandler
+  rename$: RenameKeystoreWalletHandler
   unlock: (password: string) => Promise<void>
   lock: FP.Lazy<void>
   locked: boolean
 } => {
   const {
-    keystoreService: { keystore$, unlock, lock, removeKeystoreWallet: remove, changeKeystoreWallet: change$ }
+    keystoreService: {
+      keystore$,
+      unlock,
+      lock,
+      removeKeystoreWallet: remove,
+      changeKeystoreWallet: change$,
+      renameKeystoreWallet: rename$
+    }
   } = useWalletContext()
 
   const state = useObservableState(keystore$, INITIAL_KEYSTORE_STATE)
@@ -33,5 +42,5 @@ export const useKeystoreState = (): {
   const [walletName] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(getWalletName))), O.none)
   const [locked] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(isLocked))), false)
 
-  return { state, phrase, walletName, unlock, lock, locked, remove, change$ }
+  return { state, phrase, walletName, unlock, lock, locked, remove, change$, rename$ }
 }

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -4,6 +4,7 @@ const wallet: WalletMessages = {
   'wallet.name': 'Wallet Name',
   'wallet.name.maxChars': 'Max. {max} Zeichen',
   'wallet.name.error.empty': 'Bitte Namen der Wallet angeben',
+  'wallet.name.error.rename': 'Error beim Umbenennen der Wallet',
   'wallet.nav.deposits': 'Einzahlungen',
   'wallet.nav.bonds': 'Bonds',
   'wallet.nav.poolshares': 'Anteile',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -4,6 +4,7 @@ const wallet: WalletMessages = {
   'wallet.name': 'Wallet name',
   'wallet.name.maxChars': 'Max. {max} chars',
   'wallet.name.error.empty': 'Please enter a name for your wallet',
+  'wallet.name.error.rename': 'Error while renaming the wallet',
   'wallet.nav.deposits': 'Deposits',
   'wallet.nav.bonds': 'Bonds',
   'wallet.nav.poolshares': 'Shares',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -4,6 +4,7 @@ const wallet: WalletMessages = {
   'wallet.name': 'Wallet name - FR',
   'wallet.name.maxChars': 'Max. {max} chars - FR',
   'wallet.name.error.empty': 'Please enter a name for your wallet - FR',
+  'wallet.name.error.rename': 'Error while renaming the wallet - FR',
   'wallet.nav.deposits': 'Dépots',
   'wallet.nav.bonds': 'Cautions',
   'wallet.nav.poolshares': 'Quote-part',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -4,6 +4,7 @@ const wallet: WalletMessages = {
   'wallet.name': 'Wallet name - RU',
   'wallet.name.maxChars': 'Max. {max} chars - RU',
   'wallet.name.error.empty': 'Please enter a name for your wallet - RU',
+  'wallet.name.error.rename': 'Error while renaming the wallet - RU',
   'wallet.nav.deposits': 'Вклады',
   'wallet.nav.bonds': 'Бонды',
   'wallet.nav.poolshares': 'Доли',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -152,6 +152,7 @@ type WalletMessageKey =
   | 'wallet.name'
   | 'wallet.name.maxChars'
   | 'wallet.name.error.empty'
+  | 'wallet.name.error.rename'
   | 'wallet.nav.deposits'
   | 'wallet.nav.bonds'
   | 'wallet.nav.poolshares'

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -58,6 +58,10 @@ export type ImportingKeystoreStateLD = Rx.Observable<ImportingKeystoreStateRD>
 
 export type RemoveKeystoreWalletHandler = () => Promise<number>
 
+export type RenameKeystoreWalletRD = RD.RemoteData<Error, boolean>
+export type RenameKeystoreWalletLD = LiveData<Error, boolean>
+export type RenameKeystoreWalletHandler = (id: KeystoreId, name: string) => RenameKeystoreWalletLD
+
 export type ChangeKeystoreWalletRD = RD.RemoteData<Error, boolean>
 export type ChangeKeystoreWalletLD = LiveData<Error, boolean>
 export type ChangeKeystoreWalletHandler = (id: KeystoreId) => ChangeKeystoreWalletLD
@@ -67,6 +71,7 @@ export type KeystoreService = {
   addKeystoreWallet: (params: AddKeystoreParams) => Promise<void>
   removeKeystoreWallet: RemoveKeystoreWalletHandler
   changeKeystoreWallet: ChangeKeystoreWalletHandler
+  renameKeystoreWallet: RenameKeystoreWalletHandler
   loadKeystore$: () => LoadKeystoreLD
   importKeystore: (params: ImportKeystoreParams) => Promise<void>
   exportKeystore: () => Promise<void>

--- a/src/renderer/views/wallet/WalletSettingsView.tsx
+++ b/src/renderer/views/wallet/WalletSettingsView.tsx
@@ -69,7 +69,7 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
     keystoreService: { exportKeystore, validatePassword$ }
   } = useWalletContext()
 
-  const { state: keystore, lock, remove, change$ } = useKeystoreState()
+  const { state: keystore, lock, remove, change$, rename$ } = useKeystoreState()
 
   const { network } = useNetwork()
 
@@ -417,8 +417,9 @@ export const WalletSettingsView: React.FC = (): JSX.Element => {
         <WalletSettings
           network={network}
           lockWallet={lock}
-          removeKeystore={remove}
-          changeKeystore$={change$}
+          removeKeystoreWallet={remove}
+          changeKeystoreWallet$={change$}
+          renameKeystoreWallet$={rename$}
           exportKeystore={exportKeystore}
           addLedgerAddress={addLedgerAddressHandler}
           verifyLedgerAddress={verifyLedgerAddressHandler}


### PR DESCRIPTION


https://user-images.githubusercontent.com/61792675/185211476-a755911a-dce9-46e7-938c-ab164e5d16f6.mp4



- [x] Business logic for renaming wallets
- [x] Update UI (`WalletSettings` etc) to handle/show `rename wallet` state
- [x] Quick update `EditableWalletName` to use `TextButton`
- [x] Update `i18n`

Part of #1601