### PR TITLE
[Swap] Improve info text of `max value to swap`

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1568,6 +1568,30 @@ export const Swap = ({
     [oSwapParams]
   )
 
+  const maxBalanceInfoTxt = useMemo(() => {
+    const balanceLabel = formatAssetAmountCurrency({
+      amount: baseToAsset(sourceAssetAmountMax1e8),
+      asset: sourceAsset,
+      decimal: isUSDAsset(sourceAsset) ? 2 : 6,
+      trimZeros: !isUSDAsset(sourceAsset)
+    })
+
+    const feeLabel = FP.pipe(
+      swapFeesRD,
+      RD.map(({ inFee: { amount, asset: feeAsset } }) =>
+        formatAssetAmountCurrency({
+          amount: baseToAsset(amount),
+          asset: feeAsset,
+          decimal: isUSDAsset(feeAsset) ? 2 : 6,
+          trimZeros: !isUSDAsset(feeAsset)
+        })
+      ),
+      RD.getOrElse(() => noDataString)
+    )
+
+    return intl.formatMessage({ id: 'swap.info.max.fee' }, { balance: balanceLabel, fee: feeLabel })
+  }, [sourceAssetAmountMax1e8, sourceAsset, swapFeesRD, intl])
+
   const [showDetails, setShowDetails] = useState<boolean>(false)
 
   return (
@@ -1594,11 +1618,16 @@ export const Swap = ({
               <MaxBalanceButton
                 className="ml-10px mt-5px"
                 classNameButton="!text-gray2 dark:!text-gray2d"
-                classNameIcon="text-gray2 dark:text-gray2d"
+                classNameIcon={
+                  // show warn icon if maxAmountToSwapMax <= 0
+                  maxAmountToSwapMax1e8.gt(zeroTargetBaseAmountMax1e8)
+                    ? `text-gray2 dark:text-gray2d`
+                    : 'text-warning0 dark:text-warning0d'
+                }
                 size="medium"
                 balance={{ amount: maxAmountToSwapMax1e8, asset: sourceAsset }}
                 onClick={() => setAmountToSwapMax1e8(maxAmountToSwapMax1e8)}
-                maxInfoText={intl.formatMessage({ id: 'swap.info.max.fee' })}
+                maxInfoText={maxBalanceInfoTxt}
               />
               {minAmountError && renderMinAmount}
             </div>

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -6,7 +6,7 @@ const swap: SwapMessages = {
   'swap.state.success': 'Erfolgreich getauscht',
   'swap.input': 'Eingabe',
   'swap.output': 'Ausgabe',
-  'swap.info.max.fee': 'Gesamtguthaben minus voraussichtliche Swapgebühr',
+  'swap.info.max.fee': 'Gesamtguthaben ({balance}) minus voraussichtliche Swapgebühr ({fee})',
   'swap.slip.title': 'Slip',
   'swap.slip.tolerance': 'Slippage-Toleranz',
   'swap.slip.tolerance.info':

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -6,7 +6,7 @@ const swap: SwapMessages = {
   'swap.state.error': 'Swap error',
   'swap.input': 'Input',
   'swap.output': 'Output',
-  'swap.info.max.fee': 'Total asset balance substracted by estimated swap fees',
+  'swap.info.max.fee': 'Total asset balance ({balance}) substracted by estimated swap fees ({fee})',
   'swap.slip.title': 'Slip',
   'swap.slip.tolerance': 'Slippage tolerance',
   'swap.slip.tolerance.info':

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -6,7 +6,7 @@ const swap: SwapMessages = {
   'swap.state.error': "Erreur lors de l'échange",
   'swap.input': 'Entrée',
   'swap.output': 'Sortie',
-  'swap.info.max.fee': "Solde total de l'actif moins les frais d'échange estimés",
+  'swap.info.max.fee': "Solde total de l'actif ({balance}) moins les frais d'échange estimés ({fee})",
   'swap.slip.title': 'Slippage',
   'swap.slip.tolerance': 'Tolérance de slippage',
   'swap.slip.tolerance.info':

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -6,7 +6,7 @@ const swap: SwapMessages = {
   'swap.state.error': 'Ошибка при обмене',
   'swap.input': 'Отдаете',
   'swap.output': 'Получаете',
-  'swap.info.max.fee': 'Баланс актива за вычетом комиссии обмена',
+  'swap.info.max.fee': 'Баланс актива ({balance}) за вычетом комиссии обмена ({fee})',
   'swap.slip.title': 'Проскальзывание',
   'swap.slip.tolerance': 'Допуск по проскальзыванию',
   'swap.slip.tolerance.info':


### PR DESCRIPTION
by including balances + inbound fee. Highlight info icon in case balances <= 0

![swap-maxbalance-info](https://user-images.githubusercontent.com/61792675/199697117-cd75045c-68b9-48ae-b6eb-94dbadad4665.png)