### PR TITLE
Sync keystore/ledger states

### DIFF
--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -19,7 +19,7 @@ export const Header: React.FC = (): JSX.Element => {
   const { keystoreService } = useWalletContext()
   const { mimir$ } = useThorchainContext()
   const { lock } = keystoreService
-  const keystore = useObservableState(keystoreService.keystore$, O.none)
+  const keystore = useObservableState(keystoreService.keystoreState$, O.none)
   const mimir = useObservableState(mimir$, RD.initial)
   const { service: midgardService } = useMidgardContext()
   const {

--- a/src/renderer/components/settings/WalletSettings.tsx
+++ b/src/renderer/components/settings/WalletSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { SearchOutlined } from '@ant-design/icons'
 import * as RD from '@devexperts/remote-data-ts'
@@ -453,10 +453,8 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
   const changeWalletHandler = useCallback(
     (id: KeystoreId) => {
       subscribeChangeWalletState(changeKeystoreWallet$(id))
-      // Jump to `UnlockView` to avoid staying at wallet settings
-      navigate(walletRoutes.locked.path())
     },
-    [changeKeystoreWallet$, navigate, subscribeChangeWalletState]
+    [changeKeystoreWallet$, subscribeChangeWalletState]
   )
 
   const renderChangeWalletError = useMemo(
@@ -477,6 +475,13 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
       ),
     [changeWalletState, intl]
   )
+
+  useEffect(() => {
+    if (RD.isSuccess(changeWalletState)) {
+      // Jump to `UnlockView` to avoid staying at wallet settings
+      navigate(walletRoutes.locked.path())
+    }
+  }, [changeWalletState, navigate])
 
   const { state: renameWalletState, subscribe: subscribeRenameWalletState } =
     useSubscriptionState<RenameKeystoreWalletRD>(RD.initial)
@@ -612,7 +617,12 @@ export const WalletSettings: React.FC<Props> = (props): JSX.Element => {
                 <h2 className="w-full text-center font-main text-[12px] uppercase text-text2 dark:text-text2d">
                   {intl.formatMessage({ id: 'wallet.change.title' })}
                 </h2>
-                <WalletSelector wallets={wallets} onChange={changeWalletHandler} className="min-w-[200px]" />
+                <WalletSelector
+                  className="min-w-[200px]"
+                  disabled={RD.isPending(changeWalletState)}
+                  wallets={wallets}
+                  onChange={changeWalletHandler}
+                />
                 {renderChangeWalletError}
               </div>
             </div>

--- a/src/renderer/hooks/useKeystoreState.ts
+++ b/src/renderer/hooks/useKeystoreState.ts
@@ -27,7 +27,7 @@ export const useKeystoreState = (): {
 } => {
   const {
     keystoreService: {
-      keystore$,
+      keystoreState$,
       unlock,
       lock,
       removeKeystoreWallet: remove,
@@ -36,11 +36,11 @@ export const useKeystoreState = (): {
     }
   } = useWalletContext()
 
-  const state = useObservableState(keystore$, INITIAL_KEYSTORE_STATE)
+  const state = useObservableState(keystoreState$, INITIAL_KEYSTORE_STATE)
 
-  const [phrase] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(getPhrase))), O.none)
-  const [walletName] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(getWalletName))), O.none)
-  const [locked] = useObservableState(() => FP.pipe(keystore$, RxOp.map(FP.flow(isLocked))), false)
+  const [phrase] = useObservableState(() => FP.pipe(keystoreState$, RxOp.map(FP.flow(getPhrase))), O.none)
+  const [walletName] = useObservableState(() => FP.pipe(keystoreState$, RxOp.map(FP.flow(getWalletName))), O.none)
+  const [locked] = useObservableState(() => FP.pipe(keystoreState$, RxOp.map(FP.flow(isLocked))), false)
 
   return { state, phrase, walletName, unlock, lock, locked, remove, change$, rename$ }
 }

