### PR TITLE
Fix `getLiquidityProviders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@
 - [SymDeposit] Redesign [#2503](https://github.com/thorchain/asgardex-electron/issues/2503), [#2502](https://github.com/thorchain/asgardex-electron/pull/2502)
 - [AssetInput] Add Ledger + extraContent [#2505](https://github.com/thorchain/asgardex-electron/pull/2505)
 - Refactor styles for 'warning` components (TW only) [#2504](https://github.com/thorchain/asgardex-electron/pull/2504)
+- [Deposit] Wallet types based on routes [#2506](https://github.com/thorchain/asgardex-electron/pull/2506)
 
 ## Fix
 
 - External links not clickable [#2495](https://github.com/thorchain/asgardex-electron/issues/2495)
 - [Send] Max value can't be negative [#2500](https://github.com/thorchain/asgardex-electron/issues/2500)
 - [Swap] Fees needs to be considered for max value to swap [#2498](https://github.com/thorchain/asgardex-electron/issues/2498)
+- [SymDeposit] RUNE can be selected on asset side [#2507](https://github.com/thorchain/asgardex-electron/issues/2507)
+- [Deposit] Check of asset missmatch failed [#2509](https://github.com/thorchain/asgardex-electron/issues/2509)
 
 # 1.18.5 (2022-12-20)
 

--- a/src/renderer/services/thorchain/types.ts
+++ b/src/renderer/services/thorchain/types.ts
@@ -4,11 +4,9 @@ import { Address, Asset, BaseAmount, Chain } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as O from 'fp-ts/Option'
 import * as t from 'io-ts'
-import { optionFromNullable } from 'io-ts-types/lib/optionFromNullable'
 import { IntlShape } from 'react-intl'
 import * as Rx from 'rxjs'
 
-import { assetIO } from '../../../shared/api/io'
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
 import { AssetsWithAmount1e8, AssetWithAmount1e8 } from '../../types/asgardex'
@@ -225,14 +223,6 @@ export type LiquidityProviderHasAsymAssetsRD = RD.RemoteData<Error, LiquidityPro
 
 export type LiquidityProviderAssetMismatch = O.Option<{ runeAddress: Address; assetAddress: Address }>
 export type LiquidityProviderAssetMismatchRD = RD.RemoteData<Error, LiquidityProviderAssetMismatch>
-
-export const LiquidityProviderIO = t.type({
-  asset: assetIO,
-  rune_address: optionFromNullable(t.string),
-  asset_address: optionFromNullable(t.string),
-  pending_rune: t.string,
-  pending_asset: t.string
-})
 
 export type SaverProvider = {
   address: Address


### PR DESCRIPTION
to call `/thorchain/pool/{asset}/liquidity_providers` instead of `pools` (deprecated) and to parse `LiquidityProviders` properly

Fix #2509