### PR TITLE
Swap: Fix fee handling (ETH outbound + inbound error handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
-# 1.18.3 (2022-10-xx)
+# 1.18.3 (2022-11-03)
 
 ## Update
 
+- [Swap] Redesign [#2430](https://github.com/thorchain/asgardex-electron/pull/2430), [#2432](https://github.com/thorchain/asgardex-electron/pull/2432)
+- Refactor `AssetMenu` component [#2429](https://github.com/thorchain/asgardex-electron/pull/2429)
+- Redesign AssetSelect [#2426](https://github.com/thorchain/asgardex-electron/pull/2426)
+- Upgrade to heroicons@2.x [#2425](https://github.com/thorchain/asgardex-electron/pull/2425)
+- Move handling of LastBlock from Midgard to THORNode [#2419](https://github.com/thorchain/asgardex-electron/pull/2419)
+- Move handling of Constants from Midgard to THORNode [#2418](https://github.com/thorchain/asgardex-electron/pull/2418)
 - Update types/api for latest thornode@1.97.2 [#2412](https://github.com/thorchain/asgardex-electron/pull/2412)
 - Update types/api for latest midgard@2.9.4 [#2413](https://github.com/thorchain/asgardex-electron/pull/2413)
 - Update ERC20 whitelist based on latest thornode@1.97.2 [#2414](https://github.com/thorchain/asgardex-electron/pull/2414)
 - Get outbound fees from `inbound_addresses` [#2406](https://github.com/thorchain/asgardex-electron/issues/2406)
+
+## Add
+
+- `InputSearch` component [#2427](https://github.com/thorchain/asgardex-electron/pull/2427)
+
+## Fix
+
+- AssetSelect: Scroll area breaks layout + dialog shouldn't close by clicking search input [#2428](https://github.com/thorchain/asgardex-electron/issues/2428)
+- Check Midgard status from its health endpoint [#2417](https://github.com/thorchain/asgardex-electron/issues/2417)
 
 # 1.18.2 (2022-10-03)
 

--- a/src/renderer/components/swap/SelectableSlipTolerance.tsx
+++ b/src/renderer/components/swap/SelectableSlipTolerance.tsx
@@ -35,7 +35,7 @@ export const SelectableSlipTolerance: React.FC<Props> = (props): JSX.Element => 
         {value.toString()} %
         <Cog8ToothIcon className="ease ml-5px h-[15px] w-[15px] text-gray2 group-hover:rotate-180 dark:text-gray2d" />
       </Popover.Button>
-      <Popover.Panel className="absolute z-10 translate-y-[-100%] translate-x-[-50%] bg-bg0 shadow dark:bg-bg0d ">
+      <Popover.Panel className="absolute z-10 translate-y-[-100%] translate-x-[-50%] bg-bg0 shadow-full dark:bg-bg0d dark:shadow-fulld ">
         {({ close }) => (
           <div>
             {FP.pipe(

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -34,7 +34,6 @@ import * as RxOp from 'rxjs/operators'
 import { Network } from '../../../shared/api/types'
 import { WalletType } from '../../../shared/wallet/types'
 import { ZERO_BASE_AMOUNT } from '../../const'
-import { truncateAddress } from '../../helpers/addressHelper'
 import {
   getEthTokenAddress,
   isEthAsset,
@@ -1853,14 +1852,14 @@ export const Swap = ({
                         {intl.formatMessage({ id: 'common.addresses' })}
                       </div>
                       {/* sender address */}
-                      <div className="flex w-full justify-between pl-10px text-[12px]">
+                      <div className="flex w-full items-center justify-between pl-10px text-[12px]">
                         <div>{intl.formatMessage({ id: 'common.sender' })}</div>
-                        <div className="normal-case">
+                        <div className="truncate pl-20px text-[13px] normal-case leading-normal">
                           {FP.pipe(
                             oSwapParams,
                             O.map(({ sender }) => (
                               <TooltipAddress title={sender} key="tooltip-sender-addr">
-                                {truncateAddress(sender, sourceAsset.chain, network)}
+                                {sender}
                               </TooltipAddress>
                             )),
                             O.getOrElse(() => <>{noDataString}</>)
@@ -1868,14 +1867,14 @@ export const Swap = ({
                         </div>
                       </div>
                       {/* recipient address */}
-                      <div className="flex w-full justify-between pl-10px text-[12px]">
+                      <div className="flex w-full items-center justify-between pl-10px text-[12px]">
                         <div>{intl.formatMessage({ id: 'common.recipient' })}</div>
-                        <div className="normal-case">
+                        <div className="truncate pl-20px text-[13px] normal-case leading-normal">
                           {FP.pipe(
                             oTargetAddress,
                             O.map((address) => (
                               <TooltipAddress title={address} key="tooltip-target-addr">
-                                {truncateAddress(address, targetAsset.chain, network)}
+                                {address}
                               </TooltipAddress>
                             )),
                             O.getOrElse(() => <>{noDataString}</>)
@@ -1885,12 +1884,14 @@ export const Swap = ({
                       {/* inbound address */}
                       {FP.pipe(
                         oSwapParams,
-                        O.map(({ poolAddress: { address, chain } }) =>
+                        O.map(({ poolAddress: { address } }) =>
                           address ? (
-                            <div className="flex w-full justify-between pl-10px text-[12px]" key="pool-addr">
+                            <div
+                              className="flex w-full items-center justify-between pl-10px text-[12px]"
+                              key="pool-addr">
                               <div>{intl.formatMessage({ id: 'common.pool.inbound' })}</div>
                               <TooltipAddress title={address}>
-                                <div className="normal-case">{truncateAddress(address, chain, network)}</div>
+                                <div className="truncate pl-20px text-[13px] normal-case leading-normal">{address}</div>
                               </TooltipAddress>
                             </div>
                           ) : null
@@ -1902,10 +1903,12 @@ export const Swap = ({
 
                   {/* memo */}
                   {showDetails && (
-                    <div className="flex w-full items-start justify-between pt-10px text-[14px]">
-                      <div className="ml-[-2px] font-mainBold">{memoTitle}</div>
-                      <div className="break-all pl-20px font-main">{memoLabel}</div>
-                    </div>
+                    <>
+                      <div className="ml-[-2px] flex w-full items-start pt-10px font-mainBold text-[14px]">
+                        {memoTitle}
+                      </div>
+                      <div className="truncate pl-10px font-main text-[12px]">{memoLabel}</div>
+                    </>
                   )}
                 </div>
               </div>

--- a/src/renderer/services/midgard/utils.test.ts
+++ b/src/renderer/services/midgard/utils.test.ts
@@ -534,7 +534,8 @@ describe('services/midgard/utils/', () => {
             result,
             O.some({
               asset: AssetETH,
-              amount: baseAmount(2000000000, ETH_DECIMAL)
+              // "2" (1e8) in THORChain will be "20000000000" (1e18) at ETH
+              amount: baseAmount(20000000000, ETH_DECIMAL)
             })
           )
         ).toBeTruthy()

--- a/src/renderer/services/midgard/utils.ts
+++ b/src/renderer/services/midgard/utils.ts
@@ -256,10 +256,9 @@ export const getOutboundAssetFeeByChain = (
             asset: AssetDOGE
           })
         case ETHChain: {
-          // For ETH value is provided in `gwei` and needs to be converted into `wei`
-          const valueGwei = value.multipliedBy(10 ** 9)
           return O.some({
-            amount: baseAmount(valueGwei, ETH_DECIMAL),
+            // Convertion of decimal needed: 1e8 (by default in THORChain) -> 1e18 (ETH)
+            amount: convertBaseAmountDecimal(baseAmount(value, THORCHAIN_DECIMAL), ETH_DECIMAL),
             asset: AssetETH
           })
         }

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -231,12 +231,22 @@ const SuccessRouteView: React.FC<Props> = ({ sourceAsset, targetAsset }): JSX.El
         <BackLink className="!m-0" />
         <RefreshButton clickHandler={reloadHandler} />
       </div>
-      <div className="flex items-center justify-center bg-bg0 dark:bg-bg0d">
+
+      <div className="flex flex-col items-center justify-center bg-bg0 dark:bg-bg0d">
+        <div className="flex w-full justify-center border-b border-gray1 dark:border-gray1d">
+          <div className="border-b-[2px] border-turquoise py-10px px-10px font-mainSemiBold text-[16px] uppercase text-turquoise ">
+            {intl.formatMessage({ id: 'common.swap' })}
+          </div>
+        </div>
         {FP.pipe(
           sequenceTRD(poolsState, sourceAssetRD, targetAssetRD),
           RD.fold(
             () => <></>,
-            () => <Spin size="large" />,
+            () => (
+              <div className="flex min-h-[400px] items-center justify-center">
+                <Spin size="large" />
+              </div>
+            ),
             renderError,
             ([{ assetDetails, poolsData, poolDetails }, sourceAsset, targetAsset]) => {
               const hasRuneAsset = FP.pipe(


### PR DESCRIPTION
incl. few quick fixes

Note: Changes in `Swap` mostly format based after moving `Swap` headling to `SwapView`

- [x] Fix outbound fees for ETH
- [x] Swap details: Don't truncate addresses by default
- [x] Swap: Fix inbound fee error handling + fix layout (move `Swap` headline to `SwapView`, Fix position of loader)
- [x] Quick fix shadow for slippage layer
- [x] Update CHANGELOG