--- a/src/renderer/hooks/useKeystoreWallets.ts
+++ b/src/renderer/hooks/useKeystoreWallets.ts
@@ -6,16 +6,16 @@ import { useWalletContext } from '../contexts/WalletContext'
 import { KeystoreWalletsRD, KeystoreWalletsUI } from '../services/wallet/types'
 
 export const useKeystoreWallets = (): {
-  wallets: KeystoreWalletsRD
+  walletsPersistentRD: KeystoreWalletsRD
   reload: FP.Lazy<void>
   walletsUI: KeystoreWalletsUI
 } => {
   const {
-    keystoreService: { reloadKeystoreWallets: reload, keystoreWallets$, keystoreWalletsUI$ }
+    keystoreService: { reloadPersistentKeystoreWallets: reload, keystoreWalletsPersistent$, keystoreWalletsUI$ }
   } = useWalletContext()
 
-  const wallets = useObservableState(keystoreWallets$, RD.initial)
+  const walletsPersistentRD = useObservableState(keystoreWalletsPersistent$, RD.initial)
   const walletsUI = useObservableState(keystoreWalletsUI$, [])
 
-  return { wallets: wallets, walletsUI, reload }
+  return { walletsPersistentRD, walletsUI, reload }
 }

--- a/src/renderer/services/binance/common.ts
+++ b/src/renderer/services/binance/common.ts
@@ -22,7 +22,7 @@ import { ClientState, ClientState$, Client$ } from './types'
  * A `BinanceClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -24,7 +24,7 @@ import { ClientState, ClientState$ } from './types'
  * A `BitcoinClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/bitcoincash/common.ts
