### PR TITLE
[Deposit] Wallet types based on routes

### DIFF
--- a/src/renderer/components/deposit/Deposit.tsx
+++ b/src/renderer/components/deposit/Deposit.tsx
@@ -144,8 +144,8 @@ export const Deposit: React.FC<Props> = (props) => {
           <SymDepositContent
             poolDetail={poolDetailRD}
             asset={assetWD}
-            runeWalletAddress={runeWalletAddress.address}
-            assetWalletAddress={assetWalletAddress.address}
+            runeWalletAddress={runeWalletAddress}
+            assetWalletAddress={assetWalletAddress}
             haltedChains={haltedChains}
             mimirHalt={mimirHalt}
           />

--- a/src/renderer/components/deposit/add/SymDeposit.stories.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.stories.tsx
@@ -58,7 +58,17 @@ const defaultProps: SymDepositProps = {
   asset: { asset: AssetBNB, decimal: BNB_DECIMAL },
   poolDetails: [],
   pricePool: RUNE_PRICE_POOL,
-  onChangeAsset: (a: Asset) => console.log('change asset', a),
+  assetWalletType: 'keystore',
+  runeWalletType: 'ledger',
+  onChangeAsset: ({
+    asset,
+    assetWalletType,
+    runeWalletType
+  }: {
+    asset: Asset
+    assetWalletType: WalletType
+    runeWalletType: WalletType
+  }) => console.log('change asset', assetToString(asset), assetWalletType, runeWalletType),
   reloadFees: () => console.log('reload fees'),
   fees$: () =>
     Rx.of(
@@ -126,9 +136,7 @@ const defaultProps: SymDepositProps = {
   hasAsymAssets: RD.initial,
   symAssetMismatch: RD.initial,
   openRecoveryTool: () => console.log('openRecoveryTool'),
-  openAsymDepositTool: () => console.log('openAsymDepositTool'),
-  setAssetWalletType: (walletType: WalletType) => console.log('setAssetWalletType', walletType),
-  setRuneWalletType: (walletType: WalletType) => console.log('setRuneWalletType', walletType)
+  openAsymDepositTool: () => console.log('openAsymDepositTool')
 }
 
 export const Default: Story = () => <SymDeposit {...defaultProps} />

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -22,6 +22,7 @@ import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
 import * as NEA from 'fp-ts/lib/NonEmptyArray'
 import * as O from 'fp-ts/lib/Option'
+import * as P from 'fp-ts/Predicate'
 import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import * as RxOp from 'rxjs/operators'
@@ -222,7 +223,9 @@ export const SymDeposit: React.FC<Props> = (props) => {
     poolBasedBalances,
     A.map(({ asset }) => asset),
     // Merge duplications
-    (assets) => unionAssets(assets)(assets)
+    (assets) => unionAssets(assets)(assets),
+    // Filter RUNE out - not selectable on asset side
+    A.filter(P.not(isRuneNativeAsset))
   )
 
   const oRuneWB: O.Option<WalletBalance> = useMemo(() => {

--- a/src/renderer/components/pool/PoolTitle.tsx
+++ b/src/renderer/components/pool/PoolTitle.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { Network } from '../../../shared/api/types'
 import { Action as ActionButtonAction, ActionButton } from '../../components/uielements/button/ActionButton'
-// import { DEFAULT_WALLET_TYPE } from '../../const'
+import { DEFAULT_WALLET_TYPE } from '../../const'
 import { loadingString } from '../../helpers/stringHelper'
 import * as poolsRoutes from '../../routes/pools'
 // import * as saversRoutes from '../../routes/pools/savers'
@@ -88,7 +88,13 @@ export const PoolTitle: React.FC<Props> = ({
         label: intl.formatMessage({ id: 'common.manage' }),
         disabled: disableAllPoolActions || disablePoolActions || walletLocked,
         callback: () => {
-          navigate(poolsRoutes.deposit.path({ asset: assetToString(asset) }))
+          navigate(
+            poolsRoutes.deposit.path({
+              asset: assetToString(asset),
+              assetWalletType: DEFAULT_WALLET_TYPE,
+              runeWalletType: DEFAULT_WALLET_TYPE
+            })
+          )
         }
       }
       // TODO(@veado) Enable savers

--- a/src/renderer/components/uielements/button/ManageButton.tsx
+++ b/src/renderer/components/uielements/button/ManageButton.tsx
@@ -5,6 +5,7 @@ import { Asset, assetToString } from '@xchainjs/xchain-util'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 
+import { DEFAULT_WALLET_TYPE } from '../../../const'
 import * as poolsRoutes from '../../../routes/pools'
 import { BorderButton } from './'
 import type { Props as BorderButtonProps } from './BorderButton'
@@ -22,7 +23,13 @@ export const ManageButton: React.FC<Props> = ({ asset, isTextView, ...otherProps
     (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
       event.preventDefault()
       event.stopPropagation()
-      navigate(poolsRoutes.deposit.path({ asset: assetToString(asset) }))
+      navigate(
+        poolsRoutes.deposit.path({
+          asset: assetToString(asset),
+          assetWalletType: DEFAULT_WALLET_TYPE,
+          runeWalletType: DEFAULT_WALLET_TYPE
+        })
+      )
     },
     [asset, navigate]
   )

--- a/src/renderer/components/uielements/slider/Slider.styles.ts
+++ b/src/renderer/components/uielements/slider/Slider.styles.ts
@@ -18,7 +18,7 @@ export const SliderWrapper = styled(Slider)<SliderSingleProps & { error: boolean
       }
 
       &-track {
-        background-color: ${({ error }) => (error ? palette('error', 0) : palette('gradient', 0))};
+        background-color: ${({ error }) => (error ? palette('error', 0) : palette('success', 0))} !important;
       }
 
       &-handle {

--- a/src/renderer/contexts/ChainContext.tsx
+++ b/src/renderer/contexts/ChainContext.tsx
@@ -2,8 +2,6 @@ import React, { createContext, useContext } from 'react'
 
 import {
   addressByChain$,
-  symDepositAddresses$,
-  setSymDepositAddresses,
   clientByChain$,
   symDepositFees$,
   reloadSymDepositFees,
@@ -26,8 +24,6 @@ import {
 
 type ChainContextValue = {
   addressByChain$: typeof addressByChain$
-  symDepositAddresses$: typeof symDepositAddresses$
-  setSymDepositAddresses: typeof setSymDepositAddresses
   clientByChain$: typeof clientByChain$
   symDepositFees$: typeof symDepositFees$
   reloadSymDepositFees: typeof reloadSymDepositFees
@@ -50,8 +46,6 @@ type ChainContextValue = {
 
 const initialContext: ChainContextValue = {
   addressByChain$,
-  symDepositAddresses$,
-  setSymDepositAddresses,
   clientByChain$,
   symDepositFees$,
   reloadSymDepositFees,

--- a/src/renderer/helpers/addressHelper.test.ts
+++ b/src/renderer/helpers/addressHelper.test.ts
@@ -1,7 +1,8 @@
-import { BCHChain, BNBChain, BTCChain, CosmosChain, LTCChain, THORChain } from '@xchainjs/xchain-util'
+import { BCHChain, BNBChain, BTCChain, CosmosChain, ETHChain, LTCChain, THORChain } from '@xchainjs/xchain-util'
 import * as O from 'fp-ts/lib/Option'
 
-import { getEthChecksumAddress, removeAddressPrefix, truncateAddress } from './addressHelper'
+import { LedgerAddresses } from '../services/wallet/types'
+import { getEthChecksumAddress, hasLedgerAddress, removeAddressPrefix, truncateAddress } from './addressHelper'
 
 describe('helpers/addressHelper', () => {
   describe('truncateAddress', () => {
@@ -138,6 +139,38 @@ describe('helpers/addressHelper', () => {
     it('empty address', () => {
       const result = getEthChecksumAddress('')
       expect(result).toEqual(O.none)
+    })
+  })
+
+  describe('hasLedgerAddress', () => {
+    const addresses: LedgerAddresses = [
+      {
+        address: 'bnb-address',
+        type: 'ledger',
+        keystoreId: 1,
+        network: 'mainnet',
+        chain: BNBChain,
+        walletIndex: 1,
+        hdMode: 'default'
+      },
+      {
+        address: 'eth-address',
+        type: 'ledger',
+        keystoreId: 1,
+        network: 'mainnet',
+        chain: ETHChain,
+        walletIndex: 1,
+        hdMode: 'default'
+      }
+    ]
+    it('has ledger BNB', () => {
+      expect(hasLedgerAddress(addresses, BNBChain)).toBeTruthy()
+    })
+    it('has ledger ETH', () => {
+      expect(hasLedgerAddress(addresses, BNBChain)).toBeTruthy()
+    })
+    it('has NOT ledger BTC', () => {
+      expect(hasLedgerAddress(addresses, BTCChain)).toBeFalsy()
     })
   })
 })

--- a/src/renderer/helpers/addressHelper.ts
+++ b/src/renderer/helpers/addressHelper.ts
@@ -21,10 +21,14 @@ import {
   Address
 } from '@xchainjs/xchain-util'
 import { ethers } from 'ethers'
+import * as A from 'fp-ts/lib/Array'
+import * as FP from 'fp-ts/lib/function'
 import * as O from 'fp-ts/lib/Option'
 
 import { Network } from '../../shared/api/types'
 import { toClientNetwork } from '../../shared/utils/client'
+import { LedgerAddresses } from '../services/wallet/types'
+import { eqChain } from './fp/eq'
 
 export const truncateAddress = (addr: Address, chain: Chain, network: Network): string => {
   const first = addr.substring(0, Math.max(getAddressPrefixLength(chain, network) + 3, 6))
@@ -74,3 +78,11 @@ export const removeAddressPrefix = (address: Address): Address => {
  */
 export const getEthChecksumAddress = (address: Address): O.Option<Address> =>
   O.tryCatch(() => ethers.utils.getAddress(address.toLowerCase()))
+
+export const hasLedgerAddress = (addresses: LedgerAddresses, chain: Chain): boolean =>
+  FP.pipe(
+    addresses,
+    A.findFirst(({ chain: ledgerChain }) => eqChain.equals(chain, ledgerChain)),
+    O.map((_) => true),
+    O.getOrElse(() => false)
+  )

--- a/src/renderer/hooks/useLedgerAddresses.ts
+++ b/src/renderer/hooks/useLedgerAddresses.ts
@@ -3,6 +3,7 @@ import * as FP from 'fp-ts/lib/function'
 import { useObservableState } from 'observable-hooks'
 
 import { useWalletContext } from '../contexts/WalletContext'
+import { INITIAL_LEDGER_ADDRESSES } from '../services/wallet/const'
 import { LedgerAddresses, LedgerAddressesRD } from '../services/wallet/types'
 
 export const useLedgerAddresses = (): {
@@ -13,7 +14,7 @@ export const useLedgerAddresses = (): {
   const { reloadPersistentLedgerAddresses, persistentLedgerAddresses$, ledgerAddresses$ } = useWalletContext()
 
   const ledgerAddressesPersistentRD = useObservableState(persistentLedgerAddresses$, RD.initial)
-  const ledgerAddresses = useObservableState(ledgerAddresses$, [])
+  const ledgerAddresses = useObservableState(ledgerAddresses$, INITIAL_LEDGER_ADDRESSES)
 
   return { ledgerAddressesPersistentRD, ledgerAddresses, reloadPersistentLedgerAddresses }
 }

--- a/src/renderer/routes/pools/deposit.ts
+++ b/src/renderer/routes/pools/deposit.ts
@@ -1,3 +1,4 @@
+import { WalletType } from '../../../shared/wallet/types'
 import { Route } from '../types'
 import { base as poolsBase } from './base'
 
@@ -7,12 +8,13 @@ export const base: Route<void> = {
     return this.template
   }
 }
-export type DepositRouteParams = { asset: string }
+export type DepositRouteParams = { asset: string; assetWalletType: WalletType; runeWalletType: WalletType }
 export const deposit: Route<DepositRouteParams> = {
-  template: `${base.template}/:asset`,
-  path: ({ asset }) => {
+  template: `${base.template}/:asset|:assetWalletType|:runeWalletType`,
+  path: ({ asset, assetWalletType, runeWalletType }) => {
+    // Don't accept empty string for asset
     if (asset) {
-      return `${base.template}/${asset.toLowerCase()}`
+      return `${base.template}/${asset.toLowerCase()}|${assetWalletType}|${runeWalletType}`
     }
     // Redirect to base route if asset param is empty
     return base.path()

--- a/src/renderer/routes/pools/pools.test.ts
+++ b/src/renderer/routes/pools/pools.test.ts
@@ -30,13 +30,32 @@ describe('Pools routes', () => {
 
   describe('Deposit routes', () => {
     it('template', () => {
-      expect(deposit.template).toEqual('/pools/deposit/:asset')
+      expect(deposit.template).toEqual('/pools/deposit/:asset|:assetWalletType|:runeWalletType')
     })
-    it('returns path by given asset parameter', () => {
-      expect(deposit.path({ asset: 'BNB.BNB' })).toEqual('/pools/deposit/bnb.bnb')
+    it('asset - keystore | rune - keystore', () => {
+      expect(deposit.path({ asset: 'BNB.BNB', assetWalletType: 'keystore', runeWalletType: 'keystore' })).toEqual(
+        '/pools/deposit/bnb.bnb|keystore|keystore'
+      )
     })
-    it('redirects to base path if asset is empty', () => {
-      expect(deposit.path({ asset: '' })).toEqual('/pools/deposit')
+    it('asset - ledger | rune - keystore', () => {
+      expect(deposit.path({ asset: 'BNB.BNB', assetWalletType: 'ledger', runeWalletType: 'keystore' })).toEqual(
+        '/pools/deposit/bnb.bnb|ledger|keystore'
+      )
+    })
+    it('asset - keystore | rune - ledger', () => {
+      expect(deposit.path({ asset: 'BNB.BNB', assetWalletType: 'keystore', runeWalletType: 'ledger' })).toEqual(
+        '/pools/deposit/bnb.bnb|keystore|ledger'
+      )
+    })
+    it('asset - ledger | rune - ledger', () => {
+      expect(deposit.path({ asset: 'BNB.BNB', assetWalletType: 'ledger', runeWalletType: 'ledger' })).toEqual(
+        '/pools/deposit/bnb.bnb|ledger|ledger'
+      )
+    })
+    it('redirects for empty assets', () => {
+      expect(deposit.path({ asset: '', assetWalletType: 'keystore', runeWalletType: 'keystore' })).toEqual(
+        '/pools/deposit'
+      )
     })
   })
 

--- a/src/renderer/services/chain/address.ts
+++ b/src/renderer/services/chain/address.ts
@@ -14,7 +14,6 @@ import {
 import * as O from 'fp-ts/lib/Option'
 import * as Rx from 'rxjs'
 
-import { observableState } from '../../helpers/stateHelper'
 import * as BNB from '../binance'
 import * as BTC from '../bitcoin'
 import * as BCH from '../bitcoincash'
@@ -25,8 +24,6 @@ import * as ETH from '../ethereum'
 import * as LTC from '../litecoin'
 import * as THOR from '../thorchain'
 import { client$ } from './client'
-import { INITIAL_SYM_DEPOSIT_ADDRESSES } from './const'
-import { SymDepositAddresses } from './types'
 
 /**
  * Returns keystore addresses by givven chain
@@ -63,11 +60,4 @@ const addressByChain$ = (chain: Chain): WalletAddress$ => {
  */
 const assetAddress$ = (chain: Chain): WalletAddress$ => address$(client$, chain)
 
-/**
- * State of addresses used for sym. deposits
- * It will be set at view level (`DepositView` or `SymDepositView`)
- */
-const { get$: symDepositAddresses$, set: setSymDepositAddresses } =
-  observableState<SymDepositAddresses>(INITIAL_SYM_DEPOSIT_ADDRESSES)
-
-export { assetAddress$, addressByChain$, symDepositAddresses$, setSymDepositAddresses }
+export { assetAddress$, addressByChain$ }

--- a/src/renderer/services/chain/index.ts
+++ b/src/renderer/services/chain/index.ts
@@ -1,4 +1,4 @@
-import { addressByChain$, assetAddress$, symDepositAddresses$, setSymDepositAddresses } from './address'
+import { addressByChain$, assetAddress$ } from './address'
 import { clientByChain$ } from './client'
 import { assetWithDecimal$ } from './decimal'
 import {
@@ -26,8 +26,6 @@ import {
  */
 export {
   addressByChain$,
-  symDepositAddresses$,
-  setSymDepositAddresses,
   clientByChain$,
   reloadSymDepositFees,
   symDepositFees$,

--- a/src/renderer/services/wallet/const.ts
+++ b/src/renderer/services/wallet/const.ts
@@ -37,6 +37,6 @@ export const INITIAL_LOAD_TXS_PROPS: LoadTxsParams = {
 
 export const EMPTY_LOAD_TXS_HANDLER: LoadTxsHandler = (_: LoadTxsParams) => {}
 
-export const INITIAL_KEYSTORE_LEDGER_ADDRESSES: LedgerAddresses = [] // empty by default
+export const INITIAL_LEDGER_ADDRESSES: LedgerAddresses = [] // empty by default
 
 export const MAX_WALLET_NAME_CHARS = 20

--- a/src/renderer/services/wallet/ledger.ts
+++ b/src/renderer/services/wallet/ledger.ts
@@ -14,7 +14,7 @@ import { eqChain, eqKeystoreId, eqNetwork, eqOLedgerAddress } from '../../helper
 import { liveData } from '../../helpers/rx/liveData'
 import { observableState, triggerStream } from '../../helpers/stateHelper'
 import { Network$ } from '../app/types'
-import { INITIAL_KEYSTORE_LEDGER_ADDRESSES as INITIAL_LEDGER_ADDRESSES } from './const'
+import { INITIAL_LEDGER_ADDRESSES } from './const'
 import {
   GetLedgerAddressHandler,
   KeystoreState$,

--- a/src/renderer/views/deposit/DepositView.tsx
+++ b/src/renderer/views/deposit/DepositView.tsx
@@ -14,6 +14,7 @@ import * as RxOp from 'rxjs/operators'
 import { Deposit } from '../../components/deposit/Deposit'
 import { ErrorView } from '../../components/shared/error'
 import { BackLinkButton, RefreshButton } from '../../components/uielements/button'
+import { DEFAULT_WALLET_TYPE } from '../../const'
 import { useChainContext } from '../../contexts/ChainContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
@@ -39,7 +40,11 @@ export const DepositView: React.FC<Props> = () => {
 
   const { reloadLiquidityProviders } = useThorchainContext()
 
-  const { asset } = useParams<DepositRouteParams>()
+  const {
+    asset: routeAsset,
+    assetWalletType: routeAssetWalletType,
+    runeWalletType: routeRuneWalletType
+  } = useParams<DepositRouteParams>()
   const {
     service: {
       setSelectedPoolAsset,
@@ -55,7 +60,9 @@ export const DepositView: React.FC<Props> = () => {
 
   const { assetWithDecimal$ } = useChainContext()
 
-  const oRouteAsset = useMemo(() => getAssetFromNullableString(asset), [asset])
+  const oRouteAsset = useMemo(() => getAssetFromNullableString(routeAsset), [routeAsset])
+  const assetWalletType = routeAssetWalletType || DEFAULT_WALLET_TYPE
+  const runeWalletType = routeRuneWalletType || DEFAULT_WALLET_TYPE
 
   // Set selected pool asset whenever an asset in route has been changed
   // Needed to get all data for this pool (pool details etc.)
@@ -90,7 +97,11 @@ export const DepositView: React.FC<Props> = () => {
 
   const {
     addresses: { rune: oRuneWalletAddress, asset: oAssetWalletAddress }
-  } = useSymDepositAddresses(oRouteAsset)
+  } = useSymDepositAddresses({
+    asset: oRouteAsset,
+    assetWalletType,
+    runeWalletType
+  })
   /**
    * We have to get a new shares$ stream for every new address
    * @description /src/renderer/services/midgard/shares.ts

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -8,6 +8,7 @@ import { useObservableState } from 'observable-hooks'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
 
+import { WalletType } from '../../../../shared/wallet/types'
 import { SymDeposit } from '../../../components/deposit/add'
 import { Alert } from '../../../components/uielements/alert'
 import { ASYM_DEPOSIT_TOOL_URL, RECOVERY_TOOL_URL, ZERO_POOL_DATA } from '../../../const'
@@ -22,7 +23,6 @@ import { useLiquidityProviders } from '../../../hooks/useLiquidityProviders'
 import { useNetwork } from '../../../hooks/useNetwork'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
 import { useProtocolLimit } from '../../../hooks/useProtocolLimit'
-import { useSymDepositAddresses } from '../../../hooks/useSymDepositAddresses'
 import * as poolsRoutes from '../../../routes/pools'
 import { PoolAddress, PoolAssetsRD } from '../../../services/midgard/types'
 import { toPoolData } from '../../../services/midgard/utils'
@@ -44,11 +44,19 @@ export const SymDepositView: React.FC<Props> = (props) => {
 
   const { network } = useNetwork()
 
-  const { setAssetWalletType, setRuneWalletType } = useSymDepositAddresses(O.some(asset))
-
   const onChangeAsset = useCallback(
-    (asset: Asset) => {
-      navigate(poolsRoutes.deposit.path({ asset: assetToString(asset) }), { replace: true })
+    ({
+      asset,
+      assetWalletType,
+      runeWalletType
+    }: {
+      asset: Asset
+      assetWalletType: WalletType
+      runeWalletType: WalletType
+    }) => {
+      navigate(poolsRoutes.deposit.path({ asset: assetToString(asset), assetWalletType, runeWalletType }), {
+        replace: true
+      })
     },
     [navigate]
   )
@@ -126,8 +134,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
 
   const { symPendingAssets, hasAsymAssets, symAssetMismatch } = useLiquidityProviders({
     asset,
-    runeAddress: runeWalletAddress,
-    assetAddress: assetWalletAddress
+    runeAddress: runeWalletAddress.address,
+    assetAddress: assetWalletAddress.address
   })
 
   const openRecoveryTool = useCallback(
@@ -181,8 +189,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
           hasAsymAssets={RD.initial}
           symAssetMismatch={RD.initial}
           openAsymDepositTool={openAsymDepositTool}
-          setAssetWalletType={setAssetWalletType}
-          setRuneWalletType={setRuneWalletType}
+          assetWalletType={assetWalletAddress.type}
+          runeWalletType={runeWalletAddress.type}
         />
       </>
     ),
@@ -210,8 +218,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
       protocolLimitReached,
       openRecoveryTool,
       openAsymDepositTool,
-      setAssetWalletType,
-      setRuneWalletType
+      assetWalletAddress.type,
+      runeWalletAddress.type
     ]
   )
 
@@ -261,8 +269,8 @@ export const SymDepositView: React.FC<Props> = (props) => {
               hasAsymAssets={hasAsymAssets}
               symAssetMismatch={symAssetMismatch}
               openAsymDepositTool={openAsymDepositTool}
-              setAssetWalletType={setAssetWalletType}
-              setRuneWalletType={setRuneWalletType}
+              assetWalletType={assetWalletAddress.type}
+              runeWalletType={runeWalletAddress.type}
             />
           </>
         )

--- a/src/renderer/views/deposit/add/SymDepositView.types.ts
+++ b/src/renderer/views/deposit/add/SymDepositView.types.ts
@@ -1,6 +1,6 @@
-import { Address } from '@xchainjs/xchain-util'
 import { Chain } from '@xchainjs/xchain-util'
 
+import { WalletAddress } from '../../../../shared/wallet/types'
 import { PoolDetailRD } from '../../../services/midgard/types'
 import { MimirHalt } from '../../../services/thorchain/types'
 import { AssetWithDecimal } from '../../../types/asgardex'
@@ -10,6 +10,6 @@ export type Props = {
   poolDetail: PoolDetailRD
   haltedChains: Chain[]
   mimirHalt: MimirHalt
-  runeWalletAddress: Address
-  assetWalletAddress: Address
+  runeWalletAddress: WalletAddress
+  assetWalletAddress: WalletAddress
 }

--- a/src/renderer/views/pools/ActivePools.tsx
+++ b/src/renderer/views/pools/ActivePools.tsx
@@ -26,6 +26,7 @@ import { Action as ActionButtonAction, ActionButton } from '../../components/uie
 import { PoolsPeriodSelector } from '../../components/uielements/pools/PoolsPeriodSelector'
 import { Table } from '../../components/uielements/table'
 // import { DEFAULT_WALLET_TYPE } from '../../const'
+import { DEFAULT_WALLET_TYPE } from '../../const'
 import { useAppContext } from '../../contexts/AppContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { ordBaseAmount, ordNumber } from '../../helpers/fp/ord'
@@ -106,7 +107,13 @@ export const ActivePools: React.FC<PoolsComponentProps> = ({ haltedChains, mimir
           label: intl.formatMessage({ id: 'common.manage' }),
           disabled: disableAllPoolActions || disablePoolActions || walletLocked,
           callback: () => {
-            navigate(poolsRoutes.deposit.path({ asset: assetToString(asset) }))
+            navigate(
+              poolsRoutes.deposit.path({
+                asset: assetToString(asset),
+                assetWalletType: DEFAULT_WALLET_TYPE,
+                runeWalletType: DEFAULT_WALLET_TYPE
+              })
+            )
           }
         }
         // TODO(@veado) Enable savers


### PR DESCRIPTION
but not on global states

- [x] Update `deposit` routes to include `WalletType`s
- [x] Update / simplify `useSymDepositAddresses`
- [x] Update / simplify wallet type handling in `SymDeposit`
- [x] Filter RUNE out from selectable assets 
- [x] Helper `hasLedgerAddress` incl. tests
- [x] Quick fix sliders track bg color

Fixes  #2507