+++ b/src/renderer/services/bitcoincash/common.ts
@@ -24,7 +24,7 @@ import { ClientState, ClientState$ } from './types'
  * A `BitcoinCashClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/cosmos/common.ts
+++ b/src/renderer/services/cosmos/common.ts
@@ -22,7 +22,7 @@ import type { Client$, ClientState, ClientState$ } from './types'
  * A `CosmosClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$, Rx.of(getClientUrls())]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$, Rx.of(getClientUrls())]),
   RxOp.switchMap(
     ([keystore, network, clientUrls]): ClientState$ =>
       FP.pipe(

--- a/src/renderer/services/doge/common.ts
+++ b/src/renderer/services/doge/common.ts
@@ -24,7 +24,7 @@ import { ClientState, ClientState$ } from './types'
  * A `DogeClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/ethereum/common.ts
+++ b/src/renderer/services/ethereum/common.ts
@@ -28,7 +28,7 @@ import { Client$, ClientState, ClientState$ } from './types'
  * A `EthereumClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/litecoin/common.ts
+++ b/src/renderer/services/litecoin/common.ts
@@ -23,7 +23,7 @@ import { Client$, ClientState$, ClientState } from './types'
  * A `LitecoinClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
   RxOp.switchMap(
     ([keystore, network]): ClientState$ =>
       Rx.of(

--- a/src/renderer/services/thorchain/common.ts
+++ b/src/renderer/services/thorchain/common.ts
@@ -23,7 +23,7 @@ import { Client$, ClientState, ClientState$ } from './types'
  * A `ThorchainClient` will never be created as long as no phrase is available
  */
 const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystore$, clientNetwork$, Rx.of(getClientUrl())]),
+  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$, Rx.of(getClientUrl())]),
   RxOp.switchMap(
     ([keystore, network, clientUrl]): ClientState$ =>
       FP.pipe(

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -7,7 +7,8 @@ import { getTxs$, loadTxs, explorerUrl$, resetTxsPage } from './transaction'
 
 const { askLedgerAddress$, getLedgerAddress$, verifyLedgerAddress, removeLedgerAddress, ledgerAddresses$ } =
   createLedgerService({
-    keystore$: keystoreService.keystoreState$
+    keystore$: keystoreService.keystoreState$,
+    wallets$: keystoreService.keystoreWalletsUI$
   })
 
 const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } = createBalancesService({

--- a/src/renderer/services/wallet/index.ts
+++ b/src/renderer/services/wallet/index.ts
@@ -7,11 +7,11 @@ import { getTxs$, loadTxs, explorerUrl$, resetTxsPage } from './transaction'
 
 const { askLedgerAddress$, getLedgerAddress$, verifyLedgerAddress, removeLedgerAddress, ledgerAddresses$ } =
   createLedgerService({
-    keystore$: keystoreService.keystore$
+    keystore$: keystoreService.keystoreState$
   })
 
 const { reloadBalances, reloadBalancesByChain, balancesState$, chainBalances$ } = createBalancesService({
-  keystore$: keystoreService.keystore$,
+  keystore$: keystoreService.keystoreState$,
   network$,
   getLedgerAddress$
 })

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -1,7 +1,10 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Chain } from '@xchainjs/xchain-util'
+import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
+import * as M from 'fp-ts/lib/Map'
 import * as O from 'fp-ts/lib/Option'
+import * as N from 'fp-ts/number'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
@@ -21,11 +24,19 @@ import {
   VerifyLedgerAddressHandler,
   AskLedgerAddressesHandler,
   RemoveLedgerAddressHandler,
-  isKeystoreUnlocked
+  isKeystoreUnlocked,
+  KeystoreWalletsUI$,
+  RemovedKeystoreId$
 } from './types'
 import { hasImportedKeystore } from './util'
 
-export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }): LedgerService => {
+export const createLedgerService = ({
+  keystore$,
+  wallets$
+}: {
+  keystore$: KeystoreState$
+  wallets$: KeystoreWalletsUI$
+}): LedgerService => {
   // State of all Ledger addresses added to a keystore wallet
   const {
     get$: keystoreLedgerAddresses$,
@@ -40,6 +51,22 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
     RxOp.map(FP.flow(O.map(({ id }) => id))),
     RxOp.distinctUntilChanged(),
     RxOp.shareReplay(1)
+  )
+
+  /**
+   * Stream of removed `KeystoreId`s
+   * by comparing changes of `KeystoreWalletsUI[]`
+   */
+  const removedKeystoreId$: RemovedKeystoreId$ = FP.pipe(
+    wallets$,
+    // get prev. + curr. `KeystoreWalletsUI[]`
+    RxOp.pairwise(),
+    // Transform pair of `KeystoreWalletsUI[]` to pair of `KeystoreId[]`
+    RxOp.map((pair) => FP.pipe(pair, A.map(FP.flow(A.map(({ id }) => id))))),
+    RxOp.map(([prev, curr]) =>
+      // get's the difference
+      FP.pipe(prev, A.difference(N.Eq)(curr), A.head)
+    )
   )
 
   const ledgerAddresses = (id: KeystoreId): LedgerAddressesMap =>
@@ -156,8 +183,18 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
     }
   })
 
+  // Whenever a keystore have been removed, remove its related ledger addresses
+  removedKeystoreId$.subscribe((oKeystoreId: O.Option<KeystoreId>) =>
+    FP.pipe(
+      oKeystoreId,
+      O.map((id) => FP.pipe(keystoreLedgerAddresses(), M.deleteAt(N.Eq)(id), setKeystoreLedgerAddresses))
+    )
+  )
+
   // TODO(@Veado) Remove it - for debugging only
-  ledgerAddresses$.subscribe((v) => console.log('ledgerAddresses subscription', v))
+  ledgerAddresses$.subscribe((v) => console.log('ledgerAddresses$ sub', v))
+  keystoreLedgerAddresses$.subscribe((v) => console.log('keystoreLedgerAddresses$ sub', v))
+  removedKeystoreId$.subscribe((v) => console.log('removedKeystoreId$ sub', v))
 
   return {
     ledgerAddresses$,

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -37,7 +37,9 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
     keystore$,
     // Check unlocked keystore only
     RxOp.map(FP.flow(O.chain(O.fromPredicate(isKeystoreUnlocked)))),
-    RxOp.map(FP.flow(O.map(({ id }) => id)))
+    RxOp.map(FP.flow(O.map(({ id }) => id))),
+    RxOp.distinctUntilChanged(),
+    RxOp.shareReplay(1)
   )
 
   const ledgerAddresses = (id: KeystoreId): LedgerAddressesMap =>
@@ -62,7 +64,8 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
             )
         )
       )
-    )
+    ),
+    RxOp.startWith(INITIAL_LEDGER_ADDRESSES_MAP)
   )
 
   const setLedgerAddresses = (id: KeystoreId, addressesMap: LedgerAddressesMap) => {
@@ -152,6 +155,9 @@ export const createLedgerService = ({ keystore$ }: { keystore$: KeystoreState$ }
       setKeystoreLedgerAddresses(INITIAL_KEYSTORE_LEDGER_ADDRESSES_MAP)
     }
   })
+
+  // TODO(@Veado) Remove it - for debugging only
+  ledgerAddresses$.subscribe((v) => console.log('ledgerAddresses subscription', v))
 
   return {
     ledgerAddresses$,

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -67,7 +67,7 @@ export type ChangeKeystoreWalletLD = LiveData<Error, boolean>
 export type ChangeKeystoreWalletHandler = (id: KeystoreId) => ChangeKeystoreWalletLD
 
 export type KeystoreService = {
-  keystore$: KeystoreState$
+  keystoreState$: KeystoreState$
   addKeystoreWallet: (params: AddKeystoreParams) => Promise<void>
   removeKeystoreWallet: RemoveKeystoreWalletHandler
   changeKeystoreWallet: ChangeKeystoreWalletHandler
@@ -82,8 +82,8 @@ export type KeystoreService = {
    * No need to store any success data. Only status
    */
   validatePassword$: ValidatePasswordHandler
-  reloadKeystoreWallets: FP.Lazy<void>
-  keystoreWallets$: KeystoreWalletsLD
+  reloadPersistentKeystoreWallets: FP.Lazy<void>
+  keystoreWalletsPersistent$: KeystoreWalletsLD
   keystoreWalletsUI$: KeystoreWalletsUI$
   importingKeystoreState$: ImportingKeystoreStateLD
   resetImportingKeystoreState: FP.Lazy<void>
@@ -247,6 +247,7 @@ export type KeystoreLedgerAddressesMap = Map<KeystoreId, LedgerAddressesMap>
 
 export type KeystoreWalletsRD = RD.RemoteData<Error, KeystoreWallets>
 export type KeystoreWalletsLD = LiveData<Error, KeystoreWallets>
+export type KeystoreWallets$ = Rx.Observable<KeystoreWallets>
 
 export type KeystoreWalletUI = Omit<KeystoreWallet, 'keystore'>
 export type KeystoreWalletsUI = KeystoreWalletUI[]

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -58,6 +58,8 @@ export type ImportingKeystoreStateLD = Rx.Observable<ImportingKeystoreStateRD>
 
 export type RemoveKeystoreWalletHandler = () => Promise<number>
 
+export type RemovedKeystoreId$ = Rx.Observable<O.Option<KeystoreId>>
+
 export type RenameKeystoreWalletRD = RD.RemoteData<Error, boolean>
 export type RenameKeystoreWalletLD = LiveData<Error, boolean>
 export type RenameKeystoreWalletHandler = (id: KeystoreId, name: string) => RenameKeystoreWalletLD

--- a/src/renderer/views/app/AppView.tsx
+++ b/src/renderer/views/app/AppView.tsx
@@ -72,7 +72,7 @@ export const AppView: React.FC = (): JSX.Element => {
   const prevHaltedChains = useRef<Chain[]>([])
   const prevMimirHalt = useRef<MimirHalt>(DEFAULT_MIMIR_HALT)
 
-  const { wallets: keystoreWallets, reload: reloadKeystoreWallets } = useKeystoreWallets()
+  const { walletsPersistentRD, reload: reloadPersistentWallets } = useKeystoreWallets()
 
   const { mimirHaltRD } = useMimirHalt()
 
@@ -273,7 +273,7 @@ export const AppView: React.FC = (): JSX.Element => {
           {' '}
           keystoreWallets:
           {FP.pipe(
-            keystoreWallets,
+            walletsPersistentRD,
             RD.fold(
               () => <>init</>,
               () => <>loading</>,
@@ -282,10 +282,10 @@ export const AppView: React.FC = (): JSX.Element => {
             )
           )}
         </div>
-        <button onClick={reloadKeystoreWallets}>reloadKeystoreWallets</button>
+        <button onClick={reloadPersistentWallets}>reloadKeystoreWallets</button>
       </div>
     )
-  }, [keystoreWallets, reloadKeystoreWallets])
+  }, [walletsPersistentRD, reloadPersistentWallets])
 
   return (
     <Styled.AppWrapper>

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -145,7 +145,7 @@ export const DepositView: React.FC<Props> = () => {
   // Because `useObservableState` will set its state NOT before first rendering loop,
   // and `AddWallet` would be rendered for the first time,
   // before a check of `keystoreState` can be done
-  const keystoreState = useObservableState(keystoreService.keystore$, undefined)
+  const keystoreState = useObservableState(keystoreService.keystoreState$, undefined)
 
   const poolDetailRD = useObservableState<PoolDetailRD>(selectedPoolDetail$, RD.initial)
 

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -63,7 +63,7 @@ const SuccessRouteView: React.FC<Props> = ({ sourceAsset, targetAsset }): JSX.El
     balancesState$,
     reloadBalancesByChain,
     getLedgerAddress$,
-    keystoreService: { keystore$, validatePassword$ }
+    keystoreService: { keystoreState$, validatePassword$ }
   } = useWalletContext()
 
   const [haltedChains] = useObservableState(() => FP.pipe(haltedChains$, RxOp.map(RD.getOrElse((): Chain[] => []))), [])
@@ -71,7 +71,7 @@ const SuccessRouteView: React.FC<Props> = ({ sourceAsset, targetAsset }): JSX.El
 
   const { reloadApproveFee, approveFee$, approveERC20Token$, isApprovedERC20Token$ } = useEthereumContext()
 
-  const keystore = useObservableState(keystore$, O.none)
+  const keystore = useObservableState(keystoreState$, O.none)
 
   const poolsState = useObservableState(poolsState$, RD.initial)
 

--- a/src/renderer/views/wallet/WalletAuth.tsx
+++ b/src/renderer/views/wallet/WalletAuth.tsx
@@ -18,7 +18,7 @@ export const WalletAuth = ({ children }: { children: JSX.Element }): JSX.Element
   // Since `useObservableState` is set after first render (but not before)
   // and Route.render is called before first render,
   // we have to add 'undefined'  as default value
-  const keystore = useObservableState(keystoreService.keystore$, undefined)
+  const keystore = useObservableState(keystoreService.keystoreState$, undefined)
 
   // Redirect if  an user has not a phrase imported or wallet has been locked
   // Special case: keystore can be `undefined` (see comment at its definition using `useObservableState`)

--- a/src/renderer/views/wallet/WalletSettingsAuth.tsx
+++ b/src/renderer/views/wallet/WalletSettingsAuth.tsx
@@ -2,20 +2,29 @@ import React, { useCallback } from 'react'
 
 import * as FP from 'fp-ts/function'
 import * as O from 'fp-ts/lib/Option'
+import { useObservableState } from 'observable-hooks'
 import { useLocation, useNavigate } from 'react-router-dom'
+import * as RxOp from 'rxjs/operators'
 
 import { UnlockWalletSettings } from '../../components/settings'
+import { useWalletContext } from '../../contexts/WalletContext'
 import { useCollapsedSetting } from '../../hooks/useCollapsedSetting'
-import { useKeystoreState } from '../../hooks/useKeystoreState'
 import * as walletRoutes from '../../routes/wallet'
+import { INITIAL_KEYSTORE_STATE } from '../../services/wallet/const'
 import { isKeystoreUnlocked } from '../../services/wallet/types'
 import { WalletSettingsView } from './WalletSettingsView'
 
 export const WalletSettingsAuth: React.FC = (): JSX.Element => {
   const navigate = useNavigate()
   const location = useLocation()
+  const {
+    keystoreService: { keystoreState$ }
+  } = useWalletContext()
 
-  const { state: keystoreState } = useKeystoreState()
+  // Note: Short delay for acting changes of `KeystoreState` is needed
+  // Just to let `WalletSettingsView` process changes w/o race conditions
+  // In other case it will jump to `UnlockWalletSettings` right after changing a wallet in `WalletSettingsView`
+  const keystoreState = useObservableState(FP.pipe(keystoreState$, RxOp.delay(100)), INITIAL_KEYSTORE_STATE)
 
   const { collapsed, toggle: toggleCollapse } = useCollapsedSetting('wallet')
 

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -37,7 +37,7 @@ export type IPCExportKeystoreParams = { fileName: string; keystore: Keystore }
 export type IPCSaveKeystoreParams = { id: KeystoreId; keystore: Keystore }
 
 export type ApiKeystore = {
-  saveKeystoreWallets: (wallets: KeystoreWallets) => Promise<void>
+  saveKeystoreWallets: (wallets: KeystoreWallets) => Promise<E.Either<Error, KeystoreWallets>>
   exportKeystore: (params: IPCExportKeystoreParams) => Promise<void>
   initKeystoreWallets: () => Promise<E.Either<Error, KeystoreWallets>>
   load: () => Promise<Keystore>

--- a/src/shared/mock/api.ts
+++ b/src/shared/mock/api.ts
@@ -8,7 +8,7 @@ import { MOCK_KEYSTORE } from './wallet'
 
 // Mock "empty" `apiKeystore`
 export const apiKeystore: ApiKeystore = {
-  saveKeystoreWallets: (_) => Promise.resolve(),
+  saveKeystoreWallets: (_) => Promise.resolve(E.right([])),
   exportKeystore: (_: IPCExportKeystoreParams) => Promise.resolve(),
   load: () => Promise.resolve(MOCK_KEYSTORE),
   initKeystoreWallets: () => Promise.resolve(E.right([]))


### PR DESCRIPTION
- [x] `keystore` service: Rename `kestore$` -> `keystoreState$` /
`keystoreWallets` -> `keystoreWalletsPersistent$` etc.
- [x] Subscribe to `keystoreWalletsPersistent$` to update internal state
in memory
- [x] Fix: Wallet change from WalletSettings failed
- [x] Remove related ledger addresses by removing a wallet

Part of #1601